### PR TITLE
fix(673) file picker losing selected file on tab switch by enabling…

### DIFF
--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTabFileInput.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTabFileInput.tsx
@@ -46,6 +46,7 @@ export default function BodyTabFileInput({ className }: BodyTabFileInputProps) {
     <div className={cn('h-full', className)}>
       <FilePicker
         entry={file}
+        controlled={true}
         onFileSelected={(file) => setRequestBodyFile(file)}
         onFileRemoved={removeRequestBodyFile}
       />


### PR DESCRIPTION
## Changes

- Pass `controlled={true}` to `FilePicker` in `BodyTabFileInput.tsx`
- This ensures the component uses the file from the store (via `entry` prop) instead of its internal state
- Previously, the internal state would reset to `null` on tab switch, causing the file to disappear visually


## Testing



https://github.com/user-attachments/assets/687b3b1d-8010-4757-8090-647bb4f40ad5






## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
