### PR TITLE
feat(460): Support Auth Code Flow

### DIFF
--- a/src/main/logging/logger.test.ts
+++ b/src/main/logging/logger.test.ts
@@ -134,7 +134,7 @@ describe('Logger', () => {
     // Arrange
     const now = new Date();
     const message = 'Error was thrown:';
-    const error = new Error('test error');
+    const error = new Error('test\nerror');
     const expected = `${now.toISOString()} [MAIN] [ERROR]: ${message} ${error.stack}${EOL}`;
 
     const data: unknown[] = [];
@@ -157,5 +157,20 @@ describe('Logger', () => {
       vi.useRealTimers();
       logger.remove(transport);
     }
+  });
+
+  it('should filter secret logs from file transport but allow in memory transport', () => {
+    // Arrange
+    const secretMessage = 'Secret data';
+    const secretData = { token: 'abc123', apiKey: 'secret-key' };
+
+    // Act
+    logger.secret.info(secretMessage, secretData);
+
+    // Assert
+    expect(memoryTransport.logs).toHaveLength(1);
+    const logEntry = memoryTransport.logs[0] as LogEntry;
+    expect(logEntry.message).toBe(`${secretMessage} { token: 'abc123', apiKey: 'secret-key' }`);
+    expect(logEntry.isSecret).toBe(true);
   });
 });

