### PR TITLE
feat(483 ): Add show/hide Button to Secret Variables

### DIFF
--- a/src/renderer/components/shared/settings/VariableTab/VariableEditor.tsx
+++ b/src/renderer/components/shared/settings/VariableTab/VariableEditor.tsx
@@ -14,6 +14,7 @@ import { memo, useEffect } from 'react';
 import { produce } from 'immer';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Trash2 } from 'lucide-react';
+import { SecretInput } from '@/components/ui/secret-input';
 
 export interface VariableEditorProps {
   variables: VariableObjectWithKey[];
@@ -65,7 +66,7 @@ export const VariableEditor = memo<VariableEditorProps>(
       if (invalidVariableKeys.has('')) return;
       onVariablesChange(
         produce(variables, (variables) => {
-          variables.push({ key: '', value: '' });
+          variables.push({ key: '', value: '', description: '', secret: false });
         })
       );
     };
@@ -122,10 +123,9 @@ export const VariableEditor = memo<VariableEditorProps>(
                   />
                 </TableCell>
                 <TableCell className="break-all">
-                  <input
-                    type="text"
+                  <SecretInput
+                    secret={variable.secret}
                     value={variable.value}
-                    className="w-full bg-transparent outline-none"
                     placeholder="Enter variable value"
                     onChange={(e) => update(index, { value: e.target.value })}
                   />

--- a/src/renderer/components/ui/secret-input.tsx
+++ b/src/renderer/components/ui/secret-input.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+
+interface SecretInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  secret?: boolean;
+}
+
+export function SecretInput({ secret = false, className, ...props }: SecretInputProps) {
+  const [show, setShow] = useState(false);
+
+  if (!secret) {
+    return (
+      <input
+        type="text"
+        className={cn('w-full bg-transparent outline-none', className)}
+        {...props}
+      />
+    );
+  }
+
+  return (
+    <div className="relative w-full">
+      <input
+        type={show ? 'text' : 'password'}
+        className={cn('w-full bg-transparent pr-12 outline-none', className)}
+        {...props}
+      />
+      <button
+        type="button"
+        className="absolute inset-y-0 right-0 flex items-center text-sm text-text-secondary hover:text-text-primary"
+        onClick={() => setShow((prev) => !prev)}
+        tabIndex={-1}
+      >
+        {show ? 'Hide' : 'Show'}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Changes

This update enhances the SecretInput component by adding a Show/Hide toggle button for password fields.

Default state: password is hidden.

Clicking the toggle switches between masked (password) and visible (text) input types.
## Testing
<img width="1440" height="900" alt="Screenshot 2025-08-09 at 1 48 39 PM" src="https://github.com/user-attachments/assets/90bb189a-2163-4ecc-a488-ff45ed3b35c8" />
<img width="1440" height="900" alt="Screenshot 2025-08-09 at 1 48 46 PM" src="https://github.com/user-attachments/assets/da6c77cc-a9ba-457b-95e2-9a7e691fe016" />
<img width="1440" height="900" alt="Screenshot 2025-08-09 at 1 48 53 PM" src="https://github.com/user-attachments/assets/3afa6984-b81a-4519-b7a5-dfe329a46d9e" />


## Checklist

- [x] Issue has been linked to this PR
- [ ] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
