### PR TITLE
fix(581): Variable Tooltip being cut off

### DIFF
--- a/src/renderer/components/shared/settings/monaco-settings.ts
+++ b/src/renderer/components/shared/settings/monaco-settings.ts
@@ -12,6 +12,7 @@ export const DEFAULT_MONACO_OPTIONS: Partial<editor.IStandaloneEditorConstructio
   },
   smoothScrolling: true,
   mouseWheelScrollSensitivity: 1,
+  fixedOverflowWidgets: true,
 };
 
 export const REQUEST_EDITOR_OPTIONS: Partial<editor.IStandaloneEditorConstructionOptions> = {


### PR DESCRIPTION
## Changes
Fixed an issue where the variable tooltip was being cut off when hovered.

## Testing
Manually tested by hovering over variables to verify the tooltip displays fully.
<img width="746" height="192" alt="Screenshot From 2025-10-21 08-22-28" src="https://github.com/user-attachments/assets/b90f31d4-eea2-46e2-8f14-5ac7eff2cc36" />



## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
