### PR TITLE
feat(77): Logging Framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "template-replace-stream": "^2.1.2",
     "tmp": "^0.2.3",
     "undici": "^7.5.0",
+    "winston": "^3.17.0",
     "zustand": "^5.0.3"
   }
 }

--- a/src/main/__mocks__/electron/app.ts
+++ b/src/main/__mocks__/electron/app.ts
@@ -7,3 +7,5 @@ export function getPath() {
 export function getName() {
   return 'Trufos';
 }
+
+export const isPackaged = false;

--- a/src/main/__mocks__/electron/index.ts
+++ b/src/main/__mocks__/electron/index.ts
@@ -1,1 +1,2 @@
 export * as app from './app';
+export * as ipcMain from './ipc-main';

--- a/src/main/__mocks__/electron/ipc-main.ts
+++ b/src/main/__mocks__/electron/ipc-main.ts
@@ -1,0 +1,1 @@
+export function on() {}

--- a/src/main/__mocks__/index.ts
+++ b/src/main/__mocks__/index.ts
@@ -2,6 +2,9 @@ import { homedir, tmpdir } from 'node:os';
 import { vol } from 'memfs';
 import { vi, beforeEach } from 'vitest';
 
+// @ts-expect-error mock global logger with console
+global.logger = console;
+
 vi.mock('electron', () => ({
   app: {
     getPath: () => tmpdir(),

--- a/src/main/__mocks__/index.ts
+++ b/src/main/__mocks__/index.ts
@@ -5,12 +5,7 @@ import { vi, beforeEach } from 'vitest';
 // @ts-expect-error mock global logger with console
 global.logger = console;
 
-vi.mock('electron', () => ({
-  app: {
-    getPath: () => tmpdir(),
-    getName: () => 'Trufos',
-  },
-}));
+vi.mock('electron');
 vi.mock('node:fs');
 vi.mock('node:fs/promises');
 vi.mock('tmp');

--- a/src/main/environment/service/environment-service.ts
+++ b/src/main/environment/service/environment-service.ts
@@ -93,7 +93,7 @@ export class EnvironmentService implements Initializable {
     // do not close the default collection
     const settings = settingsService.modifiableSettings;
     if (path === SettingsService.DEFAULT_COLLECTION_DIR || settings.collections.length <= 1) {
-      console.warn('Cannot close the default collection.');
+      logger.warn('Cannot close the default collection.');
       return this.currentCollection;
     }
 

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -24,7 +24,7 @@ function wrapWithErrorHandler<F extends AsyncFunction<R>, R>(fn: F) {
     try {
       return (await fn(...args)) as R;
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       return toError(error);
     }
   };
@@ -40,7 +40,7 @@ function registerEvent<T>(instance: T, functionName: keyof T) {
 
   const method = instance[functionName];
   if (typeof method === 'function') {
-    console.debug(`Registering event function "${functionName}()" on backend`);
+    logger.debug(`Registering event function "${functionName}()" on backend`);
     ipcMain.handle(functionName as string, (_event, ...args) =>
       wrapWithErrorHandler(method as unknown as AsyncFunction<unknown>)(...args)
     );
@@ -64,7 +64,7 @@ export class MainEventService implements IEventService {
     for (const propertyName of Reflect.ownKeys(MainEventService.prototype)) {
       registerEvent(this, propertyName as keyof MainEventService);
     }
-    console.debug('Registered event channels on backend');
+    logger.debug('Registered event channels on backend');
   }
 
   async loadCollection(force?: boolean) {

--- a/src/main/import/service/import-service.ts
+++ b/src/main/import/service/import-service.ts
@@ -37,11 +37,11 @@ export class ImportService {
       );
     }
 
-    console.info(
+    logger.info(
       `Importing collection from "${srcFilePath}" to "${targetDirPath}" using strategy "${strategy}"`
     );
     const collection = await importer.importCollection(srcFilePath, targetDirPath);
-    console.info('Successfully imported collection:', collection);
+    logger.info('Successfully imported collection:', collection);
     await persistenceService.saveCollectionRecursive(collection);
     return collection;
   }

--- a/src/main/import/service/postman-importer.ts
+++ b/src/main/import/service/postman-importer.ts
@@ -36,7 +36,7 @@ export class PostmanImporter implements CollectionImporter {
             },
           ] as [string, VariableObject]
       );
-    console.info('Loaded', variablesArray.length, 'collection variables');
+    logger.info('Loaded', variablesArray.length, 'collection variables');
 
     // create collection directory
     const dirName = path.basename(targetDirPath);

--- a/src/main/logging/logger.test.ts
+++ b/src/main/logging/logger.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import './logger';
+import Transport from 'winston-transport';
+
+class MemoryTransport extends Transport {
+  public logs: unknown[] = [];
+
+  log(info: unknown, callback: () => void) {
+    setImmediate(() => this.emit('logged', info));
+    this.logs.push(info);
+    callback();
+  }
+}
+
+describe('Logger', () => {
+  let memoryTransport: MemoryTransport;
+
+  beforeEach(() => {
+    logger.level = 'debug';
+    logger?.add((memoryTransport = new MemoryTransport()));
+  });
+
+  afterEach(() => {
+    logger?.remove(memoryTransport);
+    logger.level = 'info';
+  });
+
+  it('should provide a global logger', () => {
+    // Assert
+    expect(logger).toBeDefined();
+  });
+
+  it.each(['info', 'warn', 'debug', 'error'] as const)(
+    'should log on %s to console in development or tests',
+    async (level) => {
+      // Arrange
+      const message = 'test';
+
+      // Act
+      logger[level](message);
+
+      // Assert
+      expect(memoryTransport.logs).toHaveLength(1);
+      expect(memoryTransport.logs[0].message).toBe(message);
+    }
+  );
+
+  it('should respect the log level', () => {
+    // Arrange
+    logger.level = 'debug';
+
+    // Act
+    logger.debug('test');
+
+    // Assert
+    expect(memoryTransport.logs).toHaveLength(1);
+
+    // Arrange
+    logger.level = 'info';
+
+    // Act
+    logger.debug('test');
+
+    // Assert
+    expect(memoryTransport.logs).toHaveLength(1);
+  });
+});

--- a/src/main/logging/logger.ts
+++ b/src/main/logging/logger.ts
@@ -27,7 +27,13 @@ global.logger = winston.createLogger({
   ),
   defaultMeta: { process: 'main' },
   transports: [
-    new winston.transports.File({ dirname: app.getPath('logs'), filename: 'combined.log' }),
+    new winston.transports.File({
+      dirname: app.getPath('logs'),
+      filename: 'trufos.log',
+      maxFiles: 10,
+      maxsize: 1024 * 1024 * 10, // 10MiB
+      tailable: true,
+    }),
   ],
 });
 

--- a/src/main/logging/logger.ts
+++ b/src/main/logging/logger.ts
@@ -1,0 +1,40 @@
+import winston, { format, Logform, transports } from 'winston';
+import { app, ipcMain } from 'electron';
+import { LogEntry } from 'shim/logger';
+
+console.info('Saving logs at', app.getPath('logs'));
+
+declare global {
+  // eslint-disable-next-line no-var
+  var logger: winston.Logger;
+}
+
+function print({
+  timestamp,
+  level,
+  process,
+  message,
+}: Logform.TransformableInfo & LogEntry & { timestamp: string }) {
+  return `${timestamp} [${process.toUpperCase()}] [${level.toUpperCase()}]: ${message}`;
+}
+
+global.logger = winston.createLogger({
+  level: 'info',
+  format: format.combine(
+    format.splat(),
+    format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+    format.printf(print)
+  ),
+  defaultMeta: { process: 'main' },
+  transports: [
+    new winston.transports.File({ dirname: app.getPath('logs'), filename: 'combined.log' }),
+  ],
+});
+
+if (!app.isPackaged) {
+  logger.add(new transports.Console());
+}
+
+ipcMain.on('log', (event, data: LogEntry) => {
+  logger.write(data);
+});

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,3 +1,5 @@
+import './logging/logger';
+
 import { app, BrowserWindow, ipcMain, shell } from 'electron';
 import { EnvironmentService } from 'main/environment/service/environment-service';
 import 'main/event/main-event-service';

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -52,7 +52,7 @@ const createWindow = async () => {
           setTimeout(() => reject(new Error('Timeout')), 30000);
         });
       } catch (error) {
-        console.error('Could not handle close event in renderer:', error);
+        logger.error('Could not handle close event in renderer:', error);
       }
 
       // Close app

--- a/src/main/network/service/http-service.ts
+++ b/src/main/network/service/http-service.ts
@@ -33,7 +33,7 @@ export class HttpService {
    * @returns response object
    */
   public async fetchAsync(request: TrufosRequest) {
-    console.info('Sending request:', request);
+    logger.info('Sending request:', request);
 
     const now = getSteadyTimestamp();
     const body = await this.readBody(request);
@@ -49,14 +49,14 @@ export class HttpService {
     });
 
     const duration = getDurationFromNow(now);
-    console.info(`Received response in ${duration} milliseconds`);
+    logger.info(`Received response in ${duration} milliseconds`);
 
     // write the response body to a temporary file
     const bodyFile = fileSystemService.temporaryFile();
     if (responseData.body != null) {
-      console.debug('Writing response body to temporary file:', bodyFile.name);
+      logger.debug('Writing response body to temporary file:', bodyFile.name);
       await pipeline(responseData.body, fs.createWriteStream('', { fd: bodyFile.fd }));
-      console.debug('Successfully written response body');
+      logger.debug('Successfully written response body');
     }
 
     // return a new Response instance
@@ -73,7 +73,7 @@ export class HttpService {
       bodyFilePath: responseData.body != null ? bodyFile.name : null,
     };
 
-    console.debug('Returning response:', response);
+    logger.debug('Returning response:', response);
     return response;
   }
 

--- a/src/main/persistence/service/info-files/migrators.ts
+++ b/src/main/persistence/service/info-files/migrators.ts
@@ -19,12 +19,12 @@ const MIGRATORS = new Map<string, AbstractInfoFileMigrator<VersionedObject, Vers
 
 export async function migrateInfoFile(infoFile: VersionedObject, type: TrufosObjectType) {
   while (infoFile.version !== LATEST_VERSION.toString()) {
-    console.debug(`Looking for mapper for source version ${infoFile.version}`);
+    logger.debug(`Looking for mapper for source version ${infoFile.version}`);
     const mapper = MIGRATORS.get(infoFile.version);
     if (!mapper) throw new Error(`No mapper found for version ${infoFile.version}`);
     const oldVersion = infoFile.version;
     infoFile = await mapper.migrate(infoFile, type);
-    console.info(`Migrated from version ${oldVersion} to ${infoFile.version}`);
+    logger.info(`Migrated from version ${oldVersion} to ${infoFile.version}`);
     if (oldVersion === infoFile.version) {
       throw new Error(`Mapper for version ${infoFile.version} did not change the version`);
     }

--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -44,7 +44,7 @@ export class PersistenceService {
   public async createDefaultCollectionIfNotExists() {
     const dirPath = SettingsService.DEFAULT_COLLECTION_DIR;
     if (!(await exists(path.join(dirPath, 'collection.json')))) {
-      console.info('Creating default collection at', dirPath);
+      logger.info('Creating default collection at', dirPath);
       const collection = generateDefaultCollection(dirPath);
       await this.saveCollectionRecursive(collection);
     }
@@ -83,7 +83,7 @@ export class PersistenceService {
     object.title = newTitle;
     const newDirPath = path.join(path.dirname(oldDirPath), this.getDirName(object));
 
-    console.info('Renaming object at', oldDirPath, 'to', newDirPath);
+    logger.info('Renaming object at', oldDirPath, 'to', newDirPath);
     await fs.rename(oldDirPath, newDirPath);
 
     this.idToPathMap.set(object.id, newDirPath);
@@ -144,7 +144,7 @@ export class PersistenceService {
    * @param fileName the name of the information file
    */
   private async saveInfoFile(object: TrufosObject, dirPath: string, fileName: string) {
-    console.info('Saving object', (object.id ??= randomUUID()));
+    logger.info('Saving object', (object.id ??= randomUUID()));
     if (!isCollection(object) && object.parentId == null) {
       throw new Error('Object must have a parent');
     } else if (!(await exists(dirPath))) {
@@ -202,7 +202,7 @@ export class PersistenceService {
   public async saveChanges(request: TrufosRequest) {
     const { draft, dirPath, infoFileName } = await this.undraft(request);
     if (draft) {
-      console.info('Saving changes of request at', dirPath);
+      logger.info('Saving changes of request at', dirPath);
       await fs.rename(path.join(dirPath, '~' + infoFileName), path.join(dirPath, infoFileName));
       if (isRequest(request)) {
         const draftBodyFilePath = path.join(dirPath, DRAFT_TEXT_BODY_FILE_NAME);
@@ -227,7 +227,7 @@ export class PersistenceService {
     if (!draft) {
       return request;
     }
-    console.info('Discarding changes of request at', dirPath);
+    logger.info('Discarding changes of request at', dirPath);
 
     // delete draft files
     await fs.unlink(path.join(dirPath, '~' + infoFileName));
@@ -245,7 +245,7 @@ export class PersistenceService {
    */
   public async delete(object: TrufosObject) {
     const dirPath = this.getDirPath(object);
-    console.info('Deleting object at', dirPath);
+    logger.info('Deleting object at', dirPath);
 
     // delete children first
     if (!isRequest(object)) {
@@ -266,15 +266,15 @@ export class PersistenceService {
    * @returns the text body of the request if it exists
    */
   public async loadTextBodyOfRequest(request: TrufosRequest, encoding?: BufferEncoding) {
-    console.info('Loading text body of request', request.id);
+    logger.info('Loading text body of request', request.id);
     if (request.body.type === RequestBodyType.TEXT) {
       const fileName = request.draft ? DRAFT_TEXT_BODY_FILE_NAME : TEXT_BODY_FILE_NAME;
       const filePath = path.join(this.getDirPath(request), fileName);
       if (await exists(filePath)) {
-        console.debug(`Opening text body file at ${filePath}`);
+        logger.debug(`Opening text body file at ${filePath}`);
         return createReadStream(filePath, encoding);
       }
-      console.warn('Text body file does not exist for request', request.id);
+      logger.warn('Text body file does not exist for request', request.id);
     }
   }
 
@@ -284,7 +284,7 @@ export class PersistenceService {
    * @param title the title of the collection
    */
   public async createCollection(dirPath: string, title: string): Promise<Collection> {
-    console.info('Creating new collection at', dirPath);
+    logger.info('Creating new collection at', dirPath);
     if ((await fs.readdir(dirPath)).length !== 0) {
       throw new Error('Directory is not empty');
     }
@@ -308,7 +308,7 @@ export class PersistenceService {
    * @returns the loaded collection
    */
   public async loadCollection(dirPath: string): Promise<Collection> {
-    console.info('Loading collection at', dirPath);
+    logger.info('Loading collection at', dirPath);
     const type = 'collection' as const;
     const info = await this.readInfoFile(dirPath, type);
     this.idToPathMap.set(info.id, dirPath);

--- a/src/main/persistence/service/settings-service.ts
+++ b/src/main/persistence/service/settings-service.ts
@@ -35,7 +35,7 @@ export class SettingsService implements Initializable {
     if (await exists(SettingsService.SETTINGS_FILE)) {
       await this.readSettings();
     } else {
-      console.info('No settings file found. Creating default.');
+      logger.info('No settings file found. Creating default.');
       await this.writeSettings();
     }
   }

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1,3 +1,4 @@
+import '@/logging/console';
 import { enableMapSet } from 'immer';
 
 enableMapSet();
@@ -7,6 +8,7 @@ import { createRoot } from 'react-dom/client';
 import { App } from '@/App';
 import { RendererEventService } from '@/services/event/renderer-event-service';
 import { useCollectionStore } from '@/state/collectionStore';
+import winston from 'winston';
 
 import('@/lib/monaco/config'); // lazy load monaco editor to improve startup time
 
@@ -16,10 +18,10 @@ console.info('Initializing renderer process...');
 
 // declare global functions
 declare global {
-  function joinClassNames(...classNames: string[]): string;
+  interface Window {
+    logger: winston.Logger;
+  }
 }
-
-globalThis.joinClassNames = (...classNames: string[]) => classNames.join(' ');
 
 document.getElementById('body')?.classList.add('dark');
 

--- a/src/renderer/logging/console.ts
+++ b/src/renderer/logging/console.ts
@@ -1,0 +1,32 @@
+import { LogEntry, LogLevel } from 'shim/logger';
+
+const _console = window.console;
+
+function log(level: LogLevel, ...data: unknown[]) {
+  switch (level) {
+    case 'info':
+    case 'debug':
+    case 'warn':
+    case 'error':
+      _console[level](...data);
+      break;
+  }
+
+  const [message, ...splat] = data;
+  const entry: LogEntry = {
+    process: 'renderer',
+    level,
+    message: `${message ?? ''}`,
+    splat,
+  };
+  window.electron.ipcRenderer.send('log', entry);
+}
+
+window.console = {
+  ..._console,
+  log: (...data: unknown[]) => log('info', ...data),
+  info: (...data: unknown[]) => log('info', ...data),
+  debug: (...data: unknown[]) => log('debug', ...data),
+  warn: (...data: unknown[]) => log('warn', ...data),
+  error: (...data: unknown[]) => log('error', ...data),
+};

--- a/src/shim/logger.ts
+++ b/src/shim/logger.ts
@@ -1,0 +1,8 @@
+export type LogLevel = 'info' | 'debug' | 'warn' | 'error';
+
+export interface LogEntry {
+  level: LogLevel;
+  message: string;
+  process: 'renderer' | 'main';
+  splat: unknown[];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,6 +191,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz#bbe12dca5b4ef983a0d0af4b07b9bc90ea0ababa"
   integrity sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==
 
+"@colors/colors@1.6.0", "@colors/colors@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.6.0.tgz#ec6cd237440700bc23ca23087f513c75508958b0"
+  integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -225,6 +230,15 @@
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz#a5502c8539265fecbd873c1e395a890339f119c2"
   integrity sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==
+
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.3.tgz#7f7e97ee9a725dffc7808d93668cc984e1dc477a"
+  integrity sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
 
 "@electron-forge/cli@^7.6.1":
   version "7.7.0"
@@ -1656,6 +1670,11 @@
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.6.tgz#d785ee90c52d7cc020e249c948c36f7b32d1e217"
   integrity sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==
 
+"@types/triple-beam@^1.3.2":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.5.tgz#74fef9ffbaa198eb8b588be029f38b00299caa2c"
+  integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
+
 "@types/uuid@^10.0.0":
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
@@ -2075,6 +2094,11 @@ async@^1.4.2:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==
 
+async@^3.2.3:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
+  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -2442,6 +2466,13 @@ clsx@^2.1.1:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
+color-convert@^1.9.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -2454,15 +2485,44 @@ color-convert@~0.5.0:
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
   integrity sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==
 
-color-name@~1.1.4:
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.6.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 colorette@^2.0.20:
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
+colorspace@1.1.x:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243"
+  integrity sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==
+  dependencies:
+    color "^3.1.3"
+    text-hex "1.0.x"
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -2872,6 +2932,11 @@ emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
 encode-utf8@^1.0.3:
   version "1.0.3"
@@ -3379,6 +3444,11 @@ fdir@^6.4.3:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.3.tgz#011cdacf837eca9b811c89dbb902df714273db72"
   integrity sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==
 
+fecha@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
+  integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
+
 file-entry-cache@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz#7787bddcf1131bffb92636c69457bbc0edd6d81f"
@@ -3467,6 +3537,11 @@ fmix@^0.1.0:
   integrity sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==
   dependencies:
     imul "^1.0.0"
+
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 for-each@^0.3.3:
   version "0.3.5"
@@ -4095,6 +4170,11 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
 is-async-function@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-async-function/-/is-async-function-2.1.1.tgz#3e69018c8e04e73b738793d020bfe884b9fd3523"
@@ -4283,6 +4363,11 @@ is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
+
+is-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
 is-string@^1.0.7, is-string@^1.1.1:
   version "1.1.1"
@@ -4527,6 +4612,11 @@ keyv@^4.0.0, keyv@^4.5.4:
   dependencies:
     json-buffer "3.0.1"
 
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -4636,6 +4726,18 @@ log-update@^5.0.1:
     slice-ansi "^5.0.0"
     strip-ansi "^7.0.1"
     wrap-ansi "^8.0.1"
+
+logform@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.7.0.tgz#cfca97528ef290f2e125a08396805002b2d060d1"
+  integrity sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==
+  dependencies:
+    "@colors/colors" "1.6.0"
+    "@types/triple-beam" "^1.3.2"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    safe-stable-stringify "^2.3.1"
+    triple-beam "^1.3.0"
 
 loupe@^3.1.0, loupe@^3.1.3:
   version "3.1.3"
@@ -5147,6 +5249,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
 
 onetime@^5.1.0:
   version "5.1.2"
@@ -5728,7 +5837,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^3.4.0:
+readable-stream@^3.4.0, readable-stream@^3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -5978,6 +6087,11 @@ safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
+safe-stable-stringify@^2.3.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
+  integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
+
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -6171,6 +6285,13 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
+
 slice-ansi@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
@@ -6266,6 +6387,11 @@ stable-hash@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/stable-hash/-/stable-hash-0.0.4.tgz#55ae7dadc13e4b3faed13601587cec41859b42f7"
   integrity sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==
 
 stackback@0.0.2:
   version "0.0.2"
@@ -6532,6 +6658,11 @@ test-exclude@^7.0.1:
     glob "^10.4.1"
     minimatch "^9.0.4"
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 thenify-all@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
@@ -6655,6 +6786,11 @@ trim-repeated@^1.0.0:
   integrity sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==
   dependencies:
     escape-string-regexp "^1.0.2"
+
+triple-beam@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.4.1.tgz#6fde70271dc6e5d73ca0c3b24e2d92afb7441984"
+  integrity sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==
 
 ts-api-utils@^2.0.1:
   version "2.0.1"
@@ -7093,6 +7229,32 @@ why-is-node-running@^2.3.0:
   dependencies:
     siginfo "^2.0.0"
     stackback "0.0.2"
+
+winston-transport@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.9.0.tgz#3bba345de10297654ea6f33519424560003b3bf9"
+  integrity sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==
+  dependencies:
+    logform "^2.7.0"
+    readable-stream "^3.6.2"
+    triple-beam "^1.3.0"
+
+winston@^3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.17.0.tgz#74b8665ce9b4ea7b29d0922cfccf852a08a11423"
+  integrity sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==
+  dependencies:
+    "@colors/colors" "^1.6.0"
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.7.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    safe-stable-stringify "^2.3.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.9.0"
 
 word-wrap@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
## Changes

Use winston to log
- `console` logs from renderer
- `logger` logs from main

The renderer `console` log methods are overwritten to redirect the log message to main, where they are written to FS. The `logger` is a new global variable, available in main. `console` should not be used in main anymore.

FS logger logic:
- max 10 files
- tailable (current file is always `trufos.log`)
- max 10MiB per file

## Testing

```
2025-03-16 19:16:31 [MAIN] [INFO]: Loading collection at
2025-03-16 19:16:31 [MAIN] [INFO]: Migrated from version 1.0.1 to 1.1.0
2025-03-16 19:16:31.383 Electron[54635:9276667] +[IMKClient subclass]: chose IMKClient_Modern
2025-03-16 19:16:31.383 Electron[54635:9276667] +[IMKInputSession subclass]: chose IMKInputSession_Modern
2025-03-16 19:16:32 [RENDERER] [INFO]: Download the React DevTools for a better development experience: https://react.dev/link/react-devtools
2025-03-16 19:16:32 [RENDERER] [INFO]: Initializing renderer process...
2025-03-16 19:16:32 [RENDERER] [INFO]: initialize
2025-03-16 19:16:32 [RENDERER] [INFO]: Monaco editor initialized
2025-03-16 19:16:52 [RENDERER] [INFO]: Saving currently opened request before closing
```

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
