### PR TITLE
feat(476): Rename also on FS

### DIFF
--- a/docs/architecture/02_rename_behavior.md
+++ b/docs/architecture/02_rename_behavior.md
@@ -1,0 +1,17 @@
+# Rename Behavior
+
+The `PersistenceService.rename()` method updates both the logical (title) and physical (directory) representation of a folder or request.
+
+Behavior details:
+
+- The directory containing the `<type>.json` info file is renamed to match the sanitized new title (via `sanitizeTitle`).
+- If the sanitized title does not change the directory name (e.g. only whitespace differences), the directory is left in place but the title inside the info file is still updated.
+- A conflict (target directory already exists) is resolved with the same logic used for new items
+- For folders the path map for all descendants is updated recursively so future path resolutions remain valid.
+- The info file (`collection.json`, `folder.json`, `request.json` or draft variant) is rewritten to persist the new title. Draft files are not modified unless they are the active representation (requests with `draft: true`).
+
+Edge cases:
+
+- Secrets files and body files remain in place; only the directory container changes.
+
+This guarantees that UI renames are reflected on disk and preserved across reloads.

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -167,4 +167,8 @@ export class MainEventService implements IEventService {
   ) {
     return await importService.importCollection(srcFilePath, targetDirPath, strategy, title);
   }
+
+  async rename(object: Folder | TrufosRequest, newTitle: string): Promise<void> {
+    await persistenceService.rename(object, newTitle);
+  }
 }

--- a/src/main/persistence/service/persistence-service.test.ts
+++ b/src/main/persistence/service/persistence-service.test.ts
@@ -15,6 +15,7 @@ import { RequestMethod } from 'shim/objects/request-method';
 import { VariableMap, VariableObject } from 'shim/objects/variables';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { generateDefaultCollection } from './default-collection';
