### PR TITLE
#288 - bug/ fix the naming model component placeholder 

### DIFF
--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/modals/NamingModal.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/modals/NamingModal.tsx
@@ -79,7 +79,7 @@ export const NamingModal = ({ createType, trufosObject, isOpen, setOpen }: Namin
             value={name}
             onChange={(e) => setName(e.target.value)}
             className="w-full bg-transparent outline-none"
-            placeholder="Enter the folder name"
+            placeholder={`Enter the ${createType ?? trufosObject.type} name`}
           />
         </div>
         <DialogFooter className="bottom-0">


### PR DESCRIPTION
## What does this PR do?
This PR fixes the naming model placeholder to differentiate between naming a folder or request.

close #288 

## Description of Task
- Added a content type and the 'trufus' object type as a variable to the placeholder value using template literals.
- Added a nullish operator to check whether the content type is null or not. If it is null that means it's a rename process and the variable will be the 'trufus' object type which is the collection type that was created (Folder/ Request ). If It's not null that means we are creating a new (Folder/request).