### PR TITLE
fix(336): Set draft state when modifying request headers

### DIFF
--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/HeaderTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/HeaderTab.tsx
@@ -12,19 +12,38 @@ import {
 import { cn } from '@/lib/utils';
 import { TrufosHeader } from 'shim/objects/headers';
 import { selectRequest, useCollectionActions, useCollectionStore } from '@/state/collectionStore';
+import { useCallback } from 'react';
 
 export const HeaderTab = () => {
-  const { addHeader, deleteHeader, clearHeaders, updateHeader } = useCollectionActions();
+  const { addHeader, deleteHeader, clearHeaders, updateHeader, setDraftFlag } =
+    useCollectionActions();
   const headers = useCollectionStore((state) => selectRequest(state).headers);
 
-  const handleAddHeader = addHeader;
+  const handleAddHeader = useCallback(() => {
+    addHeader();
+    setDraftFlag();
+  }, [addHeader, setDraftFlag]);
 
-  const handleDeleteHeader = deleteHeader;
+  const handleDeleteHeader = useCallback(
+    (index: number) => {
+      deleteHeader(index);
+      setDraftFlag();
+    },
+    [deleteHeader, setDraftFlag]
+  );
 
-  const deleteAllHeaders = clearHeaders;
+  const handleDeleteAllHeaders = useCallback(() => {
+    clearHeaders();
+    setDraftFlag();
+  }, [clearHeaders, setDraftFlag]);
 
-  const handleUpdateHeader = (index: number, updatedFields: Partial<TrufosHeader>) =>
-    updateHeader(index, updatedFields);
+  const handleUpdateHeader = useCallback(
+    (index: number, updatedFields: Partial<TrufosHeader>) => {
+      updateHeader(index, updatedFields);
+      setDraftFlag();
+    },
+    [updateHeader, setDraftFlag]
+  );
 
   return (
     <div className={'p-4 h-full relative'}>
@@ -43,7 +62,7 @@ export const HeaderTab = () => {
             className={'hover:bg-transparent gap-1 h-fit'}
             size={'sm'}
             variant={'ghost'}
-            onClick={deleteAllHeaders}
+            onClick={handleDeleteAllHeaders}
           >
             <DeleteIcon />
             Delete All


### PR DESCRIPTION
## Changes

- Fixes #336
- I modified the code to set the draft flag within the event handlers in `HeaderTabs.tsx`. However, if preferred, I can update the corresponding header functions (`addHeader`, `deleteHeader` etc.) in `collectionStore.ts` to set the draft flag directly within those functions. Let me know if you'd like me to modify the PR accordingly.

## Testing

I tested the fix manually as can be seen in the video below.

https://github.com/user-attachments/assets/59c8edab-41ba-499b-ab8f-4d6283060b51

## Checklist

- [X] Issue has been linked to this PR
- [X] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [X] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
