### PR TITLE
feat(303): Temporary Buttons for opening Collections

### DIFF
--- a/examples/collection/collection.json
+++ b/examples/collection/collection.json
@@ -1,0 +1,7 @@
+{
+  "id": "dbba497e-b5a1-47f3-86d4-5461c01e034f",
+  "title": "New Collection",
+  "version": "1.1.0",
+  "variables": {},
+  "environments": {}
+}

--- a/examples/collection/echo/request-body.txt
+++ b/examples/collection/echo/request-body.txt
@@ -1,0 +1,3 @@
+{
+    "randomUuid": "{{$randomUuid}}"
+}

--- a/examples/collection/echo/request.json
+++ b/examples/collection/echo/request.json
@@ -1,0 +1,13 @@
+{
+  "id": "35efb7a3-84ab-4d28-a91c-2945c0591c6e",
+  "title": "Echo",
+  "version": "1.1.0",
+  "url": "https://echo.free.beeceptor.com",
+  "method": "POST",
+  "headers": [],
+  "queryParams": [],
+  "body": {
+    "type": "text",
+    "mimeType": "application/json"
+  }
+}

--- a/src/main/environment/service/environment-service.ts
+++ b/src/main/environment/service/environment-service.ts
@@ -61,15 +61,20 @@ export class EnvironmentService implements Initializable {
   }
 
   /**
-   * Loads the collection at the specified path and sets it as the current collection.
+   * Loads the given collection and sets it as the current collection.
    *
-   * @param path The path of the collection
+   * @param collection The collection to select or the path to the collection.
    */