--- a/src/main/logging/logger.ts
+++ b/src/main/logging/logger.ts
@@ -25,7 +25,6 @@ declare global {
 
 class SplatFormat implements Format {
   transform(info: TransformableInfoExtended) {
-    console.log(info);
     if (info instanceof Error) {
       info.message = info.stack ?? info.message;
       return info;

--- a/src/main/logging/logger.ts
+++ b/src/main/logging/logger.ts
@@ -5,16 +5,27 @@ import { LogEntry } from 'shim/logger';
 import { format as formatString } from 'node:util';
 
 const SPLAT = Symbol.for('splat');
+const LOG_SECRET = Symbol('logSecret');
 
 console.info('Saving logs at', app.getPath('logs'));
 
+type TransformableInfoExtended = TransformableInfo & LogEntry;
+
 declare global {
   // eslint-disable-next-line no-var
-  var logger: winston.Logger;
+  var logger: winston.Logger & {
+    secret: {
+      info: (message: string, ...meta: unknown[]) => void;
+      debug: (message: string, ...meta: unknown[]) => void;
+      warn: (message: string, ...meta: unknown[]) => void;
+      error: (message: string, ...meta: unknown[]) => void;
+    };
+  };
 }
 
 class SplatFormat implements Format {
-  transform(info: TransformableInfo) {
+  transform(info: TransformableInfoExtended) {
+    console.log(info);
     if (info instanceof Error) {
       info.message = info.stack ?? info.message;
       return info;
@@ -22,19 +33,33 @@ class SplatFormat implements Format {
 
     let args = info[SPLAT] as unknown[];
     if (!Array.isArray(args)) args = [];
-    if (args.length === 0 && info.message instanceof Error) {
-      info.message = info.message.stack ?? info.message.message;
-    } else if (args.length !== 0 && args[args.length - 1] instanceof Error) {
-      const error = args.pop() as Error;
-      if (typeof info.message === 'string' && info.message.length !== 0) {
-        info.message = info.message.slice(0, -error.message.length - 1);
-      }
-      args.push(error.stack);
+
+    // check if this is a secret log
+    if (args.length > 0 && args[0] === LOG_SECRET) {
+      info.isSecret = true;
+      args = args.slice(1);
     }
 
-    // format rest of the arguments
+    // ensure the message is a string
+    if (typeof info.message !== 'string') {
+      args.unshift(info.message);
+      info.message = '';
+    }
+
+    // handle broken error object formatting
+    if (args.length > 0 && args[0] instanceof Error) {
+      info.message = info.message.slice(0, -args[0].message.length - 1);
+    }
+
+    // format any other arguments
     info.message = formatString(info.message, ...args);
     return info;
+  }
+}
+
+class SecretFilter implements Format {
+  transform(info: TransformableInfoExtended) {
+    return info.isSecret === true ? false : info;
   }
 }
 
@@ -43,13 +68,15 @@ function print({
   level,
   process,
   message,
-}: TransformableInfo & LogEntry & { timestamp: string }) {
+}: TransformableInfoExtended & { timestamp: string }) {
   return `${timestamp} [${process.toUpperCase()}] [${level.toUpperCase()}]: ${message}`;
 }
 
+const BASE_FORMAT = format.combine(new SplatFormat(), format.timestamp(), format.printf(print));
+
 global.logger = winston.createLogger({
   level: 'warn',
-  format: format.combine(new SplatFormat(), format.timestamp(), format.printf(print)),
+  format: BASE_FORMAT,
   defaultMeta: { process: 'main' },
   transports: [
     new winston.transports.File({
@@ -58,9 +85,18 @@ global.logger = winston.createLogger({
       maxFiles: 10,
       maxsize: 1024 * 1024 * 10, // 10MiB
       tailable: true,
+      format: format.combine(new SecretFilter(), BASE_FORMAT),
     }),
   ],
-});
+}) as any;
+
+// Add secret logging methods that automatically mark logs as secret
+logger.secret = {
+  info: (message: string, ...meta: unknown[]) => logger.info(message, LOG_SECRET, ...meta),
+  debug: (message: string, ...meta: unknown[]) => logger.debug(message, LOG_SECRET, ...meta),
+  warn: (message: string, ...meta: unknown[]) => logger.warn(message, LOG_SECRET, ...meta),
+  error: (message: string, ...meta: unknown[]) => logger.error(message, LOG_SECRET, ...meta),
+};
 
 if (!app.isPackaged) {
   logger.add(new transports.Console({ level: 'info' }));

--- a/src/main/network/authentication/oauth2/auth-code-flow.ts
+++ b/src/main/network/authentication/oauth2/auth-code-flow.ts
@@ -9,10 +9,7 @@ export default class AuthCodeFlowAuthorizationStrategy extends OAuth2AuthStrateg
     let redirectUrl: URL | undefined;
 
     // Create the browser window.
-    const window = new BrowserWindow({
-      frame: false,
-      titleBarStyle: 'hidden',
-    });
+    const window = new BrowserWindow({ titleBarStyle: 'hidden' });
 
     // intercept the callback URL to get the auth code
     window.webContents.session.webRequest.onBeforeRequest(

--- a/src/main/network/authentication/oauth2/auth-code-flow.ts
+++ b/src/main/network/authentication/oauth2/auth-code-flow.ts
@@ -60,11 +60,11 @@ export default class AuthCodeFlowAuthorizationStrategy<
 
     // prepare the authorization URL and state
     parameters.redirect_uri = this.authInfo.callbackUrl;
-    parameters.state = this.authInfo.state ?? randomState();
+    parameters.state = this.authInfo.state?.trim() || randomState();
 
     // if PKCE is used, generate code verifier and challenge
     if (isPKCEConfig(this.authInfo)) {
-      this.authInfo.codeVerifier ??= randomPKCECodeVerifier();
+      this.authInfo.codeVerifier = this.authInfo.codeVerifier?.trim() || randomPKCECodeVerifier();
       parameters.code_challenge = await calculatePKCECodeChallenge(this.authInfo.codeVerifier);
       parameters.code_challenge_method = this.authInfo.codeChallengeMethod;
     }

--- a/src/main/network/authentication/oauth2/auth-code-flow.ts
+++ b/src/main/network/authentication/oauth2/auth-code-flow.ts
@@ -1,0 +1,34 @@
+import { OAuth2ClientAuthorizationCodeFlowInformation } from 'shim/objects/auth/oauth2';
+import OAuth2AuthStrategy from './strategy';
+import { authorizationCodeGrant, buildAuthorizationUrl, randomState } from 'openid-client';
+import { BrowserWindow } from 'electron';
+import { once } from 'node:events';
+
+export default class AuthCodeFlowAuthorizationStrategy extends OAuth2AuthStrategy<OAuth2ClientAuthorizationCodeFlowInformation> {
+  private async getAuthorizationCode(url: URL) {
+    // Create the browser window.
+    const window = new BrowserWindow({
+      frame: false,
+      titleBarStyle: 'hidden',
+    });
+
+    window.loadURL(url.toString());
+    await once(window, 'close');
+  }
+
+  protected async getTokens() {
+    const configuration = this.getConfiguration();
+    const parameters = this.getParameters();
+    parameters.redirect_uri = this.authInfo.redirectUri;
+    parameters.state = this.authInfo.state ?? randomState();
+
+    const redirectUrl = buildAuthorizationUrl(configuration, parameters);
+    logger.info(`Redirecting to authorization URL: ${redirectUrl}`);
+
+    await this.getAuthorizationCode(redirectUrl);
+
+    this.authInfo.tokens = await authorizationCodeGrant(configuration, redirectUrl, {
+      expectedState: parameters.state,
+    });
+  }
+}

--- a/src/main/network/authentication/oauth2/auth-code-flow.ts
+++ b/src/main/network/authentication/oauth2/auth-code-flow.ts
@@ -32,7 +32,7 @@ export default class AuthCodeFlowAuthorizationStrategy<
     let redirectUrl: URL | undefined;
 
     // create the browser window.
-    const window = new BrowserWindow({ titleBarStyle: 'hidden' });
+    const window = new BrowserWindow({ title: 'OAuth2 Auth Code Flow' });
     const { session } = window.webContents;
     if (this.authInfo.cache !== true) {
       session.clearStorageData();

--- a/src/main/network/authentication/oauth2/auth-code-flow.ts
+++ b/src/main/network/authentication/oauth2/auth-code-flow.ts
@@ -5,29 +5,50 @@ import { BrowserWindow } from 'electron';
 import { once } from 'node:events';
 
 export default class AuthCodeFlowAuthorizationStrategy extends OAuth2AuthStrategy<OAuth2ClientAuthorizationCodeFlowInformation> {
-  private async getAuthorizationCode(url: URL) {
+  private async getAuthorizationCode(url: URL, callbackUrl: string) {
+    let redirectUrl: URL | undefined;
+
     // Create the browser window.
     const window = new BrowserWindow({
       frame: false,
       titleBarStyle: 'hidden',
     });
 
+    // intercept the callback URL to get the auth code
+    window.webContents.session.webRequest.onBeforeRequest(
+      { urls: [callbackUrl + '*'] },
+      (details, callback) => {
+        if (details.method.toUpperCase() === 'GET') {
+          logger.info('Completed auth code login');
+          callback({ cancel: true });
+          redirectUrl = URL.parse(details.url);
+          window.close();
+        }
+      }
+    );
+
+    logger.info(`Opening window with authorization URL: ${url}`);
     window.loadURL(url.toString());
     await once(window, 'close');
+    return redirectUrl;
   }
 
   protected async getTokens() {
+    // prepare the authorization URL and state
     const configuration = this.getConfiguration();
     const parameters = this.getParameters();
     parameters.redirect_uri = this.authInfo.redirectUri;
     parameters.state = this.authInfo.state ?? randomState();
+    const url = buildAuthorizationUrl(configuration, parameters);
 
-    const redirectUrl = buildAuthorizationUrl(configuration, parameters);
-    logger.info(`Redirecting to authorization URL: ${redirectUrl}`);
+    // open browser window to get the authorization code
+    const authCode = await this.getAuthorizationCode(url, parameters.redirect_uri);
+    if (!authCode) {
+      throw new Error('Authorization code not received');
+    }
 
-    await this.getAuthorizationCode(redirectUrl);
-
-    this.authInfo.tokens = await authorizationCodeGrant(configuration, redirectUrl, {
+    // exchange the authorization code for tokens
+    this.authInfo.tokens = await authorizationCodeGrant(configuration, authCode, {
       expectedState: parameters.state,
     });
   }

--- a/src/main/network/authentication/oauth2/client-credentials.ts
+++ b/src/main/network/authentication/oauth2/client-credentials.ts
@@ -1,49 +1,12 @@
-import {
-  OAuth2ClientAuthenticationMethod,
-  OAuth2ClientCrentialsAuthorizationInformation,
-} from 'shim/objects/auth/oauth2';
+import { OAuth2ClientCrentialsAuthorizationInformation } from 'shim/objects/auth/oauth2';
 import OAuth2AuthStrategy from './strategy';
-import {
-  ClientAuth,
-  clientCredentialsGrant,
-  ClientSecretBasic,
-  ClientSecretPost,
-  Configuration,
-  customFetch,
-} from 'openid-client';
+import { clientCredentialsGrant } from 'openid-client';
 
 export default class ClientCredentialsAuthorizationStrategy extends OAuth2AuthStrategy<OAuth2ClientCrentialsAuthorizationInformation> {
   protected async getTokens() {
-    const parameters: Record<string, string> = {};
-    if (this.authInfo.scope != null && this.authInfo.scope !== '') {
-      parameters.scope = this.authInfo.scope;
-    }
-
-    // set client authentication method
-    let clientAuth: ClientAuth | undefined;
-    switch (this.authInfo.clientAuthenticationMethod) {
-      case OAuth2ClientAuthenticationMethod.BASIC_AUTH:
-        clientAuth = ClientSecretBasic(this.authInfo.clientSecret);
-        break;
-      case OAuth2ClientAuthenticationMethod.REQUEST_BODY:
-        clientAuth = ClientSecretPost(this.authInfo.clientSecret);
-        break;
-    }
-
-    // prepare confiugration
-    const config = new Configuration(
-      {
-        issuer: new URL(this.authInfo.tokenUrl).origin,
-        token_endpoint: this.authInfo.tokenUrl,
-        client_id: this.authInfo.clientId,
-      },
-      this.authInfo.clientId,
-      this.authInfo.clientSecret,
-      clientAuth
+    this.authInfo.tokens = await clientCredentialsGrant(
+      this.getConfiguration(),
+      this.getParameters()
     );
-
-    // execute the client credentials grant
-    config[customFetch] = this.fetch;
-    this.authInfo.tokens = await clientCredentialsGrant(config, parameters);
   }
 }

--- a/src/main/network/authentication/oauth2/strategy-factory.ts
+++ b/src/main/network/authentication/oauth2/strategy-factory.ts
@@ -1,11 +1,15 @@
 import { OAuth2AuthorizationInformation, OAuth2Method } from 'shim/objects/auth/oauth2';
 import ClientCredentialsAuthorizationStrategy from './client-credentials';
+import AuthCodeFlowAuthorizationStrategy from './auth-code-flow';
 
 export function createOAuth2Strategy(auth: OAuth2AuthorizationInformation) {
   switch (auth.method) {
     case OAuth2Method.CLIENT_CREDENTIALS:
       return new ClientCredentialsAuthorizationStrategy(auth);
+    case OAuth2Method.AUTHORIZATION_CODE:
+      return new AuthCodeFlowAuthorizationStrategy(auth);
     default:
+      // @ts-expect-error should never happen
       throw new Error(`Unsupported OAuth2 method: ${auth.method}`);
   }
 }

--- a/src/main/network/authentication/oauth2/strategy-factory.ts
+++ b/src/main/network/authentication/oauth2/strategy-factory.ts
@@ -8,6 +8,8 @@ export function createOAuth2Strategy(auth: OAuth2AuthorizationInformation) {
       return new ClientCredentialsAuthorizationStrategy(auth);
     case OAuth2Method.AUTHORIZATION_CODE:
       return new AuthCodeFlowAuthorizationStrategy(auth);
+    case OAuth2Method.AUTHORIZATION_CODE_PKCE:
+      return new AuthCodeFlowAuthorizationStrategy(auth);
     default:
       // @ts-expect-error should never happen
       throw new Error(`Unsupported OAuth2 method: ${auth.method}`);

--- a/src/main/network/authentication/oauth2/strategy.ts
+++ b/src/main/network/authentication/oauth2/strategy.ts
@@ -48,8 +48,8 @@ export default abstract class OAuth2AuthStrategy<
     const config = new Configuration(
       {
         issuer: this.authInfo.issuerUrl,
-        // @ts-expect-error may be undefined
-        authorization_endpoint: this.authInfo.authorizationUrl,
+        authorization_endpoint:
+          'authorizationUrl' in this.authInfo ? this.authInfo.authorizationUrl : undefined,
         token_endpoint: this.authInfo.tokenUrl,
         client_id: this.authInfo.clientId,
       },

--- a/src/main/network/authentication/oauth2/strategy.ts
+++ b/src/main/network/authentication/oauth2/strategy.ts
@@ -45,21 +45,24 @@ export default abstract class OAuth2AuthStrategy<
     }
 
     // prepare configuration
-    return new Configuration(
+    const config = new Configuration(
       {
-        // @ts-expect-error one of these is defined
-        issuer: new URL(this.authInfo.tokenUrl ?? this.authInfo.authorizationUrl).origin,
+        issuer: this.authInfo.issuerUrl,
         // @ts-expect-error may be undefined
         authorization_endpoint: this.authInfo.authorizationUrl,
-        // @ts-expect-error may be undefined
         token_endpoint: this.authInfo.tokenUrl,
         client_id: this.authInfo.clientId,
-        [customFetch]: this.fetch,
       },
       this.authInfo.clientId,
       this.authInfo.clientSecret,
       clientAuth
     );
+
+    // @ts-expect-error type mismatch, but it actually works
+    config[customFetch] = this.fetch;
+
+    // done
+    return config;
   }
 
   /**
@@ -79,7 +82,7 @@ export default abstract class OAuth2AuthStrategy<
       this.authInfo.tokenUrl = metadata.token_endpoint;
     } else {
       this.authInfo.authorizationUrl = metadata.authorization_endpoint ?? '';
-      this.authInfo.redirectUri = this.authInfo.redirectUri;
+      this.authInfo.callbackUrl = this.authInfo.callbackUrl;
     }
   }
 

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationTab.tsx
@@ -103,62 +103,49 @@ const OAUTH2_BASE_FORM: FormComponentConfiguration = {
   issuerUrl: {
     type: 'text',
     label: 'Issuer URL',
-    placeholder: 'Enter issuer URL (e.g., https://example.com)',
+    placeholder: 'https://example.com/oauth2/issuer',
   },
   tokenUrl: {
     type: 'text',
     label: 'Token URL',
-    placeholder: 'Enter token URL',
+    placeholder: 'https://example.com/oauth2/token',
   },
   scope: {
     type: 'text',
     label: 'Scope',
-    placeholder: 'Enter scopes (optional, space-separated)',
+    placeholder: '(optional, space-separated)',
+  },
+  clientAuthenticationMethod: {
+    type: 'select',
+    label: 'Client Authentication Method',
+    options: [
+      {
+        value: OAuth2ClientAuthenticationMethod.BASIC_AUTH,
+        label: 'Send Credentials as Basic Auth Header',
+      },
+      {
+        value: OAuth2ClientAuthenticationMethod.REQUEST_BODY,
+        label: 'Send Credentials in Request Body',
+      },
+    ],
   },
 };
 
 const OAUTH2_FORMS: { [K in OAuth2Method]: FormComponentConfiguration } = {
   [OAuth2Method.CLIENT_CREDENTIALS]: {
-    clientAuthenticationMethod: {
-      type: 'select',
-      label: 'Client Authentication Method',
-      options: [
-        {
-          value: OAuth2ClientAuthenticationMethod.BASIC_AUTH,
-          label: 'Send Credentials as Basic Auth Header',
-        },
-        {
-          value: OAuth2ClientAuthenticationMethod.REQUEST_BODY,
-          label: 'Send Credentials in Request Body',
-        },
-      ],
-    },
+    ...OAUTH2_BASE_FORM,
   },
   [OAuth2Method.AUTHORIZATION_CODE]: {
     ...OAUTH2_BASE_FORM,
     authorizationUrl: {
       type: 'text',
       label: 'Authorization URL',
-      placeholder: 'Enter authorization URL',
+      placeholder: 'https://example.com/oauth2/authorize',
     },
     callbackUrl: {
       type: 'text',
       label: 'Callback URL',
-      placeholder: 'Enter callback URL (redirect URI)',
-    },
-    clientAuthenticationMethod: {
-      type: 'select',
-      label: 'Client Authentication Method',
-      options: [
-        {
-          value: OAuth2ClientAuthenticationMethod.BASIC_AUTH,
-          label: 'Send Credentials as Basic Auth Header',
-        },
-        {
-          value: OAuth2ClientAuthenticationMethod.REQUEST_BODY,
-          label: 'Send Credentials in Request Body',
-        },
-      ],
+      placeholder: 'https://example.com/oauth2/callback',
     },
     state: {
       type: 'text',
@@ -175,26 +162,12 @@ const OAUTH2_FORMS: { [K in OAuth2Method]: FormComponentConfiguration } = {
     authorizationUrl: {
       type: 'text',
       label: 'Authorization URL',
-      placeholder: 'Enter authorization URL',
+      placeholder: 'https://example.com/oauth2/authorize',
     },
     callbackUrl: {
       type: 'text',
       label: 'Callback URL',
-      placeholder: 'Enter callback URL (redirect URI)',
-    },
-    clientAuthenticationMethod: {
-      type: 'select',
-      label: 'Client Authentication Method',
-      options: [
-        {
-          value: OAuth2ClientAuthenticationMethod.BASIC_AUTH,
-          label: 'Send Credentials as Basic Auth Header',
-        },
-        {
-          value: OAuth2ClientAuthenticationMethod.REQUEST_BODY,
-          label: 'Send Credentials in Request Body',
-        },
-      ],
+      placeholder: 'https://example.com/oauth2/callback',
     },
     codeChallengeMethod: {
       type: 'select',

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationTab.tsx
@@ -27,6 +27,7 @@ const INITIAL_AUTHORIZATION: { [K in AuthorizationTypeOrNone]: AuthorizationInfo
   [AuthorizationType.OAUTH2]: {
     type: AuthorizationType.OAUTH2,
     method: OAuth2Method.CLIENT_CREDENTIALS,
+    issuerUrl: '',
     tokenUrl: '',
     clientId: '',
     clientSecret: '',
@@ -88,28 +89,36 @@ const FORMS: { [K in AuthorizationTypeOrNone]: FormComponentConfiguration } = {
   },
 };
 
+const OAUTH2_BASE_FORM: FormComponentConfiguration = {
+  clientId: {
+    type: 'text',
+    label: 'Client ID',
+    placeholder: 'Enter client ID',
+  },
+  clientSecret: {
+    type: 'password',
+    label: 'Client Secret',
+    placeholder: 'Enter client secret',
+  },
+  issuerUrl: {
+    type: 'text',
+    label: 'Issuer URL',
+    placeholder: 'Enter issuer URL (e.g., https://example.com)',
+  },
+  tokenUrl: {
+    type: 'text',
+    label: 'Token URL',
+    placeholder: 'Enter token URL',
+  },
+  scope: {
+    type: 'text',
+    label: 'Scope',
+    placeholder: 'Enter scopes (optional, space-separated)',
+  },
+};
+
 const OAUTH2_FORMS: { [K in OAuth2Method]: FormComponentConfiguration } = {
   [OAuth2Method.CLIENT_CREDENTIALS]: {
-    clientId: {
-      type: 'text',
-      label: 'Client ID',
-      placeholder: 'Enter client ID',
-    },
-    clientSecret: {
-      type: 'password',
-      label: 'Client Secret',
-      placeholder: 'Enter client secret',
-    },
-    tokenUrl: {
-      type: 'text',
-      label: 'Token URL',
-      placeholder: 'Enter token URL',
-    },
-    scope: {
-      type: 'text',
-      label: 'Scope',
-      placeholder: 'Enter scopes (optional, space-separated)',
-    },
     clientAuthenticationMethod: {
       type: 'select',
       label: 'Client Authentication Method',
@@ -126,30 +135,16 @@ const OAUTH2_FORMS: { [K in OAuth2Method]: FormComponentConfiguration } = {
     },
   },
   [OAuth2Method.AUTHORIZATION_CODE]: {
-    clientId: {
-      type: 'text',
-      label: 'Client ID',
-      placeholder: 'Enter client ID',
-    },
-    clientSecret: {
-      type: 'password',
-      label: 'Client Secret',
-      placeholder: 'Enter client secret',
-    },
+    ...OAUTH2_BASE_FORM,
     authorizationUrl: {
       type: 'text',
       label: 'Authorization URL',
       placeholder: 'Enter authorization URL',
     },
-    redirectUri: {
+    callbackUrl: {
       type: 'text',
-      label: 'Redirect URI',
-      placeholder: 'Enter redirect URI',
-    },
-    scope: {
-      type: 'text',
-      label: 'Scope',
-      placeholder: 'Enter scopes (optional, space-separated)',
+      label: 'Callback URL',
+      placeholder: 'Enter callback URL (redirect URI)',
     },
     clientAuthenticationMethod: {
       type: 'select',
@@ -170,32 +165,22 @@ const OAUTH2_FORMS: { [K in OAuth2Method]: FormComponentConfiguration } = {
       label: 'State',
       placeholder: 'Enter state (optional, will be generated if empty)',
     },
+    cache: {
+      type: 'checkbox',
+      label: 'Keep Browser Session Cache',
+    },
   },
   [OAuth2Method.AUTHORIZATION_CODE_PKCE]: {
-    clientId: {
-      type: 'text',
-      label: 'Client ID',
-      placeholder: 'Enter client ID',
-    },
-    clientSecret: {
-      type: 'password',
-      label: 'Client Secret',
-      placeholder: 'Enter client secret (optional for PKCE)',
-    },
+    ...OAUTH2_BASE_FORM,
     authorizationUrl: {
       type: 'text',
       label: 'Authorization URL',
       placeholder: 'Enter authorization URL',
     },
-    redirectUri: {
+    callbackUrl: {
       type: 'text',
-      label: 'Redirect URI',
-      placeholder: 'Enter redirect URI',
-    },
-    scope: {
-      type: 'text',
-      label: 'Scope',
-      placeholder: 'Enter scopes (optional, space-separated)',
+      label: 'Callback URL',
+      placeholder: 'Enter callback URL (redirect URI)',
     },
     clientAuthenticationMethod: {
       type: 'select',
@@ -234,6 +219,10 @@ const OAUTH2_FORMS: { [K in OAuth2Method]: FormComponentConfiguration } = {
       type: 'text',
       label: 'State',
       placeholder: 'Enter state (optional, will be generated if empty)',
+    },
+    cache: {
+      type: 'checkbox',
+      label: 'Keep Browser Session Cache',
     },
   },
 };

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationTab.tsx
@@ -141,11 +141,6 @@ const OAUTH2_FORMS: { [K in OAuth2Method]: FormComponentConfiguration } = {
       label: 'Authorization URL',
       placeholder: 'Enter authorization URL',
     },
-    tokenUrl: {
-      type: 'text',
-      label: 'Token URL',
-      placeholder: 'Enter token URL',
-    },
     redirectUri: {
       type: 'text',
       label: 'Redirect URI',
@@ -191,11 +186,6 @@ const OAUTH2_FORMS: { [K in OAuth2Method]: FormComponentConfiguration } = {
       type: 'text',
       label: 'Authorization URL',
       placeholder: 'Enter authorization URL',
-    },
-    tokenUrl: {
-      type: 'text',
-      label: 'Token URL',
-      placeholder: 'Enter token URL',
     },
     redirectUri: {
       type: 'text',

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationTab.tsx
@@ -20,38 +20,32 @@ const LABELS: { [K in AuthorizationTypeOrNone]: string } = {
   [AuthorizationType.OAUTH2]: 'OAuth 2.0',
 };
 
+const BASE_FORM = {
+  type: {
+    type: 'select' as const,
+    label: 'Authorization Type',
+    options: Object.entries(LABELS).map(([value, label]) => ({ value, label })),
+    defaultValue: AUTHORIZATION_NONE,
+  },
+};
+
 const FORMS: { [K in AuthorizationTypeOrNone]: FormComponentConfiguration } = {
   [AUTHORIZATION_NONE]: {
-    type: {
-      type: 'select',
-      label: 'Authorization Type',
-      options: Object.entries(LABELS).map(([value, label]) => ({ value, label })),
-      defaultValue: AUTHORIZATION_NONE,
-    },
+    ...BASE_FORM,
     description: {
       type: 'label',
       text: 'No authorization will be applied to this request.',
     },
   },
   [AuthorizationType.INHERIT]: {
-    type: {
-      type: 'select',
-      label: 'Authorization Type',
-      options: Object.entries(LABELS).map(([value, label]) => ({ value, label })),
-      defaultValue: AuthorizationType.INHERIT,
-    },
+    ...BASE_FORM,
     description: {
       type: 'label',
       text: 'This request will inherit authorization settings from the collection.',
     },
   },
   [AuthorizationType.BEARER]: {
-    type: {
-      type: 'select',
-      label: 'Authorization Type',
-      options: Object.entries(LABELS).map(([value, label]) => ({ value, label })),
-      defaultValue: AuthorizationType.BEARER,
-    },
+    ...BASE_FORM,
     token: {
       type: 'text',
       label: 'Token',
@@ -59,12 +53,7 @@ const FORMS: { [K in AuthorizationTypeOrNone]: FormComponentConfiguration } = {
     },
   },
   [AuthorizationType.BASIC]: {
-    type: {
-      type: 'select',
-      label: 'Authorization Type',
-      options: Object.entries(LABELS).map(([value, label]) => ({ value, label })),
-      defaultValue: AuthorizationType.BASIC,
-    },
+    ...BASE_FORM,
     username: {
       type: 'text',
       label: 'Username',
@@ -77,12 +66,7 @@ const FORMS: { [K in AuthorizationTypeOrNone]: FormComponentConfiguration } = {
     },
   },
   [AuthorizationType.OAUTH2]: {
-    type: {
-      type: 'select',
-      label: 'Authorization Type',
-      options: Object.entries(LABELS).map(([value, label]) => ({ value, label })),
-      defaultValue: AuthorizationType.OAUTH2,
-    },
+    ...BASE_FORM,
     method: {
       type: 'select',
       label: 'OAuth 2.0 Method',

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationTab.tsx
@@ -13,6 +13,7 @@ import {
   OAuth2AuthorizationInformation,
   OAuth2ClientAuthenticationMethod,
   OAuth2Method,
+  OAuth2PKCECodeChallengeMethod,
 } from 'shim/objects/auth/oauth2';
 
 const AUTHORIZATION_NONE = 'none' as const;
@@ -81,6 +82,7 @@ const FORMS: { [K in AuthorizationTypeOrNone]: FormComponentConfiguration } = {
       options: [
         { value: OAuth2Method.CLIENT_CREDENTIALS, label: 'Client Credentials' },
         { value: OAuth2Method.AUTHORIZATION_CODE, label: 'Authorization Code' },
+        { value: OAuth2Method.AUTHORIZATION_CODE_PKCE, label: 'Authorization Code with PKCE' },
       ],
     },
   },
@@ -124,9 +126,124 @@ const OAUTH2_FORMS: { [K in OAuth2Method]: FormComponentConfiguration } = {
     },
   },
   [OAuth2Method.AUTHORIZATION_CODE]: {
-    description: {
-      type: 'label',
-      text: 'OAuth 2.0 Authorization Code flow is not yet implemented.',
+    clientId: {
+      type: 'text',
+      label: 'Client ID',
+      placeholder: 'Enter client ID',
+    },
+    clientSecret: {
+      type: 'password',
+      label: 'Client Secret',
+      placeholder: 'Enter client secret',
+    },
+    authorizationUrl: {
+      type: 'text',
+      label: 'Authorization URL',
+      placeholder: 'Enter authorization URL',
+    },
+    tokenUrl: {
+      type: 'text',
+      label: 'Token URL',
+      placeholder: 'Enter token URL',
+    },
+    redirectUri: {
+      type: 'text',
+      label: 'Redirect URI',
+      placeholder: 'Enter redirect URI',
+    },
+    scope: {
+      type: 'text',
+      label: 'Scope',
+      placeholder: 'Enter scopes (optional, space-separated)',
+    },
+    clientAuthenticationMethod: {
+      type: 'select',
+      label: 'Client Authentication Method',
+      options: [
+        {
+          value: OAuth2ClientAuthenticationMethod.BASIC_AUTH,
+          label: 'Send Credentials as Basic Auth Header',
+        },
+        {
+          value: OAuth2ClientAuthenticationMethod.REQUEST_BODY,
+          label: 'Send Credentials in Request Body',
+        },
+      ],
+    },
+    state: {
+      type: 'text',
+      label: 'State',
+      placeholder: 'Enter state (optional, will be generated if empty)',
+    },
+  },
+  [OAuth2Method.AUTHORIZATION_CODE_PKCE]: {
+    clientId: {
+      type: 'text',
+      label: 'Client ID',
+      placeholder: 'Enter client ID',
+    },
+    clientSecret: {
+      type: 'password',
+      label: 'Client Secret',
+      placeholder: 'Enter client secret (optional for PKCE)',
+    },
+    authorizationUrl: {
+      type: 'text',
+      label: 'Authorization URL',
+      placeholder: 'Enter authorization URL',
+    },
+    tokenUrl: {
+      type: 'text',
+      label: 'Token URL',
+      placeholder: 'Enter token URL',
+    },
+    redirectUri: {
+      type: 'text',
+      label: 'Redirect URI',
+      placeholder: 'Enter redirect URI',
+    },
+    scope: {
+      type: 'text',
+      label: 'Scope',
+      placeholder: 'Enter scopes (optional, space-separated)',
+    },
+    clientAuthenticationMethod: {
+      type: 'select',
+      label: 'Client Authentication Method',
+      options: [
+        {
+          value: OAuth2ClientAuthenticationMethod.BASIC_AUTH,
+          label: 'Send Credentials as Basic Auth Header',
+        },
+        {
+          value: OAuth2ClientAuthenticationMethod.REQUEST_BODY,
+          label: 'Send Credentials in Request Body',
+        },
+      ],
+    },
+    codeChallengeMethod: {
+      type: 'select',
+      label: 'Code Challenge Method',
+      options: [
+        {
+          value: OAuth2PKCECodeChallengeMethod.S256,
+          label: 'S256 (Recommended)',
+        },
+        {
+          value: OAuth2PKCECodeChallengeMethod.PLAIN,
+          label: 'Plain',
+        },
+      ],
+    },
+    codeVerifier: {
+      type: 'text',
+      label: 'Code Verifier',
+      placeholder: 'Enter code verifier (optional, will be generated if empty)',
+    },
+    state: {
+      type: 'text',
+      label: 'State',
+      placeholder: 'Enter state (optional, will be generated if empty)',
     },
   },
 };

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/ModularForm.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/ModularForm.tsx
@@ -53,14 +53,14 @@ export type FormFieldConfig =
 
 export type FormComponentConfiguration = Record<string, FormFieldConfig>;
 
-export interface FormProps<T extends Record<string, never>> {
+export interface FormProps<T extends Record<string, any>> {
   config: FormComponentConfiguration;
   form: T;
   onFormChanged: (delta: Partial<T>) => void;
   className?: string;
 }
 
-export const ModularForm = <T extends Record<string, never>>({
+export const ModularForm = <T extends Record<string, any>>({
   config,
   className,
   form,

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/ModularForm.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/ModularForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -10,29 +10,30 @@ import {
 } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 
-export interface BaseFieldConfig {
+export interface BaseFieldConfig<T> {
   label: string;
   placeholder?: string;
+  defaultValue?: T;
 }
 
-export interface TextFieldConfig extends BaseFieldConfig {
+export interface TextFieldConfig extends BaseFieldConfig<string> {
   type: 'text' | 'password' | 'email';
 }
 
-export interface NumberFieldConfig extends BaseFieldConfig {
+export interface NumberFieldConfig extends BaseFieldConfig<number> {
   type: 'number';
 }
 
-export interface SelectFieldConfig extends BaseFieldConfig {
+export interface SelectFieldConfig extends BaseFieldConfig<string> {
   type: 'select';
   options: Array<{ value: string; label: string }>;
 }
 
-export interface CheckboxFieldConfig extends BaseFieldConfig {
+export interface CheckboxFieldConfig extends BaseFieldConfig<boolean> {
   type: 'checkbox';
 }
 
-export interface TextareaFieldConfig extends BaseFieldConfig {
+export interface TextareaFieldConfig extends BaseFieldConfig<string> {
   type: 'textarea';
   rows?: number;
 }
@@ -55,21 +56,34 @@ export type FormComponentConfiguration = Record<string, FormFieldConfig>;
 
 export interface FormProps<T extends Record<string, any>> {
   config: FormComponentConfiguration;
-  form: T;
-  onFormChanged: (delta: Partial<T>) => void;
+  data: T;
+  onDataChanged: (delta: Partial<T>) => void;
   className?: string;
 }
 
 export const ModularForm = <T extends Record<string, any>>({
   config,
   className,
-  form,
-  onFormChanged,
+  data,
+  onDataChanged,
 }: FormProps<T>) => {
   const [visible, setVisible] = useState<Partial<{ [K in keyof T]: boolean }>>({});
   const toggleVisibility = (key: keyof T) => {
     setVisible((prev) => ({ ...prev, [key]: !prev[key] }));
   };
+
+  const getValue = useCallback(
+    <V,>(key: keyof T, defaultValue: V) => {
+      if (data[key] == null) {
+        onDataChanged({ [key]: defaultValue } as Partial<T>);
+        return defaultValue;
+      } else {
+        return data[key] as V;
+      }
+    },
+    [data, onDataChanged]
+  );
+
   const renderField = (key: keyof T, fieldConfig: FormFieldConfig) => {
     switch (fieldConfig.type) {
       case 'label':
@@ -81,14 +95,14 @@ export const ModularForm = <T extends Record<string, any>>({
 
       case 'text':
       case 'email': {
-        const { label, placeholder } = fieldConfig;
+        const { label, placeholder, defaultValue } = fieldConfig;
         return (
           <div key={key as string} className="space-y-2">
             <label className="text-sm font-medium text-text-primary">{label}</label>
             <Input
               type={fieldConfig.type}
-              value={form[key]}
-              onChange={(e) => onFormChanged({ [key]: e.target.value } as Partial<T>)}
+              value={getValue(key, defaultValue ?? '')}
+              onChange={(e) => onDataChanged({ [key]: e.target.value } as Partial<T>)}
               placeholder={placeholder}
               className="w-full rounded-md border border-border bg-background-primary px-3 py-2 text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
             />
@@ -97,15 +111,15 @@ export const ModularForm = <T extends Record<string, any>>({
       }
 
       case 'password': {
-        const { label, placeholder } = fieldConfig;
+        const { label, placeholder, defaultValue } = fieldConfig;
         return (
           <div key={key as string} className="space-y-2">
             <label className="text-sm font-medium text-text-primary">{label}</label>
             <div className="relative w-full">
               <Input
                 type={visible[key] ? 'text' : 'password'}
-                value={form[key]}
-                onChange={(e) => onFormChanged({ [key]: e.target.value } as Partial<T>)}
+                value={getValue(key, defaultValue ?? '')}
+                onChange={(e) => onDataChanged({ [key]: e.target.value } as Partial<T>)}
                 placeholder={placeholder}
                 className="w-full rounded-md border border-border bg-background-primary px-3 py-2 text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
               />
@@ -122,14 +136,14 @@ export const ModularForm = <T extends Record<string, any>>({
       }
 
       case 'number': {
-        const { label, placeholder } = fieldConfig;
+        const { label, placeholder, defaultValue } = fieldConfig;
         return (
           <div key={key as string} className="space-y-2">
             <label className="text-sm font-medium text-text-primary">{label}</label>
             <Input
               type="number"
-              value={form[key]}
-              onChange={(e) => onFormChanged({ [key]: e.target.valueAsNumber ?? 0 } as Partial<T>)}
+              value={getValue(key, defaultValue ?? 0)}
+              onChange={(e) => onDataChanged({ [key]: e.target.valueAsNumber ?? 0 } as Partial<T>)}
               placeholder={placeholder}
               className="w-full rounded-md border border-border bg-background-primary px-3 py-2 text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
             />
@@ -138,13 +152,13 @@ export const ModularForm = <T extends Record<string, any>>({
       }
 
       case 'select': {
-        const { label, placeholder } = fieldConfig;
+        const { label, placeholder, defaultValue } = fieldConfig;
         return (
           <div key={key as string} className="space-y-2">
             <label className="text-sm font-medium text-text-primary">{label}</label>
             <Select
-              value={form[key]}
-              onValueChange={(value) => onFormChanged({ [key]: value } as Partial<T>)}
+              value={getValue(key, defaultValue ?? fieldConfig.options[0].value)}
+              onValueChange={(value) => onDataChanged({ [key]: value } as Partial<T>)}
             >
               <SelectTrigger className="w-full rounded-md border border-border bg-background-primary px-3 py-2">
                 <SelectValue placeholder={placeholder ?? `Select ${label.toLowerCase()}`} />
@@ -162,14 +176,14 @@ export const ModularForm = <T extends Record<string, any>>({
       }
 
       case 'checkbox': {
-        const { label } = fieldConfig;
+        const { label, defaultValue } = fieldConfig;
         return (
           <div key={key as string} className="flex items-center space-x-2">
             <Checkbox
               id={key as string}
-              checked={form[key] as unknown as boolean} // TODO: fix type casting once there's a boolean field in authorization
+              checked={getValue(key, defaultValue ?? true)}
               onCheckedChange={(checked) =>
-                onFormChanged({ [key]: checked === true } as Partial<T>)
+                onDataChanged({ [key]: checked === true } as Partial<T>)
               }
               className="h-4 w-4"
             />
@@ -184,13 +198,13 @@ export const ModularForm = <T extends Record<string, any>>({
       }
 
       case 'textarea': {
-        const { label, placeholder } = fieldConfig;
+        const { label, placeholder, defaultValue } = fieldConfig;
         return (
           <div key={key as string} className="space-y-2">
             <label className="text-sm font-medium text-text-primary">{label}</label>
             <textarea
-              value={form[key]}
-              onChange={(e) => onFormChanged({ [key]: e.target.value } as Partial<T>)}
+              value={getValue(key, defaultValue ?? '')}
+              onChange={(e) => onDataChanged({ [key]: e.target.value } as Partial<T>)}
               placeholder={placeholder}
               rows={fieldConfig.rows ?? 3}
               className="resize-vertical w-full rounded-md border border-border bg-background-primary px-3 py-2 text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/ModularForm.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/ModularForm.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
+import { SecretInput } from '@/components/ui/secret-input';
 
 export interface BaseFieldConfig<T> {
   label: string;
@@ -67,11 +68,6 @@ export const ModularForm = <T extends Record<string, any>>({
   data,
   onDataChanged,
 }: FormProps<T>) => {
-  const [visible, setVisible] = useState<Partial<{ [K in keyof T]: boolean }>>({});
-  const toggleVisibility = (key: keyof T) => {
-    setVisible((prev) => ({ ...prev, [key]: !prev[key] }));
-  };
-
   const getValue = useCallback(
     <V,>(key: keyof T, defaultValue: V) => {
       if (data[key] == null) {
@@ -115,22 +111,12 @@ export const ModularForm = <T extends Record<string, any>>({
         return (
           <div key={key as string} className="space-y-2">
             <label className="text-sm font-medium text-text-primary">{label}</label>
-            <div className="relative w-full">
-              <Input
-                type={visible[key] ? 'text' : 'password'}
-                value={getValue(key, defaultValue ?? '')}
-                onChange={(e) => onDataChanged({ [key]: e.target.value } as Partial<T>)}
-                placeholder={placeholder}
-                className="w-full rounded-md border border-border bg-background-primary px-3 py-2 text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
-              />
-              <button
-                type="button"
-                onClick={() => toggleVisibility(key)}
-                className="absolute inset-y-0 right-0 flex items-center px-3 text-sm text-text-secondary hover:text-text-primary"
-              >
-                {visible[key] ? 'Hide' : 'Show'}
-              </button>
-            </div>
+            <SecretInput
+              value={getValue(key, defaultValue ?? '')}
+              onChange={(e) => onDataChanged({ [key]: e.target.value } as Partial<T>)}
+              placeholder={placeholder}
+              className="w-full rounded-md border border-border bg-background-primary px-3 py-2 text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent"
+            />
           </div>
         );
       }

--- a/src/renderer/components/shared/settings/VariableTab/VariableEditor.tsx
+++ b/src/renderer/components/shared/settings/VariableTab/VariableEditor.tsx
@@ -15,6 +15,7 @@ import { produce } from 'immer';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Trash2 } from 'lucide-react';
 import { SecretInput } from '@/components/ui/secret-input';
+import { cn } from '@/lib/utils';
 
 export interface VariableEditorProps {
   variables: VariableObjectWithKey[];
@@ -104,7 +105,9 @@ export const VariableEditor = memo<VariableEditorProps>(
                   <input
                     type="text"
                     value={variable.key}
-                    className={`w-full bg-transparent outline-none ${invalidVariableKeys.has(variable.key) ? 'text-danger' : ''}`}
+                    className={cn('w-full bg-transparent outline-none', {
+                      'text-danger': invalidVariableKeys.has(variable.key),
+                    })}
                     placeholder="Enter variable key"
                     onChange={(e) => update(index, { key: e.target.value })}
                   />
@@ -113,6 +116,9 @@ export const VariableEditor = memo<VariableEditorProps>(
                   <SecretInput
                     secret={variable.secret}
                     value={variable.value}
+                    className={cn('w-full border-none bg-transparent outline-none', {
+                      'text-danger': invalidVariableKeys.has(variable.key),
+                    })}
                     placeholder="Enter variable value"
                     onChange={(e) => update(index, { value: e.target.value })}
                   />

--- a/src/renderer/components/ui/secret-input.tsx
+++ b/src/renderer/components/ui/secret-input.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Input } from './input';
+import { cn } from '@/lib/utils';
 
 interface SecretInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   secret?: boolean;
@@ -14,10 +15,10 @@ export function SecretInput({ secret = true, className, ...props }: SecretInputP
 
   return (
     <div className="relative w-full">
-      <Input type={show ? 'text' : 'password'} className={className} {...props} />
+      <Input type={show ? 'text' : 'password'} className={cn('pr-16', className)} {...props} />
       <button
         type="button"
-        className="absolute inset-y-0 right-0 flex items-center px-3 text-sm text-text-secondary hover:text-text-primary"
+        className="absolute inset-y-0 right-0 flex h-10 w-16 items-center justify-center text-sm text-text-secondary hover:text-text-primary"
         onClick={() => setShow((prev) => !prev)}
         tabIndex={-1}
       >

--- a/src/renderer/components/ui/secret-input.tsx
+++ b/src/renderer/components/ui/secret-input.tsx
@@ -1,33 +1,23 @@
 import { useState } from 'react';
-import { cn } from '@/lib/utils';
+import { Input } from './input';
 
 interface SecretInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   secret?: boolean;
 }
 
-export function SecretInput({ secret = false, className, ...props }: SecretInputProps) {
+export function SecretInput({ secret = true, className, ...props }: SecretInputProps) {
   const [show, setShow] = useState(false);
 
   if (!secret) {
-    return (
-      <input
-        type="text"
-        className={cn('w-full bg-transparent outline-none', className)}
-        {...props}
-      />
-    );
+    return <Input type="text" className={className} {...props} />;
   }
 
   return (
     <div className="relative w-full">
-      <input
-        type={show ? 'text' : 'password'}
-        className={cn('w-full bg-transparent pr-12 outline-none', className)}
-        {...props}
-      />
+      <Input type={show ? 'text' : 'password'} className={className} {...props} />
       <button
         type="button"
-        className="absolute inset-y-0 right-0 flex items-center text-sm text-text-secondary hover:text-text-primary"
+        className="absolute inset-y-0 right-0 flex items-center px-3 text-sm text-text-secondary hover:text-text-primary"
         onClick={() => setShow((prev) => !prev)}
         tabIndex={-1}
       >
@@ -36,3 +26,4 @@ export function SecretInput({ secret = false, className, ...props }: SecretInput
     </div>
   );
 }
+SecretInput.displayName = 'SecretInput';

--- a/src/shim/logger.ts
+++ b/src/shim/logger.ts
@@ -4,5 +4,6 @@ export interface LogEntry {
   level: LogLevel;
   message: string;
   process: 'renderer' | 'main';
+  isSecret?: boolean;
   splat: unknown[];
 }

--- a/src/shim/objects/auth/oauth2.ts
+++ b/src/shim/objects/auth/oauth2.ts
@@ -21,7 +21,6 @@ export interface Oauth2BaseAuthorizationInformation<T extends OAuth2Method> {
   tokenUrl: string;
   scope: string;
   clientAuthenticationMethod: OAuth2ClientAuthenticationMethod;
-  cache?: boolean; // whether to keep browser session cache
 
   // not configurable
   tokens?: TokenEndpointResponse;
@@ -36,6 +35,7 @@ export interface OAuth2ClientAuthorizationCodeFlowInformation<
   authorizationUrl: string;
   callbackUrl: string;
   state?: string; // generated if not provided
+  cache?: boolean; // whether to keep browser session cache
 }
 
 export enum OAuth2PKCECodeChallengeMethod {

--- a/src/shim/objects/auth/oauth2.ts
+++ b/src/shim/objects/auth/oauth2.ts
@@ -12,43 +12,42 @@ export enum OAuth2ClientAuthenticationMethod {
   REQUEST_BODY = 'request-body',
 }
 
-export type Oauth2BaseAuthorizationInformation = {
+export interface Oauth2BaseAuthorizationInformation<T extends OAuth2Method> {
   type: AuthorizationType.OAUTH2;
-  method: OAuth2Method;
+  method: T;
   clientId: string;
   clientSecret: string;
-  tokenUrl: string;
   scope: string;
   clientAuthenticationMethod: OAuth2ClientAuthenticationMethod;
 
   // not configurable
   tokens?: TokenEndpointResponse;
-};
+}
 
-export type OAuth2ClientCrentialsAuthorizationInformation = Oauth2BaseAuthorizationInformation & {
-  method: OAuth2Method.CLIENT_CREDENTIALS;
-};
+export interface OAuth2ClientCrentialsAuthorizationInformation
+  extends Oauth2BaseAuthorizationInformation<OAuth2Method.CLIENT_CREDENTIALS> {
+  tokenUrl: string;
+}
 
-export type OAuth2ClientAuthorizationCodeFlowInformation = Oauth2BaseAuthorizationInformation & {
-  method: OAuth2Method.AUTHORIZATION_CODE;
+export interface OAuth2ClientAuthorizationCodeFlowInformation<
+  T extends OAuth2Method = OAuth2Method.AUTHORIZATION_CODE,
+> extends Oauth2BaseAuthorizationInformation<T> {
   authorizationUrl: string;
   redirectUri: string;
   state?: string; // generated if not provided
-};
+}
 
 export enum OAuth2PKCECodeChallengeMethod {
   S256 = 'S256',
   PLAIN = 'plain',
 }
 
-export type OAuth2ClientAuthorizationCodeFlowPKCEInformation =
-  OAuth2ClientAuthorizationCodeFlowInformation & {
-    method: OAuth2Method.AUTHORIZATION_CODE_PKCE;
-    authorizationUrl: string;
-    redirectUri: string;
-    codeChallengeMethod: OAuth2PKCECodeChallengeMethod;
-    codeVerifier?: string; // generated if not provided
-  };
+export interface OAuth2ClientAuthorizationCodeFlowPKCEInformation
+  extends OAuth2ClientAuthorizationCodeFlowInformation<OAuth2Method.AUTHORIZATION_CODE_PKCE> {
+  method: OAuth2Method.AUTHORIZATION_CODE_PKCE;
+  codeChallengeMethod: OAuth2PKCECodeChallengeMethod;
+  codeVerifier?: string; // generated if not provided
+}
 
 export type OAuth2AuthorizationInformation =
   | OAuth2ClientCrentialsAuthorizationInformation

--- a/src/shim/objects/auth/oauth2.ts
+++ b/src/shim/objects/auth/oauth2.ts
@@ -15,25 +15,26 @@ export enum OAuth2ClientAuthenticationMethod {
 export interface Oauth2BaseAuthorizationInformation<T extends OAuth2Method> {
   type: AuthorizationType.OAUTH2;
   method: T;
+  issuerUrl: string;
   clientId: string;
   clientSecret: string;
+  tokenUrl: string;
   scope: string;
   clientAuthenticationMethod: OAuth2ClientAuthenticationMethod;
+  cache?: boolean; // whether to keep browser session cache
 
   // not configurable
   tokens?: TokenEndpointResponse;
 }
 
 export interface OAuth2ClientCrentialsAuthorizationInformation
-  extends Oauth2BaseAuthorizationInformation<OAuth2Method.CLIENT_CREDENTIALS> {
-  tokenUrl: string;
-}
+  extends Oauth2BaseAuthorizationInformation<OAuth2Method.CLIENT_CREDENTIALS> {}
 
 export interface OAuth2ClientAuthorizationCodeFlowInformation<
   T extends OAuth2Method = OAuth2Method.AUTHORIZATION_CODE,
 > extends Oauth2BaseAuthorizationInformation<T> {
   authorizationUrl: string;
-  redirectUri: string;
+  callbackUrl: string;
   state?: string; // generated if not provided
 }
 

--- a/src/shim/objects/auth/oauth2.ts
+++ b/src/shim/objects/auth/oauth2.ts
@@ -4,6 +4,7 @@ import { AuthorizationType } from '.';
 export enum OAuth2Method {
   CLIENT_CREDENTIALS = 'client-credentials',
   AUTHORIZATION_CODE = 'authorization-code',
+  AUTHORIZATION_CODE_PKCE = 'authorization-code-pkce',
 }
 
 export enum OAuth2ClientAuthenticationMethod {
@@ -11,9 +12,9 @@ export enum OAuth2ClientAuthenticationMethod {
   REQUEST_BODY = 'request-body',
 }
 
-export type OAuth2ClientCrentialsAuthorizationInformation = {
+export type Oauth2BaseAuthorizationInformation = {
   type: AuthorizationType.OAUTH2;
-  method: OAuth2Method.CLIENT_CREDENTIALS;
+  method: OAuth2Method;
   clientId: string;
   clientSecret: string;
   tokenUrl: string;
@@ -24,4 +25,32 @@ export type OAuth2ClientCrentialsAuthorizationInformation = {
   tokens?: TokenEndpointResponse;
 };
 
-export type OAuth2AuthorizationInformation = OAuth2ClientCrentialsAuthorizationInformation;
+export type OAuth2ClientCrentialsAuthorizationInformation = Oauth2BaseAuthorizationInformation & {
+  method: OAuth2Method.CLIENT_CREDENTIALS;
+};
+
+export type OAuth2ClientAuthorizationCodeFlowInformation = Oauth2BaseAuthorizationInformation & {
+  method: OAuth2Method.AUTHORIZATION_CODE;
+  authorizationUrl: string;
+  redirectUri: string;
+  state?: string; // generated if not provided
+};
+
+export enum OAuth2PKCECodeChallengeMethod {
+  S256 = 'S256',
+  PLAIN = 'plain',
+}
+
+export type OAuth2ClientAuthorizationCodeFlowPKCEInformation =
+  OAuth2ClientAuthorizationCodeFlowInformation & {
+    method: OAuth2Method.AUTHORIZATION_CODE_PKCE;
+    authorizationUrl: string;
+    redirectUri: string;
+    codeChallengeMethod: OAuth2PKCECodeChallengeMethod;
+    codeVerifier?: string; // generated if not provided
+  };
+
+export type OAuth2AuthorizationInformation =
+  | OAuth2ClientCrentialsAuthorizationInformation
+  | OAuth2ClientAuthorizationCodeFlowInformation
+  | OAuth2ClientAuthorizationCodeFlowPKCEInformation;


### PR DESCRIPTION
## Changes

- Implement OAuth2 auth code flow
- Simplify the code for the auth modal
- Support logging secrets which are only shown in console and not stored in the FS logs
- Log OAuth2 requests being made (in console only)
- Fix password input rendering behind the hide/show button

## Testing

You can test it yourself using https://oauth.tools

https://github.com/user-attachments/assets/ed85621d-4b99-474b-8483-2d609ee86063


## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
