### PR TITLE
fix(442): Missing "method" in OAuth2ClientAuthorizationCodeFlowInformation

### DIFF
--- a/src/shim/objects/auth.ts
+++ b/src/shim/objects/auth.ts
@@ -41,15 +41,17 @@ export type OAuth2ClientCrentialsAuthorizationInformation = z.infer<
   typeof OAuth2ClientCrentialsAuthorizationInformation
 >;
 
-const OAuth2ClientAuthorizationCodeFlowInformation = Oauth2BaseAuthorizationInformation.extend({
-  authorizationUrl: z.string(),
-  callbackUrl: z.string(),
-  /** Generated if not provided */
-  state: z.string().optional(),
-  /** Default: true. Whether to keep browser session cache */
-  cache: z.boolean().optional(),
-});
-type OAuth2ClientAuthorizationCodeFlowInformation = z.infer<
+export const OAuth2ClientAuthorizationCodeFlowInformation =
+  Oauth2BaseAuthorizationInformation.extend({
+    method: z.literal(OAuth2Method.AUTHORIZATION_CODE),
+    authorizationUrl: z.string(),
+    callbackUrl: z.string(),
+    /** Generated if not provided */
+    state: z.string().optional(),
+    /** Default: true. Whether to keep browser session cache */
+    cache: z.boolean().optional(),
+  });
+export type OAuth2ClientAuthorizationCodeFlowInformation = z.infer<
   typeof OAuth2ClientAuthorizationCodeFlowInformation
 >;
 


### PR DESCRIPTION
## Changes

- add missing `method` literal in `OAuth2ClientAuthorizationCodeFlowInformation`

## Testing

- Opened a collection that uses auth code flow which could not be opened before

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
