### PR TITLE
feat(#672): Automatically set Content-Length header where possible

### DIFF
--- a/src/main/network/service/http-service.ts
+++ b/src/main/network/service/http-service.ts
@@ -67,10 +67,6 @@ export class HttpService {
 
     const { stream, size } = await this.readBody(request);
 
-    if (size != null && !('content-length' in headers)) {
-      headers['content-length'] = [size.toString()];
-    }
-
     // measure duration of the request
     const now = getSteadyTimestamp();
     const responseData = await undici.request(url, {
@@ -79,6 +75,7 @@ export class HttpService {
       headers: {
         ['content-type']: this.getContentType(request),
         ['authorization']: authorization,
+        ['content-length']: size?.toString(),
         ['user-agent']: `Trufos/${app.getVersion()} (${process.platform} ${process.getSystemVersion()}; ${process.arch})`,
         ...headers,
       },


### PR DESCRIPTION
Closes #672

### What does this change do?
Automatically sets the `Content-Length` header for file request bodies when the size is known.
If the user explicitly provides a `Content-Length`, it is respected and not overridden.

### How it works
- When the request body type is `FILE`
- And a file path is available
- And the user has not already set `Content-Length`
- The header is automatically added using the file size

### Tests
- `src/main/network/service/http-service.test.ts` ✅
- Before
<img width="1355" height="924" alt="Screenshot 2026-01-30 235243" src="https://github.com/user-attachments/assets/d940eea5-a76c-4d5a-b370-77ca08718327" />
After
<img width="1348" height="1013" alt="Screenshot 2026-01-30 235320" src="https://github.com/user-attachments/assets/72c3bed3-4ff2-4846-8c10-24025ca7f3fb" />


### Notes
- Other failing tests are in persistence/environment services and are unrelated.
- This PR only touches `HttpService` and keeps scope minimal.