### PR TITLE
feat(65) - Add drag and drop zone for a request body file

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,6 +1,6 @@
 // Disable no-unused-vars, broken for spread args
 /* eslint no-unused-vars: off */
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, webUtils } from 'electron';
 
 const electronHandler = {
   ipcRenderer: {
@@ -13,6 +13,7 @@ const electronHandler = {
       ipcRenderer
     ) as typeof ipcRenderer.removeListener,
   },
+  getAbsoluteFilePath: (file: File) => webUtils.getPathForFile(file),
 };
 
 contextBridge.exposeInMainWorld('electron', electronHandler);

--- a/src/renderer/components/mainWindow/MainBody.tsx
+++ b/src/renderer/components/mainWindow/MainBody.tsx
@@ -3,9 +3,9 @@ import { OutputTabs } from '@/components/mainWindow/bodyTabs/OutputTabs';
 
 export function MainBody() {
   return (
-    <div className="flex flex-col xl:flex-row h-full gap-6">
-      <InputTabs className="flex flex-col flex-1 min-h-0 min-w-0" />
-      <OutputTabs className="flex flex-col flex-1 min-h-0 min-w-0" />
+    <div className="grid grid-rows-[48%_48%] xl:grid-cols-2 xl:grid-rows-1 h-full gap-6">
+      <InputTabs className="min-h-0 min-w-0" />
+      <OutputTabs className="min-h-0 min-w-0" />
     </div>
   );
 }

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTab.tsx
@@ -29,17 +29,8 @@ export const BodyTab = () => {
 
   return (
     <div className="h-full flex flex-col gap-4">
-      <div className="pt-2 px-4 space-y-2">
-        <div className="flex justify-end gap-2">
-          <SimpleSelect<Language>
-            value={language}
-            onValueChange={setLanguage}
-            items={[
-              [Language.JSON, 'JSON'],
-              [Language.XML, 'XML'],
-              [Language.TEXT, 'Plain'],
-            ]}
-          />
+      <div className="pt-4 px-4 space-y-2">
+        <div className="flex gap-2 px-2">
           <SimpleSelect<RequestBodyType>
             value={requestBody?.type ?? RequestBodyType.TEXT}
             onValueChange={changeBodyType}
@@ -48,6 +39,17 @@ export const BodyTab = () => {
               [RequestBodyType.FILE, 'File'],
             ]}
           />
+          {requestBody.type === RequestBodyType.TEXT && (
+            <SimpleSelect<Language>
+              value={language}
+              onValueChange={setLanguage}
+              items={[
+                [Language.JSON, 'JSON'],
+                [Language.XML, 'XML'],
+                [Language.TEXT, 'Plain'],
+              ]}
+            />
+          )}
         </div>
         <Divider />
       </div>

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTabFileInput.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTabFileInput.tsx
@@ -1,0 +1,113 @@
+import { cn } from '@/lib/utils';
+import { selectRequest, useCollectionActions, useCollectionStore } from '@/state/collectionStore';
+import { FileText, Upload, X } from 'lucide-react';
+import { useCallback, useRef, useState } from 'react';
+import { FileBody, RequestBodyType } from 'shim/objects/request';
+
+interface BodyTabFileInputProps {
+  className?: string;
+}
+
+export default function BodyTabFileInput({ className }: BodyTabFileInputProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { setRequestBody } = useCollectionActions();
+  const requestBody = useCollectionStore((state) => selectRequest(state).body);
+
+  const setRequestBodyFile = useCallback(
+    (file?: File) => {
+      if (!file) return;
+
+      setRequestBody({
+        type: RequestBodyType.FILE,
+        filePath: window.electron.getAbsoluteFilePath(file),
+        fileName: file.name,
+        mimeType: file.type === '' ? undefined : file.type,
+      });
+    },
+    [setRequestBody]
+  );
+
+  const removeRequestBodyFile = useCallback(() => {
+    setRequestBody({ type: RequestBodyType.FILE });
+  }, [setRequestBody]);
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      if (!isDragging) {
+        setIsDragging(true);
+      }
+    },
+    [isDragging]
+  );
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragging(false);
+      setRequestBodyFile(e.dataTransfer.files?.[0]);
+    },
+    [setRequestBodyFile]
+  );
+
+  const renderSelectedFile = useCallback(
+    (requestBody: FileBody) => {
+      return (
+        <div className="flex items-center justify-between border rounded-md p-4">
+          <div className="flex items-center gap-4 overflow-hidden">
+            <FileText className="flex-shrink-0" />
+            <span className="block truncate">{requestBody.fileName}</span>
+          </div>
+          <button
+            className="text-red-500 hover:text-red-700 flex-shrink-0"
+            onClick={removeRequestBodyFile}
+          >
+            <X />
+          </button>
+        </div>
+      );
+    },
+    [removeRequestBodyFile]
+  );
+
+  const renderFileDropZone = useCallback(() => {
+    return (
+      <div
+        className={cn(
+          'w-full h-full flex flex-col items-center justify-center border-2 border-dashed rounded-lg gap-4',
+          { 'border-primary': isDragging }
+        )}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        onClick={() => fileInputRef.current?.click()}
+      >
+        <Upload size={36} />
+        <span>Drag and drop a file here, or click to select a file</span>
+        <input
+          type="file"
+          hidden
+          ref={fileInputRef}
+          onChange={(e) => {
+            setRequestBodyFile(e.target.files[0]);
+          }}
+        />
+      </div>
+    );
+  }, [isDragging, fileInputRef, setRequestBodyFile, handleDragOver, handleDragLeave, handleDrop]);
+
+  const isFileSelected = requestBody.type === RequestBodyType.FILE && requestBody.filePath;
+
+  return (
+    <div className={cn('h-full', className)}>
+      {isFileSelected ? renderSelectedFile(requestBody) : renderFileDropZone()}
+    </div>
+  );
+}

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTabTextInput.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTabTextInput.tsx
@@ -1,0 +1,40 @@
+import { REQUEST_EDITOR_OPTIONS } from '@/components/shared/settings/monaco-settings';
+import { Language } from '@/lib/monaco/language';
+import { cn } from '@/lib/utils';
+import { useCollectionActions } from '@/state/collectionStore';
+import { Editor } from '@monaco-editor/react';
+import { editor } from 'monaco-editor';
+import { useCallback } from 'react';
+
+interface BodyTabTextInputProps {
+  language: Language;
+  className?: string;
+}
+
+export default function BodyTabTextInput({ language, className }: BodyTabTextInputProps) {
+  const { setRequestEditor, setDraftFlag } = useCollectionActions();
+
+  const onEditorMount = useCallback(
+    (editor: editor.ICodeEditor) => {
+      setRequestEditor(editor);
+      editor.onDidChangeModelContent((e) => {
+        if (e.isFlush) return;
+        setDraftFlag();
+      });
+    },
+    [setRequestEditor, setDraftFlag]
+  );
+
+  return (
+    <Editor
+      height="100%"
+      className={cn('absolute h-full', className)}
+      theme="vs-dark" /* TODO: apply theme from settings */
+      options={REQUEST_EDITOR_OPTIONS}
+      language={language}
+      onMount={(editor) => {
+        onEditorMount(editor);
+      }}
+    />
+  );
+}

