### PR TITLE
636 - immer upgraded to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "electron-squirrel-startup": "^1.0.1",
-    "immer": "^10.2.0",
+    "immer": "^11.1.3",
     "lucide-react": "^0.556.0",
     "mime-types": "^3.0.2",
     "monaco-editor": "^0.53.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7175,10 +7175,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immer@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "immer@npm:10.2.0"
-  checksum: 10c0/35e66b0585b2aec4e85ae7a993f049405f170799ba89d79205bc3fdae2c5bdaa2b1d35f62803d8beee42b7e85c7f7315a6e93b6a5a510c5a46f03dbe63619e87
+"immer@npm:^11.1.3":
+  version: 11.1.3
+  resolution: "immer@npm:11.1.3"
+  checksum: 10c0/2d0bcb7946274bb99254b8129026da9579591569afdd4f29e5ef3ebf231375c7ab97c344ffbfc9eeabea27a2145623fca1287c17e3ebd007c8cdcfd82954eeb7
   languageName: node
   linkType: hard
 
@@ -11154,7 +11154,7 @@ __metadata:
     eslint-import-resolver-typescript: "npm:^4.4.4"
     eslint-plugin-import: "npm:^2.32.0"
     globals: "npm:^16.5.0"
-    immer: "npm:^10.2.0"
+    immer: "npm:^11.1.3"
     jsdom: "npm:^27.3.0"
     lucide-react: "npm:^0.556.0"
     memfs: "npm:^4.51.1"


### PR DESCRIPTION
Upgrades immer from ^10.2.0 to ^11.1.3

The original issue might have been in v11.0.0 and fixed in a patch release

fix #636 