### PR TITLE
feat(545): Add close Collection Button and closing Logic

### DIFF
--- a/src/renderer/components/sidebar/CollectionDropdown.tsx
+++ b/src/renderer/components/sidebar/CollectionDropdown.tsx
@@ -74,19 +74,21 @@ export default function CollectionDropdown() {
       collections.map(({ title, dirPath }, i) => (
         <DropdownMenuRadioItem key={i} value={dirPath}>
           <p className="flex-1 pr-2">{title}</p>
-          <button
-            onClick={async (e) => {
-              e.stopPropagation();
-              await eventService.closeCollection(dirPath);
-              setCollections((prev) => prev.filter((c) => c.dirPath !== dirPath));
-            }}
-            className={cn(
-              'text-popover-foreground flex h-6 w-6 items-center justify-center rounded-md opacity-0',
-              'hover:text-popover-foreground hover:bg-popover hover:opacity-100'
-            )}
-          >
-            <CloseIcon size={24} />
-          </button>
+          {i !== 0 && (
+            <button
+              onClick={async (e) => {
+                e.stopPropagation();
+                await eventService.closeCollection(dirPath);
+                setCollections((prev) => prev.filter((c) => c.dirPath !== dirPath));
+              }}
+              className={cn(
+                'text-popover-foreground flex h-6 w-6 items-center justify-center rounded-md opacity-0',
+                'hover:text-popover-foreground hover:bg-popover hover:opacity-100'
+              )}
+            >
+              <CloseIcon size={24} />
+            </button>
+          )}
         </DropdownMenuRadioItem>
       )),
     [collections]


### PR DESCRIPTION
## Changes

Adding the closing button with the given close icon. Use the same functionality as not found collections to close a collection To ensure proper updates, the collection's state is filtered.

With these changes, collections can be removed from the collections dropdown menu without deleting them from the system.
<img width="449" height="234" alt="image" src="https://github.com/user-attachments/assets/d2f98cda-3888-4382-b476-ef58f3f3e8a9" />

## Additional information
The button has been added to the left, as collection names can vary in length and therefore alignment to the right seemed unnecessary complicated. Truncating the collection names to a maximum length or limiting the dropdown menu size would simplify the closing function on the right side if required.

## Testing

Manual testing via closing and opening collections to check stability and reliability. It seems to be working. Sometimes, visual bugs may occur when the dropdown is updated, but I am not sure if that is related to the addition or the delay of the update.

## Checklist

- [x] Issue has been linked to this PR
- [ ] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