+import { sanitizeTitle } from 'shim/fs';
 import { CollectionInfoFile, RequestInfoFile } from './info-files/latest';
 import {
   getInfoFileName,
@@ -96,7 +97,7 @@ describe('PersistenceService', () => {
 
   it('createDefaultCollectionIfNotExists() should not create if it already exists', async () => {
     // Arrange
-    const defaultCollectionImport = await import('./default-collection');
+    const defaultCollectionImport = await import('./default-collection.js');
     const generateDefaultCollectionSpy = vi.spyOn(
       defaultCollectionImport,
       'generateDefaultCollection'
@@ -113,7 +114,7 @@ describe('PersistenceService', () => {
 
   it('createDefaultCollectionIfNotExists() should create a new default collection if does not exist', async () => {
     // Arrange
-    const defaultCollectionImport = await import('./default-collection');
+    const defaultCollectionImport = await import('./default-collection.js');
     const defaultCollection = {} as Collection;
     vi.spyOn(defaultCollectionImport, 'generateDefaultCollection').mockReturnValueOnce(
       defaultCollection
@@ -151,23 +152,6 @@ describe('PersistenceService', () => {
     expect(await exists(path.join(collection.dirPath, folder.title, request.title))).toBe(false);
   });
 
-  it('rename() should rename the directory of a collection', async () => {
-    // Arrange
-    const oldDirPath = collection.dirPath;
-
-    await mkdir(oldDirPath, { recursive: true });
-
-    // Assert
-    expect(await exists(oldDirPath)).toBe(true);
-
-    // Act
-    await persistenceService.rename(collection, randomUUID());
-
-    // Assert
-    expect(await exists(collection.dirPath)).toBe(true);
-    expect(await exists(oldDirPath)).toBe(false);
-  });
-
   it('rename() should rename the directory of a folder', async () => {
     // Arrange
     const folder = getExampleFolder(collection.id);
@@ -186,6 +170,83 @@ describe('PersistenceService', () => {
     const newDirPath = path.join(collection.dirPath, folder.title);
     expect(await exists(newDirPath)).toBe(true);
     expect(await exists(oldDirPath)).toBe(false);
+  });
+
+  it('rename() should update info file title and keep children accessible after folder rename', async () => {
+    // Arrange
+    const folder = getExampleFolderWithChildren(collection.id);
+    collection.children.push(folder);
+    await persistenceService.saveCollectionRecursive(collection);
+    const oldChildDirPath = path.join(
+      collection.dirPath,
+      folder.title,
+      (folder.children[0] as Folder).title,
+      (folder.children[0] as Folder).children[0].title
+    );
+    expect(await exists(oldChildDirPath)).toBe(true);
+
+    const newTitle = folder.title + ' Renamed';
+
+    // Act
+    await persistenceService.rename(folder, newTitle);
+
+    // Assert directory moved
+    const newFolderDirPath = path.join(collection.dirPath, sanitizeTitle(newTitle));
+    expect(await exists(newFolderDirPath)).toBe(true);
+    expect(await exists(oldChildDirPath)).toBe(false); // old path gone
+
+    // Child request new path exists
+    const childRequest = (folder.children[0] as Folder).children[0];
+    const newChildRequestPath = path.join(
+      newFolderDirPath,
+      (folder.children[0] as Folder).title,
+      childRequest.title,
+      getInfoFileName('request')
+    );
+    expect(await exists(newChildRequestPath)).toBe(true);
+
+    // Info file title updated
+    const info = JSON.parse(
+      await readFile(path.join(newFolderDirPath, getInfoFileName('folder')), 'utf-8')
+    );
+    expect(info.title).toBe(newTitle);
+  });
+
+  it('rename() should persist new title for a request even if directory name unchanged', async () => {
+    // Arrange
+    const request = getExampleRequest(collection.id);
+    request.title = 'Same %Title%'; // sanitized stays same
+    collection.children.push(request);
+    await persistenceService.saveCollectionRecursive(collection);
+    const requestDirPath = path.join(collection.dirPath, sanitizeTitle(request.title));
+    expect(await exists(requestDirPath)).toBe(true);
+
+    // Act
+    await persistenceService.rename(request, 'Same $Title$'); // sanitized collides -> no dir rename, only title change
+
+    // Assert: file still exists
+    expect(await exists(requestDirPath)).toBe(true);
+    const info = JSON.parse(
+      await readFile(path.join(requestDirPath, getInfoFileName('request')), 'utf-8')
+    );
+    expect(info.title).toBe('Same $Title$');
+  });
+
+  it('rename() should append a number if target directory already exists', async () => {
+    // Arrange
+    const folderA = getExampleFolder(collection.id);
+    folderA.title = 'FolderA';
+    const folderB = getExampleFolder(collection.id);
+    folderB.title = 'FolderB';
+    collection.children.push(folderA, folderB);
+    await persistenceService.saveCollectionRecursive(collection);
+    const expectedDirPath = path.join(collection.dirPath, 'folderb-2');
+
+    // Act
+    await persistenceService.rename(folderA, 'FolderB');
+
+    // Assert
+    expect(await exists(expectedDirPath)).toBe(true);
   });
 
   it('saveRequest() should save the metadata of the request', async () => {

--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/modals/NamingModal.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/modals/NamingModal.tsx
@@ -11,6 +11,7 @@ import { Folder } from 'shim/objects/folder';
 import { Button } from '@/components/ui/button';
 import { useCollectionActions } from '@/state/collectionStore';
 import { Collection } from 'shim/objects/collection';
+import { isFolder } from 'shim/objects';
 
 export interface NamingModalProps {
   createType?: 'folder' | 'request';
@@ -25,16 +26,16 @@ export const NamingModal = ({ createType, trufosObject, isOpen, setOpen }: Namin
 
   const handleSave = async () => {
     if (createType) {
-      if (createType === 'folder') {
+      if (isFolder(trufosObject)) {
         addNewFolder(name, trufosObject.id);
       } else {
         addNewRequest(name, trufosObject.id);
       }
     } else {
-      if (trufosObject.type === 'folder') {
-        renameFolder(trufosObject.id, name);
+      if (isFolder(trufosObject)) {
+        await renameFolder(trufosObject.id, name);
       } else {
-        renameRequest(trufosObject.id, name);
+        await renameRequest(trufosObject.id, name);
       }
     }
     setOpen(false);

--- a/src/renderer/services/event/renderer-event-service.ts
+++ b/src/renderer/services/event/renderer-event-service.ts
@@ -63,4 +63,5 @@ export class RendererEventService implements IEventService {
   showOpenDialog = createEventMethod('showOpenDialog');
   listCollections = createEventMethod('listCollections');
   importCollection = createEventMethod('importCollection');
+  rename = createEventMethod('rename');
 }

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -198,22 +198,17 @@ export const useCollectionStore = create<CollectionState & CollectionStateAction
       });
     },
 
-    renameRequest(id: TrufosRequest['id'], title: string) {
-      set((state) => {
-        const request = selectRequest(state, id);
-        if (request == null) return;
-
-        // Create a new request object with the updated title
-        const updatedRequest = {
-          ...request,
-          title: title,
-        };
-
-        // Update the folders map with the new object
-        state.requests.set(id, updatedRequest);
-      });
+    renameRequest: async (id: TrufosRequest['id'], title: string) => {
       const request = selectRequest(get(), id);
-      eventService.saveRequest(request);
+      if (request == null) return;
+
+      await eventService.rename(request, title);
+      set((state) => {
+        state.requests.set(id, {
+          ...request,
+          title,
+        });
+      });
     },
 
     copyRequest: async (id) => {
@@ -329,22 +324,17 @@ export const useCollectionStore = create<CollectionState & CollectionStateAction
       });
     },
 
-    renameFolder(id: Folder['id'], title: string) {
-      set((state) => {
-        const folder = selectFolder(state, id);
-        if (folder == null) return;
+    renameFolder: async (id: Folder['id'], title: string) => {
+      const folder = selectFolder(get(), id);
+      if (folder == null) return;
 
-        // Create a new folder object with the updated title
-        const updatedFolder = {
+      await eventService.rename(folder, title);
+      set((state) => {
+        state.folders.set(id, {
           ...folder,
           title: title,
-        };
-
-        // Update the folders map with the new object
-        state.folders.set(id, updatedFolder);
+        });
       });
-      const folder = selectFolder(get(), id);
-      eventService.saveFolder(folder);
     },
 
     copyFolder: async (id) => {

--- a/src/renderer/state/interface/CollectionStateActions.ts
+++ b/src/renderer/state/interface/CollectionStateActions.ts
@@ -60,10 +60,10 @@ export interface CollectionStateActions {
 
   /**
    * Rename the request title
-   * @param id
-   * @param title
+   * @param id the request id
+   * @param title the new title of the request
    */
-  renameRequest(id: TrufosRequest['id'], title: string): void;
+  renameRequest(id: TrufosRequest['id'], title: string): Promise<void>;
 
   /**
    * Copy a request.
@@ -147,7 +147,7 @@ export interface CollectionStateActions {
    * @param id the folder id
    * @param title the new title of the folder
    */
-  renameFolder(id: Folder['id'], title: string): void;
+  renameFolder(id: Folder['id'], title: string): Promise<void>;
 
   /**
    * Copy a folder with all its children.

--- a/src/shim/event-service.ts
+++ b/src/shim/event-service.ts
@@ -152,4 +152,12 @@ export interface IEventService {
     strategy: ImportStrategy,
     title?: string
   ): Promise<Collection>;
+
+  /**
+   * Rename the given folder or request to the new title.
+   * This updates the title and the directory name if necessary.
+   * @param object The folder or request to rename.
+   * @param newTitle The new title.
+   */
+  rename(object: Folder | TrufosRequest, newTitle: string): Promise<void>;
 }


### PR DESCRIPTION
## Changes

- Correctly implement rename in backend which also checks for directory name collisions
- Add rename method to event service
- Use new rename method in frontend

## Testing

- Added automated tests
- Rename a request to the same name as another exitsing. The collision logic worked: `Renaming object at /Users/x/Library/Application Support/Trufos/default-collection/test to /Users/x/Library/Application Support/Trufos/default-collection/echo-2`

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [x] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
