### PR TITLE
#307 - Resolve dir path naming conflicts

### DIFF
--- a/src/main/persistence/service/persistence-service.test.ts
+++ b/src/main/persistence/service/persistence-service.test.ts
@@ -78,7 +78,7 @@ describe('PersistenceService', () => {
     const defaultCollectionImport = await import('./default-collection');
     const generateDefaultCollectionSpy = vi.spyOn(
       defaultCollectionImport,
-      'generateDefaultCollection',
+      'generateDefaultCollection'
     );
     await mkdir(collectionDirPath);
     await writeFile(path.join(collectionDirPath, 'collection.json'), '');
@@ -95,11 +95,11 @@ describe('PersistenceService', () => {
     const defaultCollectionImport = await import('./default-collection');
     const defaultCollection = {} as Collection;
     vi.spyOn(defaultCollectionImport, 'generateDefaultCollection').mockReturnValueOnce(
-      defaultCollection,
+      defaultCollection
     );
     const saveCollectionRecursiveSpy = vi
-    .spyOn(persistenceService, 'saveCollectionRecursive')
-    .mockResolvedValueOnce();
+      .spyOn(persistenceService, 'saveCollectionRecursive')
+      .mockResolvedValueOnce();
 
     // Act
     await persistenceService.createDefaultCollectionIfNotExists();
@@ -175,7 +175,7 @@ describe('PersistenceService', () => {
     await persistenceService.saveCollectionRecursive(collection);
 
     const oldInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8'),
+      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8')
     ) as RequestInfoFile;
     request.method = RequestMethod.PUT;
 
@@ -187,7 +187,7 @@ describe('PersistenceService', () => {
 
     // Assert
     const newInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8'),
+      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8')
     ) as RequestInfoFile;
     expect(newInfo.method).toBe(request.method);
     expect(newInfo).not.toEqual(oldInfo);
@@ -277,7 +277,7 @@ describe('PersistenceService', () => {
     expect(await exists(path.join(collection.dirPath, 'collection.json'))).toBe(true);
     expect(await exists(path.join(collection.dirPath, folder.title, 'folder.json'))).toBe(true);
     expect(
-      await exists(path.join(collection.dirPath, folder.title, request.title, 'request.json')),
+      await exists(path.join(collection.dirPath, folder.title, request.title, 'request.json'))
     ).toBe(true);
   });
 
@@ -293,10 +293,10 @@ describe('PersistenceService', () => {
 
     await persistenceService.saveRequest(request);
     let originalInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8'),
+      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8')
     ) as RequestInfoFile;
     const draftInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, '~request.json'), 'utf-8'),
+      await readFile(path.join(collection.dirPath, request.title, '~request.json'), 'utf-8')
     ) as RequestInfoFile;
 
     // Assert
@@ -311,7 +311,7 @@ describe('PersistenceService', () => {
     expect(await exists(path.join(collection.dirPath, request.title, 'request.json'))).toBe(true);
     expect(await exists(path.join(collection.dirPath, request.title, '~request.json'))).toBe(false);
     originalInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8'),
+      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8')
     ) as RequestInfoFile;
     expect(originalInfo).toEqual(draftInfo);
   });
@@ -328,7 +328,7 @@ describe('PersistenceService', () => {
 
     await persistenceService.saveRequest(request);
     const oldInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8'),
+      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8')
     ) as RequestInfoFile;
 
     // Assert
@@ -342,7 +342,7 @@ describe('PersistenceService', () => {
     expect(await exists(path.join(collection.dirPath, request.title, 'request.json'))).toBe(true);
     expect(await exists(path.join(collection.dirPath, request.title, '~request.json'))).toBe(false);
     const newInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8'),
+      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8')
     ) as RequestInfoFile;
     expect(oldInfo).toEqual(newInfo);
   });
@@ -375,10 +375,10 @@ describe('PersistenceService', () => {
 
     // Assert
     expect(await exists(path.join(collection.dirPath, request.title, TEXT_BODY_FILE_NAME))).toBe(
-      true,
+      true
     );
     expect(
-      await exists(path.join(collection.dirPath, request.title, DRAFT_TEXT_BODY_FILE_NAME)),
+      await exists(path.join(collection.dirPath, request.title, DRAFT_TEXT_BODY_FILE_NAME))
     ).toBe(false);
 
     // Act
@@ -418,10 +418,10 @@ describe('PersistenceService', () => {
 
     // Assert
     expect(await exists(path.join(collection.dirPath, request.title, TEXT_BODY_FILE_NAME))).toBe(
-      false,
+      false
     );
     expect(
-      await exists(path.join(collection.dirPath, request.title, DRAFT_TEXT_BODY_FILE_NAME)),
+      await exists(path.join(collection.dirPath, request.title, DRAFT_TEXT_BODY_FILE_NAME))
     ).toBe(true);
 
     // Act

--- a/src/main/persistence/service/persistence-service.test.ts
+++ b/src/main/persistence/service/persistence-service.test.ts
@@ -78,7 +78,7 @@ describe('PersistenceService', () => {
     const defaultCollectionImport = await import('./default-collection');
     const generateDefaultCollectionSpy = vi.spyOn(
       defaultCollectionImport,
-      'generateDefaultCollection'
+      'generateDefaultCollection',
     );
     await mkdir(collectionDirPath);
     await writeFile(path.join(collectionDirPath, 'collection.json'), '');
@@ -95,11 +95,11 @@ describe('PersistenceService', () => {
     const defaultCollectionImport = await import('./default-collection');
     const defaultCollection = {} as Collection;
     vi.spyOn(defaultCollectionImport, 'generateDefaultCollection').mockReturnValueOnce(
-      defaultCollection
+      defaultCollection,
     );
     const saveCollectionRecursiveSpy = vi
-      .spyOn(persistenceService, 'saveCollectionRecursive')
-      .mockResolvedValueOnce();
+    .spyOn(persistenceService, 'saveCollectionRecursive')
+    .mockResolvedValueOnce();
 
     // Act
     await persistenceService.createDefaultCollectionIfNotExists();
@@ -175,7 +175,7 @@ describe('PersistenceService', () => {
     await persistenceService.saveCollectionRecursive(collection);
 
     const oldInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8')
+      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8'),
     ) as RequestInfoFile;
     request.method = RequestMethod.PUT;
 
@@ -187,7 +187,7 @@ describe('PersistenceService', () => {
 
     // Assert
     const newInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8')
+      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8'),
     ) as RequestInfoFile;
     expect(newInfo.method).toBe(request.method);
     expect(newInfo).not.toEqual(oldInfo);
@@ -199,6 +199,49 @@ describe('PersistenceService', () => {
 
     // Assert
     expect(await exists(path.join(collection.dirPath, 'collection.json'))).toBe(true);
+  });
+
+  it('saveRequest() should find an unused directory name', async () => {
+    // Arrange requests
+    const firstRequest = { ...getExampleRequest(collection.id), title: 'A B' };
+    const secondRequest = { ...getExampleRequest(collection.id), title: 'A-B' };
+    const thirdRequest = { ...getExampleRequest(collection.id), title: 'a b' };
+    const expectedFirstDirPath = path.join(collection.dirPath, 'a-b');
+    const expectedSecondDirPath = path.join(collection.dirPath, 'a-b-2');
+    const expectedThirdDirPath = path.join(collection.dirPath, 'a-b-3');
+
+    expect(await exists(expectedFirstDirPath)).toBe(false);
+    expect(await exists(expectedSecondDirPath)).toBe(false);
+    expect(await exists(expectedThirdDirPath)).toBe(false);
+
+    await persistenceService.saveCollectionRecursive(collection);
+
+    // Act
+    collection.children.push(firstRequest);
+    await persistenceService.saveRequest(firstRequest);
+
+    // Assert
+    expect(await exists(expectedFirstDirPath)).toBe(true);
+    expect(await exists(expectedSecondDirPath)).toBe(false);
+    expect(await exists(expectedThirdDirPath)).toBe(false);
+
+    // Act
+    collection.children.push(secondRequest);
+    await persistenceService.saveRequest(secondRequest);
+
+    // Assert
+    expect(await exists(expectedFirstDirPath)).toBe(true);
+    expect(await exists(expectedSecondDirPath)).toBe(true);
+    expect(await exists(expectedThirdDirPath)).toBe(false);
+
+    // Act
+    collection.children.push(thirdRequest);
+    await persistenceService.saveRequest(thirdRequest);
+
+    // Assert
+    expect(await exists(expectedFirstDirPath)).toBe(true);
+    expect(await exists(expectedSecondDirPath)).toBe(true);
+    expect(await exists(expectedThirdDirPath)).toBe(true);
   });
 
   it('saveFolder() should save the metadata of the folder', async () => {
@@ -234,7 +277,7 @@ describe('PersistenceService', () => {
     expect(await exists(path.join(collection.dirPath, 'collection.json'))).toBe(true);
     expect(await exists(path.join(collection.dirPath, folder.title, 'folder.json'))).toBe(true);
     expect(
-      await exists(path.join(collection.dirPath, folder.title, request.title, 'request.json'))
+      await exists(path.join(collection.dirPath, folder.title, request.title, 'request.json')),
     ).toBe(true);
   });
 
@@ -250,10 +293,10 @@ describe('PersistenceService', () => {
 
     await persistenceService.saveRequest(request);
     let originalInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8')
+      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8'),
     ) as RequestInfoFile;
     const draftInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, '~request.json'), 'utf-8')
+      await readFile(path.join(collection.dirPath, request.title, '~request.json'), 'utf-8'),
     ) as RequestInfoFile;
 
     // Assert
@@ -268,7 +311,7 @@ describe('PersistenceService', () => {
     expect(await exists(path.join(collection.dirPath, request.title, 'request.json'))).toBe(true);
     expect(await exists(path.join(collection.dirPath, request.title, '~request.json'))).toBe(false);
     originalInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8')
+      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8'),
     ) as RequestInfoFile;
     expect(originalInfo).toEqual(draftInfo);
   });
@@ -285,7 +328,7 @@ describe('PersistenceService', () => {
 
     await persistenceService.saveRequest(request);
     const oldInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8')
+      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8'),
     ) as RequestInfoFile;
 
     // Assert
@@ -299,7 +342,7 @@ describe('PersistenceService', () => {
     expect(await exists(path.join(collection.dirPath, request.title, 'request.json'))).toBe(true);
     expect(await exists(path.join(collection.dirPath, request.title, '~request.json'))).toBe(false);
     const newInfo = JSON.parse(
-      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8')
+      await readFile(path.join(collection.dirPath, request.title, 'request.json'), 'utf-8'),
     ) as RequestInfoFile;
     expect(oldInfo).toEqual(newInfo);
   });
@@ -332,10 +375,10 @@ describe('PersistenceService', () => {
 
     // Assert
     expect(await exists(path.join(collection.dirPath, request.title, TEXT_BODY_FILE_NAME))).toBe(
-      true
+      true,
     );
     expect(
-      await exists(path.join(collection.dirPath, request.title, DRAFT_TEXT_BODY_FILE_NAME))
+      await exists(path.join(collection.dirPath, request.title, DRAFT_TEXT_BODY_FILE_NAME)),
     ).toBe(false);
 
     // Act
@@ -375,10 +418,10 @@ describe('PersistenceService', () => {
 
     // Assert
     expect(await exists(path.join(collection.dirPath, request.title, TEXT_BODY_FILE_NAME))).toBe(
-      false
+      false,
     );
     expect(
-      await exists(path.join(collection.dirPath, request.title, DRAFT_TEXT_BODY_FILE_NAME))
+      await exists(path.join(collection.dirPath, request.title, DRAFT_TEXT_BODY_FILE_NAME)),
     ).toBe(true);
 
     // Act

--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -71,7 +71,7 @@ export class PersistenceService {
   public async moveChild(
     child: Folder | TrufosRequest,
     oldParent: Folder | Collection,
-    newParent: Folder | Collection,
+    newParent: Folder | Collection
   ) {
     const childDirName = this.getDirName(child);
     const oldChildDirPath = this.getOrCreateDirPath(child);
@@ -138,7 +138,11 @@ export class PersistenceService {
    * @param collection the collection to save
    */
   public async saveCollection(collection: Collection) {
-    await this.saveInfoFile(collection, this.getOrCreateDirPath(collection), collection.type + '.json');
+    await this.saveInfoFile(
+      collection,
+      this.getOrCreateDirPath(collection),
+      collection.type + '.json'
+    );
   }
 
   /**
@@ -359,7 +363,7 @@ export class PersistenceService {
 
   private async loadChildren(
     parentId: string,
-    parentDirPath: string,
+    parentDirPath: string
   ): Promise<(Folder | TrufosRequest)[]> {
     const children: (Folder | TrufosRequest)[] = [];
 
@@ -382,7 +386,7 @@ export class PersistenceService {
   private async load<T extends TrufosRequest | Folder>(
     parentId: string,
     dirPath: string,
-    type?: T['type'],
+    type?: T['type']
   ): Promise<T> {
     if (type === 'folder' || (await exists(path.join(dirPath, 'folder.json')))) {
       return (await this.loadFolder(parentId, dirPath)) as T;
@@ -400,13 +404,13 @@ export class PersistenceService {
   private readInfoFile(
     dirPath: string,
     type: TrufosRequest['type'],
-    draft: boolean,
+    draft: boolean
   ): Promise<RequestInfoFile>;
 
   private async readInfoFile<T extends TrufosObject>(
     dirPath: string,
     type: T['type'],
-    draft = false,
+    draft = false
   ) {
     const filePath = path.join(dirPath, `${draft ? '~' : ''}${type}.json`);
     const info = JSON.parse(await fs.readFile(filePath, 'utf8')) as InfoFile;
@@ -414,7 +418,7 @@ export class PersistenceService {
     // check if the version is supported
     if (SemVer.parse(info.version).isNewerThan(VERSION)) {
       throw new Error(
-        `The version of the loaded ${type} info file is newer than latest supported version ${VERSION}. Please update the application.`,
+        `The version of the loaded ${type} info file is newer than latest supported version ${VERSION}. Please update the application.`
       );
     }
 
@@ -469,8 +473,8 @@ export class PersistenceService {
 
   private sanitizeTitle(title: string) {
     return title
-    .toLowerCase()
-    .replace(/\s/g, '-')
-    .replace(/[^a-z0-9-]/g, '');
+      .toLowerCase()
+      .replace(/\s/g, '-')
+      .replace(/[^a-z0-9-]/g, '');
   }
 }

--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -455,10 +455,6 @@ export class PersistenceService {
         newDirPath = path.join(parentDirPath, newDirName + '-' + i);
       }
 
-      if (this.isDirPathTaken(newDirPath)) {
-        throw new Error(`Directory path ${newDirPath} is already taken`);
-      }
-
       return newDirPath;
     }
   }


### PR DESCRIPTION
This PR fixes the issue outlined in #307 where it was possible for one trufos object to overwrite another trufos object if they have a similar title, causing the resolved dir name to be the same.

## Changes

With the change from this PR, when assigning a new dir path for an object, we check if the dir path is already taken and append a number to the dir name until a name is found that is not taken.

## Testing

I tested these changes manually by creating a couple of trufos requests in the UI and checking which directories are created. Additionally I changed some data inside the requests to see if the correct files are overwritten when saving the requests.

![image](https://github.com/user-attachments/assets/b4b87c80-47f5-47ae-bf31-7b77df81ad77)

![image](https://github.com/user-attachments/assets/d8aada72-6bce-4b0d-9136-50f14c9ceda8)

I also added a unit test that tests this scenario.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [x] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
