### PR TITLE
fix(674): Frontend Crash when Response has no Content-Type

### DIFF
--- a/src/renderer/components/mainWindow/bodyTabs/OutputTabs/BodyTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/OutputTabs/BodyTab.tsx
@@ -7,8 +7,6 @@ import { SimpleSelect } from '@/components/mainWindow/bodyTabs/InputTabs/SimpleS
 import { getMimeType } from './PrettyRenderer';
 import { ImagePrettyRenderer } from './ImagePrettyRenderer';
 import { TextualPrettyRenderer } from './TextualPrettyRenderer';
-import MonacoEditor from '@/lib/monaco/MonacoEditor';
-import { RESPONSE_EDITOR_OPTIONS } from '@/components/shared/settings/monaco-settings';
 import { DefaultRenderer } from './DefaultRenderer';
 import { useStateDerived } from '@/util/react-util';
 
@@ -43,7 +41,7 @@ export const BodyTab = () => {
 
   const renderContent = () => {
     if (outputType === OutputType.PRETTY) {
-      if (mimeType.startsWith('image/')) {
+      if (mimeType?.startsWith('image/')) {
         return <ImagePrettyRenderer response={response} />;
       } else {
         return <TextualPrettyRenderer response={response} />;


### PR DESCRIPTION
## Changes

- Handle potential null mimeType in `renderContent()` for the response body

## Testing

- Tested manually for a case where it crashed before

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
