### PR TITLE
feat(413): Variables in URL and HTTP Header Values

### DIFF
--- a/src/main/__mocks__/electron/app.ts
+++ b/src/main/__mocks__/electron/app.ts
@@ -8,4 +8,8 @@ export function getName() {
   return 'Trufos';
 }
 
+export function getVersion() {
+  return '0.0.0';
+}
+
 export const isPackaged = false;

--- a/src/main/__mocks__/index.ts
+++ b/src/main/__mocks__/index.ts
@@ -9,6 +9,7 @@ global.logger.secret = console;
 vi.mock('electron');
 vi.mock('node:fs');
 vi.mock('node:fs/promises');
+vi.mock('node:process');
 vi.mock('tmp');
 
 beforeEach(() => {

--- a/src/main/__mocks__/index.ts
+++ b/src/main/__mocks__/index.ts
@@ -4,6 +4,7 @@ import { vi, beforeEach } from 'vitest';
 
 // @ts-expect-error mock global logger with console
 global.logger = console;
+global.logger.secret = console;
 
 vi.mock('electron');
 vi.mock('node:fs');

--- a/src/main/__mocks__/process.ts
+++ b/src/main/__mocks__/process.ts
@@ -1,0 +1,6 @@
+import * as process from 'node:process';
+
+export = {
+  ...process,
+  getSystemVersion: () => '0.0.0',
+};

--- a/src/main/environment/service/environment-service.test.ts
+++ b/src/main/environment/service/environment-service.test.ts
@@ -5,19 +5,20 @@ import { VariableMap, VariableObject } from 'shim/objects/variables';
 import { PersistenceService } from 'main/persistence/service/persistence-service';
 import { randomUUID } from 'node:crypto';
 import { getSystemVariables } from './system-variable';
-import { SettingsObject, SettingsService } from '../../persistence/service/settings-service';
+import { SettingsObject, SettingsService } from 'main/persistence/service/settings-service';
 
 const environmentService = EnvironmentService.instance;
 
 const environmentKey = 'test';
 const variableKey = 'var1';
+const variableValue = 'some-value';
 const collection: Partial<Collection> = {
   id: randomUUID(),
   environments: {
     [environmentKey]: {
       variables: {
         [variableKey]: {
-          value: 'some-value',
+          value: variableValue,
         },
       },
     },
@@ -173,5 +174,16 @@ describe('EnvironmentService', () => {
     expect(getSettingsSpy).toHaveBeenCalled();
     expect(loadCollectionSpy).toHaveBeenCalledTimes(settings.collections.length);
     expect(result).toEqual(collections);
+  });
+
+  it('setVariablesInString() should replace all variable placeholders with their values', async () => {
+    // Arrange
+    const template = `Replacing {{ ${variableKey} }}`;
+
+    // Act
+    const result = await environmentService.setVariablesInString(template);
+
+    // Assert
+    expect(result).toBe(`Replacing ${variableValue}`);
   });
 });

--- a/src/main/environment/service/environment-service.ts
+++ b/src/main/environment/service/environment-service.ts
@@ -80,10 +80,12 @@ export class EnvironmentService implements Initializable {
    * @param variables The variables of the Collection to set.
    */
   public setCollectionVariables(variables: VariableMap) {
+    logger.secret?.debug('Setting collection variables:', variables);
     this.currentCollection.variables = variables;
   }
 
   public setEnvironmentVariables(environmentVariables: EnvironmentMap) {
+    logger.secret?.debug('Setting environment variables:', environmentVariables);
     this.currentCollection.environments = environmentVariables;
   }
 

--- a/src/main/environment/service/environment-service.ts
+++ b/src/main/environment/service/environment-service.ts
@@ -66,6 +66,16 @@ export class EnvironmentService implements Initializable {
   }
 
   /**
+   * Replaces any `{{ $someVariable }}` template variables in the given string with their values.
+   *
+   * @param string The string to replace the variables in.
+   * @returns The string with the variables replaced.
+   */
+  public setVariablesInString(string: string) {
+    return TemplateReplaceStream.replaceStringAsync(string, this.getVariableValue.bind(this));
+  }
+
+  /**
    * Replace all variables in the current collection with the given variables.
    * @param variables The variables of the Collection to set.
    */

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -127,7 +127,7 @@ export class MainEventService implements IEventService {
     await persistenceService.saveCollection(environmentService.currentCollection);
   }
 
-  async selectEnvironment(key: string) {
+  async selectEnvironment(key?: string) {
     environmentService.currentEnvironmentKey = key;
   }
 

--- a/src/main/logging/logger.ts
+++ b/src/main/logging/logger.ts
@@ -98,7 +98,7 @@ logger.secret = {
 };
 
 if (!app.isPackaged) {
-  logger.add(new transports.Console({ level: 'info' }));
+  logger.add(new transports.Console({ level: 'debug' }));
 }
 
 ipcMain.on('log', (event, data: TransformableInfo & LogEntry) => {

--- a/src/main/network/service/http-service.ts
+++ b/src/main/network/service/http-service.ts
@@ -10,6 +10,7 @@ import { TrufosResponse } from 'shim/objects/response';
 import { PersistenceService } from 'main/persistence/service/persistence-service';
 import { TrufosHeader } from 'shim/objects/headers';
 import { calculateResponseSize } from 'main/util/size-calculation';
+import { app } from 'electron/main';
 
 const fileSystemService = FileSystemService.instance;
 const environmentService = EnvironmentService.instance;
@@ -63,6 +64,7 @@ export class HttpService {
       headers: {
         ['content-type']: this.getContentType(request),
         ['authorization']: authorization,
+        ['user-agent']: `Trufos/${app.getVersion()}`,
         ...headers,
       },
       body: await this.readBody(request),

--- a/src/main/network/service/http-service.ts
+++ b/src/main/network/service/http-service.ts
@@ -15,6 +15,8 @@ const fileSystemService = FileSystemService.instance;
 const environmentService = EnvironmentService.instance;
 const persistenceService = PersistenceService.instance;
 
+declare type HttpHeaders = Record<string, string[]>;
+
 /**
  * Singleton service for making HTTP requests
  */
@@ -47,15 +49,21 @@ export class HttpService {
       }
     }
 
+    // resolve variables (except in body, which is resolved stream-based during send)
+    const url = await environmentService.setVariablesInString(request.url);
+    const headers = await this.resolveVariablesInHeaders(
+      this.trufosHeadersToUndiciHeaders(request.headers)
+    );
+
     // measure duration of the request
     const now = getSteadyTimestamp();
-    const responseData = await undici.request(request.url, {
+    const responseData = await undici.request(url, {
       dispatcher: this._dispatcher,
       method: request.method,
       headers: {
         ['content-type']: this.getContentType(request),
         ['authorization']: authorization,
-        ...this.trufosHeadersToUndiciHeaders(request.headers),
+        ...headers,
       },
       body: await this.readBody(request),
     });
@@ -94,7 +102,7 @@ export class HttpService {
    * @param request request object
    * @returns request body as stream or null if there is no body
    */
-  private async readBody(request: TrufosRequest) {
+  private async readBody(request: TrufosRequest): Promise<Readable | null> {
     if (request.body == null) {
       return null;
     }
@@ -127,8 +135,8 @@ export class HttpService {
     }
   }
 
-  private trufosHeadersToUndiciHeaders(trufosHeaders: TrufosHeader[]) {
-    const headers: Record<string, string[]> = {};
+  private trufosHeadersToUndiciHeaders(trufosHeaders: TrufosHeader[]): HttpHeaders {
+    const headers: HttpHeaders = {};
     for (const header of trufosHeaders) {
       if (header.isActive) {
         const key = header.key.toLowerCase();
@@ -137,5 +145,19 @@ export class HttpService {
       }
     }
     return headers;
+  }
+
+  private async resolveVariablesInHeaders(headers: HttpHeaders): Promise<HttpHeaders> {
+    return Object.fromEntries(
+      await Promise.all(
+        Object.entries(headers).map(
+          async ([key, values]) => [key, await this.resolveVariablesInHeaderValues(values)] as const
+        )
+      )
+    );
+  }
+
+  private resolveVariablesInHeaderValues(values: string[]) {
+    return Promise.all(values.map((value) => environmentService.setVariablesInString(value)));
   }
 }

--- a/src/main/network/service/http-service.ts
+++ b/src/main/network/service/http-service.ts
@@ -10,7 +10,8 @@ import { TrufosResponse } from 'shim/objects/response';
 import { PersistenceService } from 'main/persistence/service/persistence-service';
 import { TrufosHeader } from 'shim/objects/headers';
 import { calculateResponseSize } from 'main/util/size-calculation';
-import { app } from 'electron/main';
+import { app } from 'electron';
+import process from 'node:process';
 
 const fileSystemService = FileSystemService.instance;
 const environmentService = EnvironmentService.instance;
@@ -64,7 +65,7 @@ export class HttpService {
       headers: {
         ['content-type']: this.getContentType(request),
         ['authorization']: authorization,
-        ['user-agent']: `Trufos/${app.getVersion()}`,
+        ['user-agent']: `Trufos/${app.getVersion()} (${process.platform} ${process.getSystemVersion()}; ${process.arch})`,
         ...headers,
       },
       body: await this.readBody(request),

--- a/src/main/persistence/service/persistence-service.test.ts
+++ b/src/main/persistence/service/persistence-service.test.ts
@@ -229,7 +229,7 @@ describe('PersistenceService', () => {
     );
   });
 
-  it('saveCollection() should store the secrets in ~secrets.json.bin', async () => {
+  it('saveCollection() should store the secrets only in ~secrets.json.bin', async () => {
     // Arrange
     const secretVariable: VariableObject = { value: 'secret', secret: true };
     const plainVariable: VariableObject = { value: 'plain' };

--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -251,6 +251,7 @@ export class PersistenceService {
     }
 
     // remove secrets from variables and save them separately
+    object = structuredClone(object); // avoid modifying the original object
     await this.saveSecrets(object, dirPath);
 
     // write the info file

--- a/src/renderer/components/shared/settings/SettingsModal.tsx
+++ b/src/renderer/components/shared/settings/SettingsModal.tsx
@@ -25,9 +25,9 @@ export const SettingsModal = () => {
   const { setVariables } = useVariableActions();
   const { setEnvironments, selectEnvironment } = useEnvironmentActions();
 
-  const variables = useVariableStore((state) => selectVariables(state));
-  const environments = useEnvironmentStore((state) => selectEnvironments(state));
-  const selectedEnvironment = useEnvironmentStore((state) => selectSelectedEnvironment(state));
+  const variables = useVariableStore(selectVariables);
+  const environments = useEnvironmentStore(selectEnvironments);
+  const selectedEnvironment = useEnvironmentStore(selectSelectedEnvironment);
 
   const [editorVariables, setEditorVariables] = useState(variableMapToArray(variables));
   const [editorEnvironments, setEditorEnvironments] = useState(environments);
@@ -35,38 +35,34 @@ export const SettingsModal = () => {
   const [isValid, setValid] = useState(false);
   const [isEnvironmentValid, setEnvironmentValid] = useState(true);
   const [isOpen, setOpen] = useState(false);
-
-  useEffect(() => {
-    setEditorVariables(variableMapToArray(variables));
-  }, [variables]);
-
-  useEffect(() => {
-    setEditorEnvironments(environments);
-    setEditorSelectedEnvironment(selectedEnvironment);
-  }, [environments, selectedEnvironment]);
-
   const isOverallValid = isValid && isEnvironmentValid;
+
+  useEffect(() => {
+    if (isOpen) {
+      setEditorVariables(variableMapToArray(variables));
+      setEditorEnvironments(environments);
+      setEditorSelectedEnvironment(selectedEnvironment);
+    }
+  }, [isOpen]);
 
   const apply = async () => {
     await setVariables(variableArrayToMap(editorVariables));
     await setEnvironments(editorEnvironments);
-    selectEnvironment(editorSelectedEnvironment);
+    await selectEnvironment(editorSelectedEnvironment);
   };
 
+  // We intentionally do NOT call cancel() after a successful save because cancel() reverts
+  // the editor state to the store snapshot at the time of closing. When save() previously
+  // closed the dialog, the onOpenChange handler invoked cancel(), briefly overriding the
+  // just-applied changes until store effects re-synchronized. This created the perception
+  // that changes were not saved. By separating the close behavior we avoid that flicker/race.
   const save = async () => {
     await apply();
     setOpen(false);
   };
 
-  const cancel = () => {
-    setEditorVariables(variableMapToArray(variables));
-    setEditorEnvironments(environments);
-    setEditorSelectedEnvironment(selectedEnvironment);
-    setOpen(false);
-  };
-
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => !open && cancel()}>
+    <Dialog open={isOpen} onOpenChange={setOpen}>
       <DialogTrigger onClick={() => setOpen(true)}>
         <FiSettings className="ml-2 text-xl" />
       </DialogTrigger>
@@ -117,7 +113,7 @@ export const SettingsModal = () => {
           {/* Footer - Fixed */}
           <DialogFooter className="flex-shrink-0 p-4">
             <div className="flex gap-2">
-              <Button onClick={cancel} variant="outline">
+              <Button onClick={() => setOpen(false)} variant="outline">
                 <span className="font-bold leading-4">Cancel</span>
               </Button>
               <Button

--- a/src/renderer/state/environmentStore.ts
+++ b/src/renderer/state/environmentStore.ts
@@ -10,13 +10,13 @@ interface EnvironmentState {
   /** The environments of the current collection */
   environments: EnvironmentMap;
   /** Currently selected environment key */
-  selectedEnvironment: string | null;
+  selectedEnvironment?: string;
 }
 
 interface EnvironmentActions {
   initialize(environments: EnvironmentMap): void;
   setEnvironments(environments: EnvironmentMap): Promise<void>;
-  selectEnvironment(environmentKey: string | null): void;
+  selectEnvironment(environmentKey?: string): Promise<void>;
   addEnvironment(key: string): void;
   removeEnvironment(key: string): void;
 }
@@ -24,7 +24,7 @@ interface EnvironmentActions {
 export const useEnvironmentStore = create<EnvironmentState & EnvironmentActions>()(
   immer((set) => ({
     environments: {},
-    selectedEnvironment: null,
+    selectedEnvironment: undefined,
 
     initialize(environments: EnvironmentMap) {
       set((state) => {
@@ -42,10 +42,8 @@ export const useEnvironmentStore = create<EnvironmentState & EnvironmentActions>
       });
     },
 
-    selectEnvironment(environmentKey: string | null) {
-      if (environmentKey) {
-        eventService.selectEnvironment(environmentKey);
-      }
+    selectEnvironment: async (environmentKey?: string) => {
+      await eventService.selectEnvironment(environmentKey);
       set((state) => {
         state.selectedEnvironment = environmentKey;
       });

--- a/src/renderer/state/variableStore.ts
+++ b/src/renderer/state/variableStore.ts
@@ -23,6 +23,7 @@ export const useVariableStore = create<VariableState & VariableStateActions>()(
     },
 
     setVariables: async (variables) => {
+      console.debug('Saving collection variables');
       await eventService.setCollectionVariables(variables);
       set((state) => {
         state.variables = variables;

--- a/src/shim/event-service.ts
+++ b/src/shim/event-service.ts
@@ -96,7 +96,7 @@ export interface IEventService {
    * Select an environment by its key.
    * @param key The key of the environment to select.
    */
-  selectEnvironment(key: string): void;
+  selectEnvironment(key?: string): void;
 
   /**
    * Save the folder to the file system.


### PR DESCRIPTION
## Changes

- Support variables in URL, HTTP header values, and any authorization field
- Fix collection variables not being saved
- Fix secret variables missing after persisting
- Fix global `logger.secret` missing in tests
- Add user agent as automatic header for any request (currently `"User-Agent": "Trufos/0.2.0"`)

## Testing

- I added automated tests :)

<img width="1392" height="1527" alt="image" src="https://github.com/user-attachments/assets/75e630e6-c44b-41b7-8f7a-66d9406bb2b7" />

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
