### PR TITLE
#449 - Add visibility toggle to password field

### DIFF
--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationForm.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationForm.tsx
@@ -66,6 +66,10 @@ export const AuthorizationForm: React.FC<AuthorizationFormProps> = ({
   auth,
   onAuthorizationChanged,
 }) => {
+  const [visibility, setVisibility] = React.useState<{ [key: string]: boolean }>({});
+  const toggleVisibility = (key: string) => {
+    setVisibility((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
   const renderField = (key: string, fieldConfig: FormFieldConfig) => {
     switch (fieldConfig.type) {
       case 'label':
@@ -76,7 +80,6 @@ export const AuthorizationForm: React.FC<AuthorizationFormProps> = ({
         );
 
       case 'text':
-      case 'password':
       case 'email': {
         const { label, placeholder } = fieldConfig;
         return (
@@ -89,6 +92,31 @@ export const AuthorizationForm: React.FC<AuthorizationFormProps> = ({
               placeholder={placeholder}
               className="w-full rounded-md border border-border bg-background-primary px-3 py-2 text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
             />
+          </div>
+        );
+      }
+
+      case 'password': {
+        const { label, placeholder } = fieldConfig;
+        return (
+          <div key={key} className="space-y-2">
+            <label className="text-sm font-medium text-text-primary">{label}</label>
+            <div className="relative w-full">
+              <Input
+                type={visibility[key] ? 'text' : 'password'}
+                value={auth[key as keyof AuthorizationInformation]}
+                onChange={(e) => onAuthorizationChanged({ [key]: e.target.value })}
+                placeholder={placeholder}
+                className="w-full rounded-md border border-border bg-background-primary px-3 py-2 text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
+              />
+              <button
+                type="button"
+                onClick={() => toggleVisibility(key)}
+                className="absolute inset-y-0 right-0 flex items-center px-3 text-sm text-text-secondary hover:text-text-primary"
+              >
+                {visibility[key] ? 'Hide' : 'Show'}
+              </button>
+            </div>
           </div>
         );
       }


### PR DESCRIPTION
Adds a 'Show/Hide' button to the password input on the Basic Auth form. This allows users to view the entered password to prevent typos and improve usability.

Fixes https://github.com/EXXETA/trufos/issues/449

## Changes
This PR introduces the functionality to toggle the visibility of password fields in the Basic Auth form.

Key changes include:

- Added a visibility state object using React.useState to track the visibility status of each input field.
- Implemented a toggleVisibility helper function to update the state for a specific field.
- Created a new, dedicated case for type: 'password' within the renderField function.
- The new password field includes a "Show/Hide" button positioned within the input, which toggles the input type between password and text.

## Testing
Manual testing:

1. Go to the "Auth" tab.
2. Select "Basic Auth" as the authorization type.
3. Click the "Show" button in the password field.
4. Verify that the password is displayed as plain text.
5. Click "Hide" again.
6. Verify that the password is hidden again.

- Default State: The password field is initially empty.
<img width="1033" height="827" alt="image" src="https://github.com/user-attachments/assets/20ad3e41-055e-4bb8-82bf-92f591a92310" />

- Password Entered: When a user types, the input is masked as a standard password field. The "Show" button is visible.
<img width="1028" height="826" alt="image" src="https://github.com/user-attachments/assets/a1087fda-63bd-4a3f-8a2c-a89795b435e0" />

- Password Revealed: After clicking "Show", the password becomes visible, and the button text changes to "Hide".
<img width="1028" height="831" alt="image" src="https://github.com/user-attachments/assets/99b5809e-d9a9-43b2-9454-898f866e7587" />

Clicking the "Hide" button will toggle the visibility off again, returning it to the hidden state shown in the second image.
## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
