### PR TITLE
fix(390): Persist MIME Type Selection of Request Body

### DIFF
--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTab.tsx
@@ -1,8 +1,13 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { SimpleSelect } from '@/components/mainWindow/bodyTabs/InputTabs/SimpleSelect';
 import { RequestBodyType } from 'shim/objects/request';
 import { Divider } from '@/components/shared/Divider';
-import { isFormattableLanguage, Language } from '@/lib/monaco/language';
+import {
+  isFormattableLanguage,
+  Language,
+  languageToMimeType,
+  mimeTypeToLanguage,
+} from '@/lib/monaco/language';
 import { selectRequest, useCollectionActions, useCollectionStore } from '@/state/collectionStore';
 import BodyTabFileInput from './BodyTabFileInput';
 import BodyTabTextInput from './BodyTabTextInput';
@@ -11,10 +16,12 @@ import { WandSparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export const BodyTab = () => {
-  const { setRequestBody, formatRequestEditorText } = useCollectionActions();
+  const { setRequestBody, setRequestBodyMimeType, formatRequestEditorText } =
+    useCollectionActions();
 
   const requestBody = useCollectionStore((state) => selectRequest(state).body);
-  const [language, setLanguage] = useState(Language.JSON);
+  const language = mimeTypeToLanguage(requestBody.mimeType);
+  const canFormatRequestBody = isFormattableLanguage(language);
 
   const changeBodyType = useCallback(
     (type: RequestBodyType) => {
@@ -29,8 +36,6 @@ export const BodyTab = () => {
     },
     [setRequestBody]
   );
-
-  const canFormatRequestBody = isFormattableLanguage(language);
 
   return (
     <div className="flex h-full flex-col gap-4">
@@ -48,7 +53,7 @@ export const BodyTab = () => {
             {requestBody.type === RequestBodyType.TEXT && (
               <SimpleSelect<Language>
                 value={language}
-                onValueChange={setLanguage}
+                onValueChange={(language) => setRequestBodyMimeType(languageToMimeType(language))}
                 items={[
                   [Language.JSON, 'JSON'],
                   [Language.XML, 'XML'],

--- a/src/renderer/lib/monaco/language.ts
+++ b/src/renderer/lib/monaco/language.ts
@@ -10,6 +10,36 @@ export enum Language {
   TEXT = 'plaintext',
 }
 
+const LANGUAGE_TO_MIME_TYPE_MAP: Record<Language, string> = {
+  [Language.JSON]: 'application/json',
+  [Language.XML]: 'application/xml',
+  [Language.TEXT]: 'text/plain',
+};
+
+const MIME_TYPE_TO_LANGUAGE_MAP: Record<string, Language> = Object.fromEntries(
+  Object.entries(LANGUAGE_TO_MIME_TYPE_MAP).map(([lang, mimeType]) => [mimeType, lang as Language])
+);
+
+/**
+ * Converts a language enum value to its corresponding MIME type.
+ *
+ * @param language The language enum value to convert.
+ * @return The corresponding MIME type as a string.
+ */
+export function languageToMimeType(language: Language): string {
+  return LANGUAGE_TO_MIME_TYPE_MAP[language];
+}
+
+/**
+ * Converts a MIME type string to its corresponding language enum value.
+ *
+ * @param mimeType The MIME type string to convert.
+ * @return The corresponding language enum value, or undefined if not found.
+ */
+export function mimeTypeToLanguage(mimeType: string): Language {
+  return MIME_TYPE_TO_LANGUAGE_MAP[mimeType];
+}
+
 const supportedLanguages = [Language.JSON, Language.XML, Language.TEXT];
 const formattableLanguages = new Set([Language.JSON, Language.XML]);
 

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -128,6 +128,12 @@ export const useCollectionStore = create<CollectionState & CollectionStateAction
       updateRequest({ body });
     },
 
+    setRequestBodyMimeType(mimeType?: string) {
+      const { body } = selectRequest(get());
+      const { setRequestBody } = get();
+      setRequestBody({ ...body, mimeType });
+    },
+
     setRequestEditor: async (requestEditor) => {
       const request = selectRequest(get());
       if (request != null) {
@@ -291,6 +297,7 @@ export const useCollectionStore = create<CollectionState & CollectionStateAction
         }
       });
     },
+
     renameFolder(id: Folder['id'], title: string) {
       set((state) => {
         const folder = selectFolder(state, id);

--- a/src/renderer/state/interface/CollectionStateActions.ts
+++ b/src/renderer/state/interface/CollectionStateActions.ts
@@ -37,6 +37,12 @@ export interface CollectionStateActions {
   setRequestBody(payload: RequestBody): void;
 
   /**
+   * Set the mime type of the text-based request body.
+   * @param mimeType The mime type to set, e.g. "application/json" or "text/plain"
+   */
+  setRequestBodyMimeType(mimeType?: string): void;
+
+  /**
    * Set the editor instance for text-based request bodies
    * @param requestEditor The editor instance
    */


### PR DESCRIPTION
## Changes
- Add conversion methods for language <--> mime type
- Language selection directly modifies request instead of the temporary react state

## Testing

https://github.com/user-attachments/assets/af41329f-ad87-4f7c-9ce7-e5715aa5cf26

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
