### PR TITLE
fix(389): Fix persistent error border on URL input when switching to valid request

### DIFF
--- a/src/renderer/components/mainWindow/MainTopBar.tsx
+++ b/src/renderer/components/mainWindow/MainTopBar.tsx
@@ -63,6 +63,13 @@ export function MainTopBar() {
     [request, requestEditor]
   );
 
+  // useEffect to reset error state when URL and method are valid
+  useEffect(() => {
+    if (request?.url && request?.method) {
+      setHasError(false);
+    }
+  }, [request]);
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       //isSaveShortcut is true if save combination is recorded


### PR DESCRIPTION
#389 - URL input field keeps red error border after switching to a valid request

## Changes

This PR addresses issue #389 by ensuring that the error border on the URL input field is cleared when a valid request is detected. Previously, the error state persisted even after a valid URL and method were selected.

- Added a `useEffect` hook to monitor changes in the `request` object.
- Clears the error state (`setHasError(false)`) when both `request.url` and `request.method` are valid.

## Testing

Tested the fix based off the reproduce steps in the bug issue post:

- Removed content from input bar (invalid URL) to reproduce error state.
- Switched to a valid URL and confirming that the error border disappears.

![Error state](https://github.com/user-attachments/assets/086277a1-70e5-486f-bd3a-d6f521120703)
![Switching to valid request](https://github.com/user-attachments/assets/d1585375-42ef-41c5-b9a1-294f28632c06)
![Sending GET request on valid request](https://github.com/user-attachments/assets/9ee53d72-9d0b-4be3-86b6-769da608e538)

## Checklist

- [X] Issue has been linked to this PR
- [X] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [X] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
