### PR TITLE
Feature/465 collection modal visual differences to penpot design

### DIFF
--- a/src/renderer/components/shared/settings/SettingsModal.tsx
+++ b/src/renderer/components/shared/settings/SettingsModal.tsx
@@ -44,15 +44,23 @@ export const SettingsModal = () => {
       <DialogTrigger onClick={() => setOpen(true)}>
         <FiSettings className="ml-2 text-xl" />
       </DialogTrigger>
-      <DialogContent className="max-w-4xl px-4 lg:max-w-5xl">
-        <DialogHeader className="mt-auto">
-          <DialogTitle>Settings</DialogTitle>
-        </DialogHeader>
+
+      <DialogContent className={'max-w-4xl p-4 lg:max-w-5xl'}>
         <Tabs defaultValue="variables" className="h-[calc(50vh)]">
-          <TabsList>
-            <TabsTrigger value="variables">Variables</TabsTrigger>
-          </TabsList>
-          <TabsContent value="variables" className="max-h-[50vh] overflow-y-auto">
+          <div className="-mx-4 -mt-4 flex flex-col gap-4 overflow-hidden rounded-t-lg bg-card px-4 pt-4">
+            <DialogHeader className="mt-auto">
+              <DialogTitle className={'font-bold'}>Collection Settings</DialogTitle>
+            </DialogHeader>
+
+            <TabsList className={'mb-4 bg-card'}>
+              <TabsTrigger value="variables">Variables</TabsTrigger>
+            </TabsList>
+          </div>
+
+          <TabsContent
+            value="variables"
+            className="mt-4 max-h-[50vh] overflow-y-auto !rounded-none !bg-transparent"
+          >
             <VariableEditor
               variables={editorVariables}
               onValidChange={setValid}
@@ -60,6 +68,7 @@ export const SettingsModal = () => {
             />
           </TabsContent>
         </Tabs>
+
         <DialogFooter>
           <Button
             className="mr-2"
@@ -68,9 +77,6 @@ export const SettingsModal = () => {
             variant={isValid ? 'default' : 'defaultDisable'}
           >
             <span className="font-bold leading-4">Save</span>
-          </Button>
-          <Button className="mr-2" onClick={cancel} variant="destructive">
-            <span className="font-bold leading-4">Cancel</span>
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/renderer/components/shared/settings/SettingsModal.tsx
+++ b/src/renderer/components/shared/settings/SettingsModal.tsx
@@ -53,7 +53,9 @@ export const SettingsModal = () => {
             </DialogHeader>
 
             <TabsList className={'mb-4 bg-card'}>
-              <TabsTrigger value="variables">Variables</TabsTrigger>
+              <TabsTrigger value="variables" className={'!font-light'}>
+                Variables
+              </TabsTrigger>
             </TabsList>
           </div>
 

--- a/src/renderer/components/shared/settings/VariableTab/VariableEditor.tsx
+++ b/src/renderer/components/shared/settings/VariableTab/VariableEditor.tsx
@@ -87,9 +87,9 @@ export const VariableEditor = memo<VariableEditorProps>(
     };
 
     return (
-      <div className="p-4">
+      <>
         <Button
-          className="h-fit gap-1 hover:bg-transparent"
+          className="h-fit gap-1 pl-0 hover:bg-transparent"
           size="sm"
           variant="ghost"
           onClick={add}
@@ -159,7 +159,7 @@ export const VariableEditor = memo<VariableEditorProps>(
             ))}
           </TableBody>
         </Table>
-      </div>
+      </>
     );
   }
 );

--- a/src/renderer/components/ui/dialog.tsx
+++ b/src/renderer/components/ui/dialog.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { X } from 'lucide-react';
+import { CloseIcon } from '@/components/icons';
 
 import { cn } from '@/lib/utils';
 
@@ -43,7 +43,7 @@ const DialogContent = React.forwardRef<
       >
         {children}
         <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-          <X className="h-4 w-4" />
+          <CloseIcon size={24} />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>
       </DialogPrimitive.Content>


### PR DESCRIPTION
## Changes

Modal updated according to the required design.

- got rid of 'cancel' button
- replaced 'Close' button with one from our icon collection
- got rid of background in Tabs 
- set correct background in the top of the modal
- updated spacings (paddings etc.)

## Testing

<img width="2672" height="1527" alt="image" src="https://github.com/user-attachments/assets/d1f392b7-90bb-481e-a16f-e82a67cdefb1" />

## Checklist

- [x] Issue has been linked to this PR
- [ ] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
