### PR TITLE
fix(579): Naming Modal

### DIFF
--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/modals/NamingModal.test.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/modals/NamingModal.test.tsx
@@ -1,0 +1,49 @@
+import { render, fireEvent } from '@testing-library/react';
+import { NamingModal } from './NamingModal';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+const addNewRequestMock = vi.fn();
+const addNewFolderMock = vi.fn();
+
+// Mock the collection actions hook (must come after mock function declarations)
+vi.mock('@/state/collectionStore', () => ({
+  useCollectionActions: () => ({
+    renameFolder: vi.fn(),
+    renameRequest: vi.fn(),
+    addNewRequest: addNewRequestMock,
+    addNewFolder: addNewFolderMock,
+  }),
+}));
+
+describe('NamingModal creation behavior', () => {
+  afterEach(() => {
+    addNewRequestMock.mockClear();
+    addNewFolderMock.mockClear();
+  });
+
+  it("calls addNewRequest when createType='request' even if parent object is a folder", () => {
+    const parentFolder = {
+      id: 'folder-1',
+      parentId: 'root',
+      type: 'folder' as const,
+      title: 'Parent Folder',
+      children: [] as any[],
+    };
+
+    const { getByPlaceholderText, getByText } = render(
+      <NamingModal
+        createType="request"
+        isOpen={true}
+        trufosObject={parentFolder}
+        setOpen={() => {}}
+      />
+    );
+
+    const input = getByPlaceholderText('Enter the request name') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'My Request' } });
+    fireEvent.click(getByText('Save'));
+
+    expect(addNewRequestMock).toHaveBeenCalledWith('My Request', 'folder-1');
+    expect(addNewFolderMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/modals/NamingModal.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/modals/NamingModal.tsx
@@ -11,7 +11,7 @@ import { Folder } from 'shim/objects/folder';
 import { Button } from '@/components/ui/button';
 import { useCollectionActions } from '@/state/collectionStore';
 import { Collection } from 'shim/objects/collection';
-import { isFolder } from 'shim/objects';
+import { isFolder, isRequest } from 'shim/objects';
 
 export interface NamingModalProps {
   createType?: 'folder' | 'request';
@@ -26,15 +26,15 @@ export const NamingModal = ({ createType, trufosObject, isOpen, setOpen }: Namin
 
   const handleSave = async () => {
     if (createType) {
-      if (isFolder(trufosObject)) {
+      if (createType === 'folder') {
         addNewFolder(name, trufosObject.id);
-      } else {
+      } else if (createType === 'request') {
         addNewRequest(name, trufosObject.id);
       }
     } else {
       if (isFolder(trufosObject)) {
         await renameFolder(trufosObject.id, name);
-      } else {
+      } else if (isRequest(trufosObject)) {
         await renameRequest(trufosObject.id, name);
       }
     }


### PR DESCRIPTION
## Changes

- Fix naming modal not correctly creating folders/requests (sorry this came in by a change from me earlier this week :D)

## Testing

- Tested the bug manually and created an automated UI test

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
