### PR TITLE
fix(650): Non-secret variables are hidden

### DIFF
--- a/src/renderer/components/ui/secret-input.tsx
+++ b/src/renderer/components/ui/secret-input.tsx
@@ -6,7 +6,7 @@ interface SecretInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   secret?: boolean;
 }
 
-export function SecretInput({ secret = true, className, ...props }: SecretInputProps) {
+export function SecretInput({ secret = false, className, ...props }: SecretInputProps) {
   const [show, setShow] = useState(false);
 
   if (!secret) {


### PR DESCRIPTION


## Changes

The issue was in secret-input.tsx. The SecretInput component had secret = true as the default value. This caused variables without an explicit secret property to be hidden, even though their checkbox was unchecked.
Fixed by changing the default to secret = false.

## Testing

secret = true:
<img width="1329" height="783" alt="grafik" src="https://github.com/user-attachments/assets/fa94ca27-0ef0-478b-b829-c5cb9cdeefd6" />
secret = false:
<img width="1330" height="784" alt="grafik" src="https://github.com/user-attachments/assets/c996305e-20ee-4e4a-a66d-df377f3607a1" />


## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
