### PR TITLE
fix(407): Show collection variables correctly after restarting the app

### DIFF
--- a/src/renderer/components/shared/settings/SettingsModal.tsx
+++ b/src/renderer/components/shared/settings/SettingsModal.tsx
@@ -14,8 +14,7 @@ import {
 } from '@/components/shared/settings/VariableTab/VariableEditor';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
-import * as React from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { selectVariables, useVariableActions, useVariableStore } from '@/state/variableStore';
 
 export const SettingsModal = () => {
@@ -24,6 +23,10 @@ export const SettingsModal = () => {
   const [editorVariables, setEditorVariables] = useState(variableMapToArray(variables));
   const [isValid, setValid] = useState(false);
   const [isOpen, setOpen] = useState(false);
+
+  useEffect(() => {
+    setEditorVariables(variableMapToArray(variables));
+  }, [variables]);
 
   const save = async () => {
     console.info('Saving variables:', editorVariables);

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -73,11 +73,11 @@ export const useCollectionStore = create<CollectionState & CollectionStateAction
         state.collection = collection;
         state.requests = requests;
         state.folders = folders;
+        initializeVariables(collection.variables);
 
         if (state.collection.id !== collection.id) {
           state.selectedRequestId = undefined;
           state.openFolders = new Set();
-          initializeVariables(collection.variables);
         }
         console.info('Initialized collection:', collection);
       });


### PR DESCRIPTION
## Changes

- Closes #407 
- Collection variables are now shown correctly after (re-)starting the app.
- Also fixed a bug where, when switching collections, the variables from the previously opened collection were still shown and only updated on the second render of the settings menu. This was resolved by using `useEffect` to update the `editorVariables` state whenever the variables change.

## Testing

I tested the changes manually. Video:

https://github.com/user-attachments/assets/e7221b51-f2d8-4701-8979-c1779bba6a5b

## Checklist

- [X] Issue has been linked to this PR
- [X] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [X] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