--- a/src/renderer/components/mainWindow/bodyTabs/OutputTabs.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/OutputTabs.tsx
@@ -70,7 +70,7 @@ export function OutputTabs({ className }: OutputTabsProps) {
 
       <TabsContent value="body" className="pt-4">
         <Editor
-          className="max-w-[calc(100vw-23rem)] max-h-[calc(100vh-12rem)]"
+          className="absolute h-full"
           language={mimeType}
           theme="vs-dark" /* TODO: apply theme from settings */
           options={RESPONSE_EDITOR_OPTIONS}

--- a/src/renderer/view/RequestWindow.tsx
+++ b/src/renderer/view/RequestWindow.tsx
@@ -30,7 +30,7 @@ export function RequestWindow() {
   }
 
   return (
-    <div className="flex flex-col h-full p-6">
+    <div className="grid grid-rows-[auto_1fr] p-6">
       <MainTopBar />
       <MainBody />
     </div>

--- a/src/shim/objects/request.ts
+++ b/src/shim/objects/request.ts
@@ -1,6 +1,6 @@
-import { RequestMethod } from './request-method';
 import { TrufosHeader } from './headers';
 import { TrufosQueryParam } from './query-param';
+import { RequestMethod } from './request-method';
 
 export const TEXT_BODY_FILE_NAME = 'request-body.txt';
 export const DRAFT_TEXT_BODY_FILE_NAME = '~' + TEXT_BODY_FILE_NAME;
@@ -35,6 +35,7 @@ export type TextBody = {
 export type FileBody = {
   type: RequestBodyType.FILE;
   filePath?: string;
+  fileName?: string;
   /** The mime type of the file content, e.g. "application/json". May include an encoding */
   mimeType?: string;
 };


### PR DESCRIPTION
## Changes

- Closes #65
- Introduces a drag-and-drop zone for request bodies with a file:
  - The drop zone highlights with a border when a file is dragged over it
  - Users can also click the zone to manually select a file from the file system
- Separates the text and file input components for the request body, improving clarity and modularity
- Replaces some `flex` layouts with `grid` to resolve overflow issues caused by truncated text and to enhance responsive behavior
- Improves styling of the Monaco Editor by setting its position to `absolute`, ensuring it respects the height and width of its parent container

Since no design reference was provided in the issue for the drag-and-drop zone, I implemented a design shown in the video below. I'm happy to update the styling if there's a preferred alternative.

## Testing

All changes were tested manually. A video demonstrating the behavior is included below.

https://github.com/user-attachments/assets/ffda9dbd-19b6-44d8-9eb4-e307282367c2

## Checklist

- [X] Issue has been linked to this PR
- [X] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [X] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
