### PR TITLE
Add loading indicator to SendButton

### DIFF
--- a/src/renderer/components/mainWindow/MainTopBar.tsx
+++ b/src/renderer/components/mainWindow/MainTopBar.tsx
@@ -10,12 +10,14 @@ import { cn } from '@/lib/utils';
 import { RendererEventService } from '@/services/event/renderer-event-service';
 import { selectRequest, useCollectionActions, useCollectionStore } from '@/state/collectionStore';
 import { useResponseActions } from '@/state/responseStore';
+import { ArrowRight, Loader2 } from 'lucide-react';
 
 const httpService = HttpService.instance;
 const eventService = RendererEventService.instance;
 
 export function MainTopBar() {
   const [hasError, setHasError] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const { updateRequest } = useCollectionActions();
   const { addResponse } = useResponseActions();
@@ -41,10 +43,15 @@ export function MainTopBar() {
         throw new Error('Missing URL or HTTP method');
       }
 
-      await eventService.saveRequest(request, requestEditor?.getValue());
+      try {
+        setIsLoading(true);
+        await eventService.saveRequest(request, requestEditor?.getValue());
 
-      const response = await httpService.sendRequest(request);
-      addResponse(request.id, response);
+        const response = await httpService.sendRequest(request);
+        addResponse(request.id, response);
+      } finally {
+        setIsLoading(false);
+      }
     }),
     [request, requestEditor, addResponse]
   );
@@ -101,7 +108,9 @@ export function MainTopBar() {
         <SaveButton isDisabled={!request?.draft} onClick={saveRequest} />
       </div>
 
-      <SendButton onClick={sendRequest} />
+      <SendButton onClick={sendRequest} disabled={isLoading}>
+        {isLoading ? <Loader2 className="h-5 w-5 animate-spin" /> : <ArrowRight />}
+      </SendButton>
     </div>
   );
 }

--- a/src/renderer/components/mainWindow/mainTopBar/SendButton.tsx
+++ b/src/renderer/components/mainWindow/mainTopBar/SendButton.tsx
@@ -4,12 +4,14 @@ import { ArrowForwardIcon } from '@/components/icons';
 
 interface SendButtonProps {
   onClick: () => void;
+  disabled?: boolean;
+  children?: React.ReactNode;
 }
 
-export const SendButton: React.FC<SendButtonProps> = ({ onClick }) => (
-  <Button className="gap-3 pl-[30px]" onClick={onClick} variant="secondary">
+export const SendButton: React.FC<SendButtonProps> = ({ onClick, disabled = false, children }) => (
+  <Button className="gap-3 pl-[30px]" onClick={onClick} variant="secondary" disabled={disabled}>
     <span className="font-bold leading-4">Send</span>
 
-    <ArrowForwardIcon />
+    {children ?? <ArrowForwardIcon />}
   </Button>
 );


### PR DESCRIPTION
## Changes
Added isLoading state in MainTopBar to track request progress.

Updated sendRequest to set isLoading true before sending and false after completion.

Modified SendButton to accept disabled and children props for flexibility.

Show spinner and disable Send button while request is in progress.

Restored arrow icon and re-enabled button after request finishes.
Describe the changes of your PR here

## Testing
Manually tested clicking Send button: spinner appears, button disables, then resets after response.

Verified error cases reset loading state correctly.

Checked UI remains consistent with no side effects.

![grafik](https://github.com/user-attachments/assets/c63945fa-24d7-4355-8f7c-a5da6f3a52e1)

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
