### PR TITLE
feat(205): Responsive layout for main body items based on screen size

### DIFF
--- a/src/renderer/components/mainWindow/MainBody.tsx
+++ b/src/renderer/components/mainWindow/MainBody.tsx
@@ -3,9 +3,9 @@ import { OutputTabs } from '@/components/mainWindow/bodyTabs/OutputTabs';
 
 export function MainBody() {
   return (
-    <div className="h-full grid grid-cols-2 gap-6">
-      <InputTabs className="rounded-sm m-0" />
-      <OutputTabs className="rounded-sm m-0" />
+    <div className="flex flex-col xl:flex-row h-full gap-6">
+      <InputTabs className="flex flex-col flex-1 min-h-0 min-w-0" />
+      <OutputTabs className="flex flex-col flex-1 min-h-0 min-w-0" />
     </div>
   );
 }

--- a/src/renderer/view/RequestWindow.tsx
+++ b/src/renderer/view/RequestWindow.tsx
@@ -30,7 +30,7 @@ export function RequestWindow() {
   }
 
   return (
-    <div className={'flex flex-col flex-auto p-6'}>
+    <div className="flex flex-col h-full p-6">
       <MainTopBar />
       <MainBody />
     </div>


### PR DESCRIPTION
## Changes

- Closes #205
- For screen sizes `>= 1280px`, the two main body elements are displayed side by side, each occupying equal width
- For screen sizes `< 1280px`, the elements stack vertically, each taking equal height
- Simplified and unified `className` syntax in modified files to use the standard `className="..."` format

## Testing

The feature has been manually tested as can be seen in the video.

https://github.com/user-attachments/assets/ecbef50e-c595-40a1-b868-3f75899adfef

## Checklist

- [X] Issue has been linked to this PR
- [X] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [X] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
