### PR TITLE
fix(337): Logger not printing extra Arguments

### DIFF
--- a/src/main/logging/logger.test.ts
+++ b/src/main/logging/logger.test.ts
@@ -100,4 +100,61 @@ describe('Logger', () => {
       logger.remove(transport);
     }
   });
+
+  it('should log exceptions as single argument', async () => {
+    // Arrange
+    const now = new Date();
+    const error = new Error('test error');
+    const expected = `${now.toISOString()} [MAIN] [ERROR]: ${error.stack}\n`;
+
+    const data: unknown[] = [];
+    const stream = new Writable({ write: (chunk) => data.push(chunk) });
+    const transport = new transports.Stream({ stream });
+
+    vi.useFakeTimers({ now });
+    logger.add(transport);
+
+    try {
+      // Act
+      logger.error(error);
+
+      // Assert
+      expect(data.length).toBe(1);
+      expect(data[0]).toBeInstanceOf(Buffer);
+      const actual = data[0].toString();
+      expect(actual).toEqual(expected);
+    } finally {
+      vi.useRealTimers();
+      logger.remove(transport);
+    }
+  });
+
+  it('should log exceptions as last argument after message', async () => {
+    // Arrange
+    const now = new Date();
+    const message = 'Error was thrown:';
+    const error = new Error('test error');
+    const expected = `${now.toISOString()} [MAIN] [ERROR]: ${message} ${error.stack}\n`;
+
+    const data: unknown[] = [];
+    const stream = new Writable({ write: (chunk) => data.push(chunk) });
+    const transport = new transports.Stream({ stream });
+
+    vi.useFakeTimers({ now });
+    logger.add(transport);
+
+    try {
+      // Act
+      logger.error(message, error);
+
+      // Assert
+      expect(data.length).toBe(1);
+      expect(data[0]).toBeInstanceOf(Buffer);
+      const actual = data[0].toString();
+      expect(actual).toEqual(expected);
+    } finally {
+      vi.useRealTimers();
+      logger.remove(transport);
+    }
+  });
 });


### PR DESCRIPTION
## Changes

- Printing any extra arguments of logger
- Printing error stacktraces (if it's last element in log statement)
- Set FS log level to warning

## Testing

```
2025-04-04T20:12:32.114Z [RENDERER] [INFO]: initialize {
  id: '7c966850-a7a1-4621-90b4-b798a76ccfeb',
  title: 'Default Collection',
 ... and so on
```

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