-  public async changeCollection(path: string) {
-    path = normalize(path);
-    const settings = settingsService.modifiableSettings;
+  public async changeCollection(collection: Collection | string) {
+    // load collection
+    this.currentCollection =
+      typeof collection === 'string'
+        ? await persistenceService.loadCollection(collection)
+        : collection;
 
-    // open the collection if it is not already open
+    // add collection to the list of open collections if it is not already there
+    const path = this.currentCollection.dirPath;
+    const settings = settingsService.modifiableSettings;
     const collectionIndex = settings.collections.indexOf(path);
     if (collectionIndex === -1) {
       settings.currentCollectionIndex = settings.collections.push(path) - 1;
@@ -77,7 +82,7 @@ export class EnvironmentService implements Initializable {
       settings.currentCollectionIndex = collectionIndex;
     }
 
-    this.currentCollection = await persistenceService.loadCollection(path);
+    // save settings and return the current collection
     await settingsService.setSettings(settings);
     return this.currentCollection;
   }

--- a/src/main/environment/service/environment-service.ts
+++ b/src/main/environment/service/environment-service.ts
@@ -32,14 +32,21 @@ export class EnvironmentService implements Initializable {
   }
 
   /**
-   * Initializes the environment service by loading the last used collection.
+   * Initializes the environment service by loading the last used collection. If that fails, the
+   * default collection is loaded instead.
    */
   public async init() {
     const { settings } = settingsService;
     await persistenceService.createDefaultCollectionIfNotExists();
 
     const collectionDir = settings.collections[settings.currentCollectionIndex];
-    this.currentCollection = await persistenceService.loadCollection(collectionDir);
+    try {
+      this.currentCollection = await persistenceService.loadCollection(collectionDir);
+    } catch (e) {
+      logger.error(`Failed to load collection at ${collectionDir}:`, e);
+      logger.info('Loading default collection instead.');
+      await this.changeCollection(SettingsService.DEFAULT_COLLECTION_DIR);
+    }
   }
 
   /**

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -122,11 +122,13 @@ export class MainEventService implements IEventService {
   }
 
   async openCollection(dirPath: string) {
-    return await persistenceService.loadCollection(dirPath);
+    return await environmentService.changeCollection(dirPath);
   }
 
   async createCollection(dirPath: string, title: string) {
-    return await persistenceService.createCollection(dirPath, title);
+    return await environmentService.changeCollection(
+      await persistenceService.createCollection(dirPath, title)
+    );
   }
 
   async closeCollection(dirPath?: string) {

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -1,7 +1,7 @@
 import './stream-events';
 import { IEventService } from 'shim/event-service';
 import { HttpService } from 'main/network/service/http-service';
-import { app, ipcMain } from 'electron';
+import { app, ipcMain, dialog } from 'electron';
 import { TrufosRequest } from 'shim/objects/request';
 import { PersistenceService } from '../persistence/service/persistence-service';
 import { TrufosObject } from 'shim/objects';
@@ -131,5 +131,9 @@ export class MainEventService implements IEventService {
 
   async closeCollection(dirPath?: string) {
     return await environmentService.closeCollection(dirPath);
+  }
+
+  async showOpenDialog(options: Electron.OpenDialogOptions) {
+    return await dialog.showOpenDialog(options);
   }
 }

--- a/src/main/persistence/service/persistence-service.test.ts
+++ b/src/main/persistence/service/persistence-service.test.ts
@@ -53,6 +53,7 @@ function getExampleRequest(parentId: string): TrufosRequest {
     draft: false,
     parentId,
     method: RequestMethod.GET,
+    queryParams: [],
     body: { type: RequestBodyType.TEXT, mimeType: 'text/plain' },
   };
 }

--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -31,7 +31,8 @@ import { SettingsService } from './settings-service';
 
 /**
  * This service is responsible for persisting and loading collections, folders, and requests
- * to and from the file system.
+ * to and from the file system. If you want to open a collection, you should use the
+ * {@link EnvironmentService.changeCollection} which will call this service internally.
  */
 export class PersistenceService {
   public static readonly instance = new PersistenceService();

--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -29,6 +29,9 @@ import { migrateInfoFile } from './info-files/migrators';
 import { SemVer } from 'main/util/semver';
 import { SettingsService } from './settings-service';
 
+/** Content of the .gitignore file for a collection */
+const COLLECTION_GITIGNORE = ['~request.json'].join('\n');
+
 /**
  * This service is responsible for persisting and loading collections, folders, and requests
  * to and from the file system. If you want to open a collection, you should use the
@@ -286,7 +289,7 @@ export class PersistenceService {
    */
   public async createCollection(dirPath: string, title: string): Promise<Collection> {
     logger.info('Creating new collection at', dirPath);
-    if ((await fs.readdir(dirPath)).length !== 0) {
+    if ((await fs.readdir(dirPath)).some((file) => file !== '.DS_Store')) {
       throw new Error('Directory is not empty');
     }
 
@@ -299,7 +302,8 @@ export class PersistenceService {
       environments: {},
       children: [],
     };
-    await this.saveCollection(collection);
+    await this.saveCollection(collection); // save collection file
+    await fs.writeFile(path.join(dirPath, '.gitignore'), COLLECTION_GITIGNORE); // create .gitignore
     return collection;
   }
 

--- a/src/renderer/components/sidebar/SidebarHeaderBar.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.tsx
@@ -4,20 +4,84 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { AddIcon } from '@/components/icons';
 import { NamingModal } from '@/components/sidebar/SidebarRequestList/Nav/Dropdown/modals/NamingModal';
-import { useCollectionStore } from '@/state/collectionStore';
+import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
+import { Collection } from 'shim/objects/collection';
+import { RendererEventService } from '@/services/event/renderer-event-service';
+
+const eventService = RendererEventService.instance;
+const COLLECTION_FILE_NAME = 'collection.json';
 
 export const SidebarHeaderBar = () => {
+  const { changeCollection } = useCollectionActions();
   const collection = useCollectionStore((state) => state.collection);
   const [modalState, setModalState] = useState({ isOpen: false, type: null });
+  const buttonClassName = cn('flex min-w-[24px] h-[36px] p-0 items-center justify-center');
 
   const openModal = (type: 'request' | 'folder') => setModalState({ isOpen: true, type });
+
+  const openCollection = async () => {
+    try {
+      const result = await eventService.showOpenDialog({
+        properties: ['openFile'],
+        filters: [{ name: 'Collection', extensions: [COLLECTION_FILE_NAME] }],
+      });
+      if (!result.canceled && result.filePaths.length > 0) {
+        const dirPath = result.filePaths[0].slice(0, -COLLECTION_FILE_NAME.length);
+        console.info('Opening collection at', dirPath);
+        changeCollection(await eventService.openCollection(dirPath));
+      }
+    } catch (e) {
+      console.error('Error opening collection:', e);
+    }
+  };
+
+  const createCollection = async () => {
+    try {
+      const result = await eventService.showOpenDialog({ properties: ['openDirectory'] });
+      if (!result.canceled && result.filePaths.length > 0) {
+        console.info('Creating collection at', result.filePaths[0]);
+        changeCollection(
+          await eventService.createCollection(result.filePaths[0], 'New Collection')
+        );
+      }
+    } catch (e) {
+      console.error('Error creating collection:', e);
+    }
+  };
 
   return (
     <div>
       <SidebarHeader>
         <div className="mt-2 flex w-full max-w-sm items-center space-x-[24px]">
           <Button
-            className={cn('flex min-w-[24px] h-[36px] p-0 items-center justify-center')}
+            className={buttonClassName}
+            type="button"
+            style={{ width: '100%' }}
+            onClick={openCollection}
+          >
+            <div className={cn('m-2')}>
+              <AddIcon size={24} color={'black'} />
+            </div>
+            <span className="overflow-hidden">Open Collection</span>
+          </Button>
+          <Button
+            className={buttonClassName}
+            type="button"
+            style={{
+              width: '100%',
+            }}
+            onClick={createCollection}
+          >
+            <div className={cn('m-2')}>
+              <AddIcon size={24} color={'black'} />
+            </div>
+            <span className="overflow-hidden">New Collection</span>
+          </Button>
+        </div>
+
+        <div className="mt-2 flex w-full max-w-sm items-center space-x-[24px]">
+          <Button
+            className={buttonClassName}
             type="button"
             style={{ width: '100%' }}
             onClick={() => openModal('folder')}
@@ -28,7 +92,7 @@ export const SidebarHeaderBar = () => {
             <span className="overflow-hidden">New Folder</span>
           </Button>
           <Button
-            className={cn(' flex min-w-[24px] h-[36px] p-0 items-center justify-center')}
+            className={buttonClassName}
             type="button"
             style={{
               width: '100%',
@@ -45,7 +109,7 @@ export const SidebarHeaderBar = () => {
       {modalState.isOpen && (
         <NamingModal
           isOpen={modalState.isOpen}
-          trufosObject={collection}
+          trufosObject={collection as Collection}
           createType={modalState.type}
           setOpen={(open) => setModalState({ isOpen: open, type: modalState.type })}
         />

--- a/src/renderer/services/event/renderer-event-service.ts
+++ b/src/renderer/services/event/renderer-event-service.ts
@@ -57,4 +57,5 @@ export class RendererEventService implements IEventService {
   openCollection = createEventMethod('openCollection');
   createCollection = createEventMethod('createCollection');
   closeCollection = createEventMethod('closeCollection');
+  showOpenDialog = createEventMethod('showOpenDialog');
 }

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -55,7 +55,7 @@ export const useCollectionStore = create<CollectionState & CollectionStateAction
     initialize: (collection) => {
       const requests = new Map<TrufosRequest['id'], TrufosRequest>();
       const folders = new Map<Folder['id'], Folder>();
-      const { initialize } = useVariableStore.getState();
+      const { initialize: initializeVariables } = useVariableStore.getState();
 
       const stack = [...collection.children];
       while (stack.length > 0) {
@@ -68,9 +68,16 @@ export const useCollectionStore = create<CollectionState & CollectionStateAction
         }
       }
 
-      set({ collection, requests, folders });
-      initialize(collection.variables);
-      console.info('initialize', get().collection);
+      // (re)set initial state
+      set({ collection, requests, folders, openFolders: new Set(), selectedRequestId: undefined });
+      initializeVariables(collection.variables);
+      console.info('Initialized collection:', get().collection);
+    },
+
+    changeCollection: async (collection: Collection) => {
+      const { setSelectedRequest, initialize } = get();
+      await setSelectedRequest(); // persist unsaved changes
+      initialize(collection);
     },
 
     addNewRequest: async (title, parentId) => {

--- a/src/renderer/state/interface/CollectionStateActions.ts
+++ b/src/renderer/state/interface/CollectionStateActions.ts
@@ -8,6 +8,12 @@ import { TrufosQueryParam } from 'shim/objects/query-param';
 export interface CollectionStateActions {
   initialize(collection: Collection): void;
 
+  /**
+   * Change the current collection to the given collection. Will save any unsaved changes
+   * @param collection The collection to change to
+   */
+  changeCollection(collection: Collection): void;
+
   addNewRequest(title?: string, parentId?: string): Promise<void>;
 
   /**

--- a/src/renderer/view/Menubar.tsx
+++ b/src/renderer/view/Menubar.tsx
@@ -8,7 +8,7 @@ export const Menubar = () => {
   return (
     <div>
       <Sidebar collapsible={'none'}>
-        <SidebarHeaderBar></SidebarHeaderBar>
+        <SidebarHeaderBar />
         <SidebarRequestList />
         <FooterBar />
       </Sidebar>

--- a/src/shim/event-service.ts
+++ b/src/shim/event-service.ts
@@ -101,4 +101,9 @@ export interface IEventService {
    * @param dirPath The directory path of the collection to close. If not provided, the current collection is closed.
    */
   closeCollection(dirPath?: string): Promise<Collection>;
+
+  /**
+   * Open a folder dialog and return the selected directory path.
+   */
+  showOpenDialog(options: Electron.OpenDialogOptions): Promise<Electron.OpenDialogReturnValue>;
 }


### PR DESCRIPTION
## Changes

- Add `showOpenDialog()` event method that allows showing a native dialog to open a file or directory
- Add a button to open an existing collection (`collection.json` file)
- Add a button to create a new collection in a selected directory (must be empty)
- Add `changeCollection()` action to collection store
- Add `examples/collection` directory to repository
- When loading of current collection fails on boot, default collection is loaded instead
- Create `.gitignore` when creating new collection to prevent committing draft requests

## Testing

**Open existing Collection:**

https://github.com/user-attachments/assets/53eb604f-c10a-4289-a767-50f73e2b9c74

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
