### PR TITLE
feat(#206): Support switching and creating Collections

### DIFF
--- a/src/main/environment/service/environment-service.test.ts
+++ b/src/main/environment/service/environment-service.test.ts
@@ -5,6 +5,7 @@ import { VariableMap, VariableObject } from 'shim/objects/variables';
 import { PersistenceService } from 'main/persistence/service/persistence-service';
 import { randomUUID } from 'node:crypto';
 import { getSystemVariables } from './system-variable';
+import { SettingsObject, SettingsService } from '../../persistence/service/settings-service';
 
 const environmentService = EnvironmentService.instance;
 
@@ -122,5 +123,24 @@ describe('EnvironmentService', () => {
 
     // Assert
     expect(result).toEqual(systemVariable);
+  });
+
+  it('should load the configured collection from SettingsService', async () => {
+    // Arrange
+    const getSettingsSpy = vi.spyOn(SettingsService.instance, 'settings', 'get');
+    const collectionPath = '/path/to/collection';
+    const settings: SettingsObject = { collections: [collectionPath], currentCollectionIndex: 0 };
+    getSettingsSpy.mockReturnValueOnce(settings);
+    const loadCollectionSpy = vi
+      .spyOn(PersistenceService.instance, 'loadCollection')
+      .mockResolvedValueOnce(collection as Collection);
+
+    // Act
+    await environmentService.init();
+
+    // Assert
+    expect(getSettingsSpy).toHaveBeenCalled();
+    expect(loadCollectionSpy).toHaveBeenCalledWith(collectionPath);
+    expect(environmentService.currentCollection).toEqual(collection);
   });
 });

--- a/src/main/environment/service/environment-service.ts
+++ b/src/main/environment/service/environment-service.ts
@@ -83,6 +83,34 @@ export class EnvironmentService implements Initializable {
   }
 
   /**
+   * Closes the collection at the specified path.
+   * @param path The path of the collection to close. If not specified, the current collection is closed.
+   */
+  public async closeCollection(path?: string) {
+    path ??= this.currentCollection.dirPath;
+    path = normalize(path);
+
+    // do not close the default collection
+    const settings = settingsService.modifiableSettings;
+    if (path === SettingsService.DEFAULT_COLLECTION_DIR || settings.collections.length <= 1) {
+      console.warn('Cannot close the default collection.');
+      return this.currentCollection;
+    }
+
+    // change the current collection if the collection to close is the current one
+    if (path === this.currentCollection.dirPath) {
+      await this.changeCollection(SettingsService.DEFAULT_COLLECTION_DIR);
+    }
+
+    // remove the collection from the list of open collections
+    settings.collections = settings.collections.filter((collectionPath) => collectionPath !== path);
+    await settingsService.setSettings(settings);
+
+    // return the current collection (after closing the specified collection)
+    return this.currentCollection;
+  }
+
+  /**
    * Returns all variables for the current state (e.g. collection variables). This also includes
    * system variables.
    */

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -120,11 +120,16 @@ export class MainEventService implements IEventService {
   async saveFolder(folder: Folder) {
     await persistenceService.saveFolder(folder);
   }
+
   async openCollection(dirPath: string) {
     return await persistenceService.loadCollection(dirPath);
   }
 
   async createCollection(dirPath: string, title: string) {
     return await persistenceService.createCollection(dirPath, title);
+  }
+
+  async closeCollection(dirPath?: string) {
+    return await environmentService.closeCollection(dirPath);
   }
 }

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -120,4 +120,11 @@ export class MainEventService implements IEventService {
   async saveFolder(folder: Folder) {
     await persistenceService.saveFolder(folder);
   }
+  async openCollection(dirPath: string) {
+    return await persistenceService.loadCollection(dirPath);
+  }
+
+  async createCollection(dirPath: string, title: string) {
+    return await persistenceService.createCollection(dirPath, title);
+  }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,6 +3,7 @@ import { EnvironmentService } from 'main/environment/service/environment-service
 import 'main/event/main-event-service';
 import path from 'node:path';
 import quit from 'electron-squirrel-startup';
+import { SettingsService } from './persistence/service/settings-service';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
@@ -13,7 +14,8 @@ if (quit) {
 }
 
 const createWindow = async () => {
-  // initialize services
+  // initialize services in correct order
+  await SettingsService.instance.init();
   await EnvironmentService.instance.init();
 
   // Create the browser window.

--- a/src/main/persistence/service/default-collection.ts
+++ b/src/main/persistence/service/default-collection.ts
@@ -26,6 +26,7 @@ export function generateDefaultCollection(dirPath: string): Collection {
         },
       ].map((variable) => [variable.key, variable])
     ),
