### PR TITLE
#167 - skip CI if PR is draft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,11 @@ on:
     branches:
       - main
       - develop
+    types: [opened, synchronize, reopened, ready_for_review]  
 
 jobs:
   build_and_test:
+    if: ${{ !github.event.pull_request.draft }}
     name: Build and Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,9 +3,11 @@ run-name: Pull Request Validator
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   cpr:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
       - name: Validate the pull request


### PR DESCRIPTION
With respect to the issue, 
https://github.com/EXXETA/trufos/issues/167

Updated the GitHub Actions workflows to prevent pipelines from running for draft pull requests by adding a condition to check the draft status. This optimization ensures that workflows are triggered only for pull requests that are ready for review, reducing unnecessary resource usage and saving worker minutes.


