### PR TITLE
feat(402): Add checkbox to mark and store variables as secrets

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@electron-forge/publisher-github": "^7.8.1",
     "@electron-forge/shared-types": "^7.8.0",
     "@monaco-editor/react": "^4.6.0",
+    "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/src/renderer/components/shared/settings/SettingsModal.tsx
+++ b/src/renderer/components/shared/settings/SettingsModal.tsx
@@ -41,7 +41,7 @@ export const SettingsModal = () => {
       <DialogTrigger onClick={() => setOpen(true)}>
         <FiSettings className="ml-2 text-xl" />
       </DialogTrigger>
-      <DialogContent style={{ minWidth: '100vh' }}>
+      <DialogContent className="max-w-4xl px-4 lg:max-w-5xl">
         <DialogHeader className="mt-auto">
           <DialogTitle>Settings</DialogTitle>
         </DialogHeader>
@@ -57,16 +57,16 @@ export const SettingsModal = () => {
             />
           </TabsContent>
         </Tabs>
-        <DialogFooter className="bottom-0">
+        <DialogFooter>
           <Button
-            className="mb-0 mr-2 mt-0"
+            className="mr-2"
             onClick={save}
             disabled={!isValid}
             variant={isValid ? 'default' : 'defaultDisable'}
           >
             <span className="font-bold leading-4">Save</span>
           </Button>
-          <Button className="mb-0 mr-2 mt-0" onClick={cancel} variant="destructive">
+          <Button className="mr-2" onClick={cancel} variant="destructive">
             <span className="font-bold leading-4">Cancel</span>
           </Button>
         </DialogFooter>

--- a/src/renderer/components/shared/settings/VariableTab/VariableEditor.tsx
+++ b/src/renderer/components/shared/settings/VariableTab/VariableEditor.tsx
@@ -1,6 +1,6 @@
 import { Divider } from '@/components/shared/Divider';
 import { Button } from '@/components/ui/button';
-import { AddIcon, DeleteIcon } from '@/components/icons';
+import { AddIcon } from '@/components/icons';
 import {
   Table,
   TableBody,
@@ -12,6 +12,8 @@ import {
 import { VARIABLE_NAME_REGEX, VariableMap, VariableObject } from 'shim/objects/variables';
 import { memo, useEffect } from 'react';
 import { produce } from 'immer';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Trash2 } from 'lucide-react';
 
 export interface VariableEditorProps {
   variables: VariableObjectWithKey[];
@@ -85,78 +87,78 @@ export const VariableEditor = memo<VariableEditorProps>(
     };
 
     return (
-      <div className="relative p-4">
-        <div className="absolute left-4 right-4 top-4 z-10">
-          <div className="flex">
-            <Button
-              className="h-fit gap-1 hover:bg-transparent"
-              size="sm"
-              variant="ghost"
-              onClick={add}
-            >
-              <AddIcon /> Add Variable
-            </Button>
-          </div>
-          <Divider className="mt-2" />
-        </div>
+      <div className="p-4">
+        <Button
+          className="h-fit gap-1 hover:bg-transparent"
+          size="sm"
+          variant="ghost"
+          onClick={add}
+        >
+          <AddIcon /> Add Variable
+        </Button>
 
-        <div className="absolute bottom-4 left-4 right-4 top-16">
-          <Table className="w-full table-auto">
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-auto">Key</TableHead>
-                <TableHead className="w-auto">Value</TableHead>
-                <TableHead className="w-full">Description</TableHead>
-                <TableHead className="w-16">{/* Action Column */}</TableHead>
+        <Divider className="mb-4" />
+
+        <Table className="w-full table-auto">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-1/5">Key</TableHead>
+              <TableHead className="w-1/4">Value</TableHead>
+              <TableHead className="w-auto">Description</TableHead>
+              <TableHead className="w-20">Secret</TableHead>
+              <TableHead className="w-16">{/* Action Column */}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {variables.map((variable, index) => (
+              <TableRow key={index}>
+                <TableCell className="break-all">
+                  <input
+                    type="text"
+                    value={variable.key}
+                    className={`w-full bg-transparent outline-none ${invalidVariableKeys.has(variable.key) ? 'text-danger' : ''}`}
+                    placeholder="Enter variable key"
+                    onChange={(e) => update(index, { key: e.target.value })}
+                  />
+                </TableCell>
+                <TableCell className="break-all">
+                  <input
+                    type="text"
+                    value={variable.value}
+                    className="w-full bg-transparent outline-none"
+                    placeholder="Enter variable value"
+                    onChange={(e) => update(index, { value: e.target.value })}
+                  />
+                </TableCell>
+                <TableCell className="break-all">
+                  <input
+                    type="text"
+                    value={variable.description}
+                    className="w-full bg-transparent outline-none"
+                    placeholder="Enter variable description"
+                    onChange={(e) => update(index, { description: e.target.value })}
+                  />
+                </TableCell>
+                <TableCell className="text-center">
+                  <Checkbox
+                    checked={variable.secret}
+                    onCheckedChange={(checked) => update(index, { secret: Boolean(checked) })}
+                  />
+                </TableCell>
+                <TableCell className="py-2 text-center">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="w-5 hover:bg-transparent hover:text-[rgba(107,194,224,1)] active:text-[#12B1E7]"
+                    onClick={() => remove(index)}
+                  >
+                    <Trash2 />
+                  </Button>
+                </TableCell>
               </TableRow>
-            </TableHeader>
-            <TableBody>
-              {variables.map((variable, index) => (
-                <TableRow key={index}>
-                  <TableCell className="w-1/4 break-all">
-                    <input
-                      type="text"
-                      value={variable.key}
-                      className={`w-full bg-transparent outline-none ${invalidVariableKeys.has(variable.key) ? 'text-danger' : ''}`}
-                      placeholder="Enter variable key"
-                      onChange={(e) => update(index, { key: e.target.value })}
-                    />
-                  </TableCell>
-                  <TableCell className="w-1/4 break-all">
-                    <input
-                      type="text"
-                      value={variable.value}
-                      className="w-full bg-transparent outline-none"
-                      placeholder="Enter variable value"
-                      onChange={(e) => update(index, { value: e.target.value })}
-                    />
-                  </TableCell>
-                  <TableCell className="w-full break-all">
-                    <input
-                      type="text"
-                      value={variable.description}
-                      className="w-full bg-transparent outline-none"
-                      placeholder="Enter variable description"
-                      onChange={(e) => update(index, { description: e.target.value })}
-                    />
-                  </TableCell>
-                  <TableCell className="w-16 text-right">
-                    <div className="flex items-center justify-center gap-2">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-6 w-6 hover:bg-transparent hover:text-[rgba(107,194,224,1)] active:text-[#12B1E7]"
-                        onClick={() => remove(index)}
-                      >
-                        <DeleteIcon />
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+            ))}
+          </TableBody>
+        </Table>
       </div>
     );
   }

--- a/src/renderer/components/ui/checkbox.tsx
+++ b/src/renderer/components/ui/checkbox.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
+import { Check } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      'peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className={cn('flex items-center justify-center text-current')}>
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/src/renderer/components/ui/table.tsx
+++ b/src/renderer/components/ui/table.tsx
@@ -75,7 +75,7 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      'overflow-wrap break-word break-all border-border p-4 align-middle [&:has([role=checkbox])]:pr-0 [&:not(:last-child)]:border-r',
+      'overflow-wrap break-word break-all border-border p-4 align-middle [&:not(:last-child)]:border-r',
       className
     )}
     {...props}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,6 +1281,20 @@
   dependencies:
     "@radix-ui/react-primitive" "2.1.3"
 
+"@radix-ui/react-checkbox@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-1.3.2.tgz#28097244d968aa8f93249b0d3df02a172fd4bee5"
+  integrity sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.2"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-presence" "1.1.4"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-use-previous" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+
 "@radix-ui/react-collapsible@^1.1.11":
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-collapsible/-/react-collapsible-1.1.11.tgz#a2d132d5baa6f14551f15b1fff29f925cae46b83"


### PR DESCRIPTION
## Changes

- Closes #402
- Increased the width of the Settings Dialog
- Added the Shadcn Checkbox component and added it to the Variables Table
  - The Shadcn Checkbox will also be advantageous for future theming support
- Removed the absolute styling in `VariableEditor.tsx`
- Exchanged the SVG Trash Icon with a Lucide Icon since the SVG icon was rendered very small in the button and simple resizing was not working

## Testing

Tested manually:

https://github.com/user-attachments/assets/4198647c-6366-478c-8349-9a9262ab197f


## Checklist

- [X] Issue has been linked to this PR
- [X] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [X] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