+    environments: {},
     children: [
       {
         id: exampleRequestId,

--- a/src/main/persistence/service/info-files/latest.ts
+++ b/src/main/persistence/service/info-files/latest.ts
@@ -52,7 +52,8 @@ export function fromFolderInfoFile(
 
 export function fromRequestInfoFile(
   infoFile: RequestInfoFile,
-  parentId: TrufosRequest['parentId']
+  parentId: TrufosRequest['parentId'],
+  draft: boolean
 ): TrufosRequest {
-  return Object.assign(infoFile, { type: 'request' as const, parentId });
+  return Object.assign(infoFile, { type: 'request' as const, parentId, draft });
 }

--- a/src/main/persistence/service/persistence-service.test.ts
+++ b/src/main/persistence/service/persistence-service.test.ts
@@ -72,24 +72,24 @@ describe('PersistenceService', () => {
     await mkdir(collection.dirPath, { recursive: true });
   });
 
-  it('loadDefaultCollection() should return the existing default collection if it exists', async () => {
+  it('createDefaultCollectionIfNotExists() should not create if it already exists', async () => {
     // Arrange
-    const defaultCollection = {} as Collection;
-    const loadCollectionSpy = vi
-      .spyOn(persistenceService, 'loadCollection')
-      .mockResolvedValueOnce(defaultCollection);
+    const defaultCollectionImport = await import('./default-collection');
+    const generateDefaultCollectionSpy = vi.spyOn(
+      defaultCollectionImport,
+      'generateDefaultCollection'
+    );
     await mkdir(collectionDirPath);
     await writeFile(path.join(collectionDirPath, 'collection.json'), '');
 
     // Act
-    const result = await persistenceService.loadDefaultCollection();
+    await persistenceService.createDefaultCollectionIfNotExists();
 
     // Assert
-    expect(result).toBe(defaultCollection);
-    expect(loadCollectionSpy).toHaveBeenCalledWith(collectionDirPath);
+    expect(generateDefaultCollectionSpy).not.toHaveBeenCalled();
   });
 
-  it('loadDefaultCollection() should create a new default collection if does not exist', async () => {
+  it('createDefaultCollectionIfNotExists() should create a new default collection if does not exist', async () => {
     // Arrange
     const defaultCollectionImport = await import('./default-collection');
     const defaultCollection = {} as Collection;
@@ -101,10 +101,9 @@ describe('PersistenceService', () => {
       .mockResolvedValueOnce();
 
     // Act
-    const result = await persistenceService.loadDefaultCollection();
+    await persistenceService.createDefaultCollectionIfNotExists();
 
     // Assert
-    expect(result).toBe(defaultCollection);
     expect(generateDefaultCollection).toHaveBeenCalledWith(collectionDirPath);
     expect(saveCollectionRecursiveSpy).toHaveBeenCalledWith(defaultCollection);
   });

--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -323,7 +323,7 @@ export class PersistenceService {
     const info = await this.readInfoFile(dirPath, type, draft);
     this.idToPathMap.set(info.id, dirPath);
 
-    return fromRequestInfoFile(info, parentId);
+    return fromRequestInfoFile(info, parentId, draft);
   }
 
   private async loadFolder(parentId: string, dirPath: string): Promise<Folder> {

--- a/src/main/persistence/service/settings-service.test.ts
+++ b/src/main/persistence/service/settings-service.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { SettingsService } from './settings-service';
+import { exists } from 'main/util/fs-util';
+
+const settingsService = SettingsService.instance;
+
+describe('SettingsService', async () => {
+  it('should create a new settings if none exists', async () => {
+    // Assert
+    expect(await exists(SettingsService.SETTINGS_FILE)).toBe(false);
+
+    // Act
+    await settingsService.init();
+
+    // Assert
+    expect(await exists(SettingsService.SETTINGS_FILE)).toBe(true);
+    expect(settingsService.settings.currentCollectionIndex).toBe(0);
+  });
+
+  it('should provide a deep clone of settings at modifiedSettings', () => {
+    // Act
+    const { modifiableSettings } = settingsService;
+
+    // Assert
+    expect(modifiableSettings).not.toBe(settingsService.settings);
+    expect(modifiableSettings).toEqual(settingsService.settings);
+  });
+
+  it('should persist settings when set', async () => {
+    // Arrange
+    await settingsService.init();
+    const newSettings: import('./settings-service').SettingsObject = {
+      currentCollectionIndex: 1,
+      collections: ['path/to/collection', 'some/where/else'],
+    };
+
+    // Assert
+    expect(settingsService.settings).not.toEqual(newSettings);
+    expect(JSON.parse(await readFile(SettingsService.SETTINGS_FILE, 'utf8'))).toEqual(
+      settingsService.settings
+    );
+
+    // Act
+    await settingsService.setSettings(newSettings);
+
+    // Assert
+    expect(settingsService.settings).toEqual(newSettings);
+    expect(JSON.parse(await readFile(SettingsService.SETTINGS_FILE, 'utf8'))).toEqual(newSettings);
+  });
+});

--- a/src/main/persistence/service/settings-service.test.ts
+++ b/src/main/persistence/service/settings-service.test.ts
@@ -37,7 +37,7 @@ describe('SettingsService', async () => {
 
     // Assert
     expect(settingsService.settings).not.toEqual(newSettings);
-    expect(JSON.parse(await readFile(SettingsService.SETTINGS_FILE, 'utf8'))).toEqual(
+    expect(JSON.parse(await readFile(SettingsService.SETTINGS_FILE, 'utf8'))).toMatchObject(
       settingsService.settings
     );
 
@@ -46,6 +46,8 @@ describe('SettingsService', async () => {
 
     // Assert
     expect(settingsService.settings).toEqual(newSettings);
-    expect(JSON.parse(await readFile(SettingsService.SETTINGS_FILE, 'utf8'))).toEqual(newSettings);
+    expect(JSON.parse(await readFile(SettingsService.SETTINGS_FILE, 'utf8'))).toMatchObject(
+      newSettings
+    );
   });
 });

--- a/src/main/persistence/service/settings-service.ts
+++ b/src/main/persistence/service/settings-service.ts
@@ -2,6 +2,9 @@ import path from 'node:path';
 import { readFile, writeFile } from 'node:fs/promises';
 import { exists, USER_DATA_DIR } from 'main/util/fs-util';
 import { Initializable } from 'main/shared/initializable';
+import { SemVer } from '../../util/semver';
+
+const VERSION = new SemVer(1, 0, 0);
 
 export type SettingsObject = {
   /** The index of the currently opened collection inside the collections array */
@@ -10,6 +13,8 @@ export type SettingsObject = {
   /** A list of all the collection directories that have been opened */
   collections: string[];
 };
+
+type SettingsInfoFile = SettingsObject & { version: typeof VERSION.string };
 
 /**
  * A service that handles the global settings of the application. These settings are not specific to
@@ -59,7 +64,9 @@ export class SettingsService implements Initializable {
   }
 
   private async writeSettings() {
-    await writeFile(SettingsService.SETTINGS_FILE, JSON.stringify(this._settings, null, 2));
+    const settings: SettingsObject & Partial<SettingsInfoFile> = this.modifiableSettings;
+    settings.version = VERSION.string;
+    await writeFile(SettingsService.SETTINGS_FILE, JSON.stringify(settings, null, 2));
   }
 
   private async readSettings() {

--- a/src/main/persistence/service/settings-service.ts
+++ b/src/main/persistence/service/settings-service.ts
@@ -1,0 +1,68 @@
+import path from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
+import { exists, USER_DATA_DIR } from 'main/util/fs-util';
+import { Initializable } from 'main/shared/initializable';
+
+export type SettingsObject = {
+  /** The index of the currently opened collection inside the collections array */
+  currentCollectionIndex: number;
+
+  /** A list of all the collection directories that have been opened */
+  collections: string[];
+};
+
+/**
+ * A service that handles the global settings of the application. These settings are not specific to
+ * a collection. For that, see {@link EnvironmentService} which has the currently opened collection.
+ */
+export class SettingsService implements Initializable {
+  public static readonly DEFAULT_COLLECTION_DIR = path.join(USER_DATA_DIR, 'default-collection');
+  public static readonly SETTINGS_FILE = path.join(USER_DATA_DIR, 'settings.json');
+
+  public static readonly instance = new SettingsService();
+
+  private _settings = Object.freeze<SettingsObject>({
+    currentCollectionIndex: 0,
+    collections: [SettingsService.DEFAULT_COLLECTION_DIR],
+  });
+
+  async init() {
+    if (await exists(SettingsService.SETTINGS_FILE)) {
+      await this.readSettings();
+    } else {
+      console.info('No settings file found. Creating default.');
+      await this.writeSettings();
+    }
+  }
+
+  /**
+   * The current settings of the application (read-only).
+   */
+  public get settings() {
+    return this._settings;
+  }
+
+  /**
+   * Sets the settings and writes them to the settings file.
+   * @param settings The new settings to set
+   */
+  public async setSettings(settings: Readonly<SettingsObject>) {
+    this._settings = structuredClone(settings);
+    await this.writeSettings();
+  }
+
+  /**
+   * A copy of the current settings that can be modified.
+   */
+  public get modifiableSettings(): SettingsObject {
+    return structuredClone(this._settings);
+  }
+
+  private async writeSettings() {
+    await writeFile(SettingsService.SETTINGS_FILE, JSON.stringify(this._settings, null, 2));
+  }
+
+  private async readSettings() {
+    this._settings = JSON.parse(await readFile(SettingsService.SETTINGS_FILE, 'utf8'));
+  }
+}

--- a/src/renderer/services/event/renderer-event-service.ts
+++ b/src/renderer/services/event/renderer-event-service.ts
@@ -56,4 +56,5 @@ export class RendererEventService implements IEventService {
   selectEnvironment = createEventMethod('selectEnvironment');
   openCollection = createEventMethod('openCollection');
   createCollection = createEventMethod('createCollection');
+  closeCollection = createEventMethod('closeCollection');
 }

--- a/src/renderer/services/event/renderer-event-service.ts
+++ b/src/renderer/services/event/renderer-event-service.ts
@@ -54,4 +54,6 @@ export class RendererEventService implements IEventService {
   setCollectionVariables = createEventMethod('setCollectionVariables');
   saveFolder = createEventMethod('saveFolder');
   selectEnvironment = createEventMethod('selectEnvironment');
+  openCollection = createEventMethod('openCollection');
+  createCollection = createEventMethod('createCollection');
 }

--- a/src/shim/event-service.ts
+++ b/src/shim/event-service.ts
@@ -82,4 +82,17 @@ export interface IEventService {
    * @param folder The folder to save.
    */
   saveFolder(folder: Folder): void;
+
+  /**
+   * Open an existing collection at the given directory path.
+   * @param dirPath The directory path of the collection.
+   */
+  openCollection(dirPath: string): Promise<Collection>;
+
+  /**
+   * Create a new collection at the given directory path with the given title.
+   * @param dirPath The directory path of the new collection. Must be empty.
+   * @param title The title of the new collection.
+   */
+  createCollection(dirPath: string, title: string): Promise<Collection>;
 }

--- a/src/shim/event-service.ts
+++ b/src/shim/event-service.ts
@@ -95,4 +95,10 @@ export interface IEventService {
    * @param title The title of the new collection.
    */
   createCollection(dirPath: string, title: string): Promise<Collection>;
+
+  /**
+   * Close the collection at the given directory path. You cannot close the default collection.
+   * @param dirPath The directory path of the collection to close. If not provided, the current collection is closed.
+   */
+  closeCollection(dirPath?: string): Promise<Collection>;
 }


### PR DESCRIPTION
## Changes

- Support creating new and opening or switching existing collections
- Fix a bug where the `fromRequestInfoFile()` does load draft requests but only the persisted

## Testing

Only backend, automated tests are written.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
