### PR TITLE
#593 - Add isDefault attribute to collections

### DIFF
--- a/src/main/persistence/service/default-collection.ts
+++ b/src/main/persistence/service/default-collection.ts
@@ -13,6 +13,7 @@ export function generateDefaultCollection(dirPath: string): Collection {
   return {
     id: collectionId,
     type: 'collection',
+    isDefault: true,
     title: 'Default Collection',
     dirPath,
     variables: Object.fromEntries(

--- a/src/main/persistence/service/info-files/latest.test.ts
+++ b/src/main/persistence/service/info-files/latest.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { CollectionInfoFile, InfoFile, RequestInfoFile } from './latest';
+import { CollectionInfoFile, InfoFile, RequestInfoFile, toInfoFile } from './latest';
 import COLLECTION_INFO_FILE from '../../../../../examples/collection/collection.json';
 import REQUEST_INFO_FILE from '../../../../../examples/collection/echo/request.json';
+import { Collection, Folder, parseUrl, RequestBodyType, RequestMethod, TrufosRequest } from 'shim';
 
 describe('latest InfoFile schema', async () => {
   it('should accept a valid latest InfoFile', async () => {
@@ -20,5 +21,78 @@ describe('latest InfoFile schema', async () => {
 
     // Act & Assert
     await expect(invalidCollectionInfoFile).not.toBeOfSchemaAsync(CollectionInfoFile);
+  });
+});
+
+describe('toInfoFile', async () => {
+  it('should omit correct attributes for requsts', async () => {
+    // Arrange
+    const request: TrufosRequest = {
+      id: 'request-id',
+      parentId: 'parent-id',
+      type: 'request',
+      title: 'Request Title',
+      url: parseUrl('https://example.com'),
+      method: RequestMethod.GET,
+      headers: [],
+      body: {
+        type: RequestBodyType.TEXT,
+        mimeType: 'text/plain',
+        text: 'Hello, world!',
+      },
+      draft: false,
+    };
+    // Act
+    const actualInfoFile = toInfoFile(request);
+    // Assert
+    expect('type' in actualInfoFile).toBe(false);
+    expect('parentId' in actualInfoFile).toBe(false);
+    expect('draft' in actualInfoFile).toBe(false);
+  });
+
+  it('should omit correct attributes for collections', async () => {
+    // Arrange
+    const request: Collection = {
+      type: 'collection',
+      id: 'collection-id',
+      title: 'Request Title',
+      dirPath: '/path/to/collection',
+      isDefault: true,
+      variables: {},
+      environments: {},
+      children: [
+        {
+          type: 'folder',
+          id: 'folder-id',
+          parentId: 'collection-id',
+          title: 'Folder Title',
+          children: [],
+        },
+      ],
+    };
+    // Act
+    const actualInfoFile = toInfoFile(request);
+    // Assert
+    expect('type' in actualInfoFile).toBe(false);
+    expect('isDefault' in actualInfoFile).toBe(false);
+    expect('dirPath' in actualInfoFile).toBe(false);
+    expect('children' in actualInfoFile).toBe(false);
+  });
+
+  it('should omit correct attributes for folders', async () => {
+    // Arrange
+    const request: Folder = {
+      type: 'folder',
+      id: 'folder-id',
+      parentId: 'collection-id',
+      title: 'Folder Title',
+      children: [],
+    };
+    // Act
+    const actualInfoFile = toInfoFile(request);
+    // Assert
+    expect('type' in actualInfoFile).toBe(false);
+    expect('parentId' in actualInfoFile).toBe(false);
+    expect('children' in actualInfoFile).toBe(false);
   });
 });

--- a/src/main/persistence/service/info-files/latest.ts
+++ b/src/main/persistence/service/info-files/latest.ts
@@ -5,6 +5,7 @@ import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
 import { VariableMap } from 'shim/objects/variables';
 import { InfoFile, VERSION, RequestInfoFile, FolderInfoFile, CollectionInfoFile } from './v2-1-0';
+import { SettingsService } from '../settings-service';
 
 export { createGitIgnore, GIT_IGNORE_FILE_NAME } from './v2-0-0';
 export { VERSION, InfoFile, CollectionInfoFile, FolderInfoFile, RequestInfoFile } from './v2-1-0';
@@ -26,7 +27,7 @@ export function toInfoFile(object: TrufosObject): InfoFile {
     case 'request':
       return omit(infoFile, 'type', 'parentId', 'draft');
     case 'collection':
-      return omit(infoFile, 'type', 'dirPath', 'children');
+      return omit(infoFile, 'type', 'isDefault', 'dirPath', 'children');
     case 'folder':
       return omit(infoFile, 'type', 'parentId', 'children');
   }
@@ -40,6 +41,7 @@ export function fromCollectionInfoFile(
   delete infoFile.version;
   return Object.assign(infoFile, {
     type: 'collection' as const,
+    isDefault: SettingsService.DEFAULT_COLLECTION_DIR === dirPath,
     dirPath,
     children,
   });

--- a/src/main/persistence/service/persistence-service.test.ts
+++ b/src/main/persistence/service/persistence-service.test.ts
@@ -24,6 +24,7 @@ function getExampleCollection(): Collection {
     id: randomUUID(),
     type: 'collection',
     title: 'collection',
+    isDefault: false,
     children: [],
     variables: {},
     environments: {},

--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -385,6 +385,7 @@ export class PersistenceService {
       id: null,
       title,
       type: 'collection',
+      isDefault: false,
       dirPath,
       variables: {},
       environments: {},

--- a/src/renderer/components/sidebar/CollectionSettings.tsx
+++ b/src/renderer/components/sidebar/CollectionSettings.tsx
@@ -27,6 +27,7 @@ export interface CollectionSettingsProps {
 export const CollectionSettings = ({ trufosObject, isOpen, onClose }: CollectionSettingsProps) => {
   const [name, setName] = useState('');
   const [pathName, setPathName] = useState('');
+  const [isDefault, setIsDefault] = useState(false);
   const [collections, setCollections] = useState<CollectionBase[]>([]);
 
   const loadCollections = useCallback(async () => {
@@ -45,6 +46,10 @@ export const CollectionSettings = ({ trufosObject, isOpen, onClose }: Collection
 
   useEffect(() => {
     setPathName(trufosObject?.dirPath);
+  }, [isOpen]);
+
+  useEffect(() => {
+    setIsDefault(!!trufosObject?.isDefault);
   }, [isOpen]);
 
   const handleChangeName = (event: ChangeEvent<HTMLInputElement>) => {
@@ -112,21 +117,25 @@ export const CollectionSettings = ({ trufosObject, isOpen, onClose }: Collection
             </Button>
           </div>
 
-          <Separator />
+          {!isDefault && (
+            <>
+              <Separator />
 
-          <div className="flex items-center justify-between">
-            <span className="text-destructive font-medium">Close Collection</span>
+              <div className="flex items-center justify-between">
+                <span className="text-destructive font-medium">Close Collection</span>
 
-            <Button
-              variant={'destructive'}
-              size="sm"
-              disabled={collections.length === 1}
-              className="rounded-full"
-              onClick={handleCloseCollection}
-            >
-              Close
-            </Button>
-          </div>
+                <Button
+                  variant={'destructive'}
+                  size="sm"
+                  disabled={collections.length === 1}
+                  className="rounded-full"
+                  onClick={handleCloseCollection}
+                >
+                  Close
+                </Button>
+              </div>
+            </>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/shim/objects/collection.ts
+++ b/src/shim/objects/collection.ts
@@ -16,6 +16,7 @@ export type CollectionBase = z.infer<typeof CollectionBase>;
 /** A collection of folders and requests. */
 export const Collection = CollectionBase.extend({
   type: z.literal('collection'),
+  isDefault: z.boolean().optional(),
   variables: VariableMap,
   environments: EnvironmentMap,
   auth: AuthorizationInformationNoInherit.optional(),


### PR DESCRIPTION
## Changes

This PR introduces the `isDefault` attribute for collection objects which can be used to determine whether a given collection is the default collection. This will be used in the CollectionSettings modal to decide whether the `Close collection` button should be displayed or not. This PR resolves #593 

## Testing

Button is visible for non-default collections:

<img width="520" height="300" alt="image" src="https://github.com/user-attachments/assets/35e7d798-285b-4461-aabc-803f50ec6a1d" />

and invisible for default collections:

<img width="520" height="228" alt="image" src="https://github.com/user-attachments/assets/389a4ae8-bb40-4034-bfc1-27ec2388071f" />

## Checklist

- [x] Issue has been linked to this PR
- [ ] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [x] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
