### PR TITLE
Align sidebar with Penpot design (#630)

### DIFF
--- a/src/renderer/components/sidebar/SidebarRequestList/ContextMenu/RequestContextMenu.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/ContextMenu/RequestContextMenu.tsx
@@ -18,8 +18,10 @@ export const RequestContextMenu = ({ requestId }: RequestContextMenuProps) => {
   const { deleteRequest } = useCollectionActions();
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger>
-        <CiMenuKebab className="cursor-pointer hover:fill-gray-900" />
+      <DropdownMenuTrigger asChild>
+        <div className="sidebar-row-menu flex h-4 w-4 items-center justify-center opacity-0 transition-opacity group-hover:opacity-100">
+          <CiMenuKebab className="cursor-pointer hover:fill-[var(--text-secondary)]" />
+        </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="bg-background">
         <DropdownMenuItem

--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/NavFolder.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/NavFolder.tsx
@@ -1,5 +1,5 @@
 import { Folder } from 'shim/objects/folder';
-import { SidebarMenuSubButton } from '@/components/ui/sidebar';
+import { SidebarGroup, SidebarMenuSubButton } from '@/components/ui/sidebar';
 import { FolderDropdown } from '@/components/sidebar/SidebarRequestList/Nav/Dropdown/FolderDropdown';
 import { selectFolder, useCollectionActions, useCollectionStore } from '@/state/collectionStore';
 import { cn } from '@/lib/utils';
@@ -7,6 +7,7 @@ import { FolderIcon, SmallArrow } from '@/components/icons';
 import { getIndentation } from '@/components/sidebar/SidebarRequestList/Nav/indentation';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 
 interface NavFolderProps {
   folderId: Folder['id'];
@@ -42,40 +43,57 @@ export const NavFolder = ({ folderId, depth = 0 }: NavFolderProps) => {
 
   return (
     <div ref={setNodeRef} style={style} {...attributes} className="relative">
-      <SidebarMenuSubButton
-        {...listeners}
-        className={cn(
-          'sidebar-request-list-item',
-          'flex',
-          'items-center',
-          'py-2',
-          'px-5',
-          'cursor-grab active:cursor-grabbing',
-          'gap-1',
-          'hover:bg-[#333333]',
-          getIndentation(depth)
-        )}
-        onClick={toggleFolder}
+      <Collapsible
+        asChild
+        open={isFolderOpen}
+        onOpenChange={(open) => (open ? setFolderOpen(folderId) : setFolderClose(folderId))}
+        className="group/collapsible"
       >
-        <div
-          className={cn(
-            'flex h-6 w-6 items-center justify-center',
-            'transition-transform duration-300 ease-in-out',
-            isFolderOpen ? 'rotate-0' : 'rotate-270'
-          )}
-        >
-          <SmallArrow size={24} />
-        </div>
+        <SidebarGroup className={cn('overflow-x-hidden p-0')}>
+          <CollapsibleTrigger asChild>
+            <SidebarMenuSubButton
+              {...listeners}
+              className={cn(
+                'sidebar-request-list-item',
+                'group',
+                'flex',
+                'items-center',
+                'py-2',
+                'px-5',
+                'cursor-grab active:cursor-grabbing',
+                'gap-1',
+                'hover:[background-color:#333333]',
+                getIndentation(depth)
+              )}
+            >
+              <div
+                className={cn(
+                  'h-6 w-6',
+                  'transition-transform duration-300 ease-in-out',
+                  isFolderOpen ? 'rotate-0' : 'rotate-270'
+                )}
+              >
+                <SmallArrow size={24} />
+              </div>
 
-        <div className="flex items-center gap-1">
-          <FolderIcon size={16} />
-          <span>{folder.title}</span>
-        </div>
+              <div className="flex min-w-0 flex-1 items-center gap-1">
+                <FolderIcon size={16} />
+                <span className="truncate">{folder.title}</span>
+              </div>
 
-        <div onClick={stopPropagation} onPointerDown={stopPropagation}>
-          <FolderDropdown folder={folder} />
-        </div>
-      </SidebarMenuSubButton>
+              <div
+                className="sidebar-row-menu flex h-4 w-4 items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
+                onClick={stopPropagation}
+                onPointerDown={stopPropagation}
+              >
+                <FolderDropdown folder={folder} />
+              </div>
+            </SidebarMenuSubButton>
+          </CollapsibleTrigger>
+
+          <CollapsibleContent />
+        </SidebarGroup>
+      </Collapsible>
     </div>
   );
 };

--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/NavFolder.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/NavFolder.tsx
@@ -7,7 +7,6 @@ import { FolderIcon, SmallArrow } from '@/components/icons';
 import { getIndentation } from '@/components/sidebar/SidebarRequestList/Nav/indentation';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 
 interface NavFolderProps {
   folderId: Folder['id'];
@@ -43,57 +42,47 @@ export const NavFolder = ({ folderId, depth = 0 }: NavFolderProps) => {
 
   return (
     <div ref={setNodeRef} style={style} {...attributes} className="relative">
-      <Collapsible
-        asChild
-        open={isFolderOpen}
-        onOpenChange={(open) => (open ? setFolderOpen(folderId) : setFolderClose(folderId))}
-        className="group/collapsible"
-      >
-        <SidebarGroup className={cn('overflow-x-hidden p-0')}>
-          <CollapsibleTrigger asChild>
-            <SidebarMenuSubButton
-              {...listeners}
-              className={cn(
-                'sidebar-request-list-item',
-                'group',
-                'flex',
-                'items-center',
-                'py-2',
-                'px-5',
-                'cursor-grab active:cursor-grabbing',
-                'gap-1',
-                'hover:[background-color:#333333]',
-                getIndentation(depth)
-              )}
-            >
-              <div
-                className={cn(
-                  'h-6 w-6',
-                  'transition-transform duration-300 ease-in-out',
-                  isFolderOpen ? 'rotate-0' : 'rotate-270'
-                )}
-              >
-                <SmallArrow size={24} />
-              </div>
+      <SidebarGroup className={cn('overflow-x-hidden p-0')}>
+        <SidebarMenuSubButton
+          {...listeners}
+          onClick={toggleFolder}
+          className={cn(
+            'sidebar-request-list-item',
+            'group',
+            'flex',
+            'items-center',
+            'py-2',
+            'px-5',
+            'cursor-grab active:cursor-grabbing',
+            'gap-1',
+            'hover:[background-color:#333333]',
+            getIndentation(depth)
+          )}
+        >
+          <div
+            className={cn(
+              'h-6 w-6',
+              'transition-transform duration-300 ease-in-out',
+              isFolderOpen ? 'rotate-0' : 'rotate-270'
+            )}
+          >
+            <SmallArrow size={24} />
+          </div>
 
-              <div className="flex min-w-0 flex-1 items-center gap-1">
-                <FolderIcon size={16} />
-                <span className="truncate">{folder.title}</span>
-              </div>
+          <div className="flex min-w-0 flex-1 items-center gap-1">
+            <FolderIcon size={16} />
+            <span className="flex-1 truncate">{folder.title}</span>
+          </div>
 
-              <div
-                className="sidebar-row-menu flex h-4 w-4 items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
-                onClick={stopPropagation}
-                onPointerDown={stopPropagation}
-              >
-                <FolderDropdown folder={folder} />
-              </div>
-            </SidebarMenuSubButton>
-          </CollapsibleTrigger>
-
-          <CollapsibleContent />
-        </SidebarGroup>
-      </Collapsible>
+          <div
+            className="sidebar-row-menu flex h-4 w-4 flex-shrink-0 items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
+            onClick={stopPropagation}
+            onPointerDown={stopPropagation}
+          >
+            <FolderDropdown folder={folder} />
+          </div>
+        </SidebarMenuSubButton>
+      </SidebarGroup>
     </div>
   );
 };

--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/NavRequest.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/NavRequest.tsx
@@ -33,7 +33,7 @@ export const NavRequest = ({ requestId, depth = 0 }: NavRequestProps) => {
       className="relative cursor-grab active:cursor-grabbing"
     >
       <SidebarMenuItem
-        className={`hover:bg-divider overflow-x-hidden ${isHighlighted && 'bg-divider'}`}
+        className={`group hover:bg-divider overflow-x-hidden ${isHighlighted && 'bg-divider'}`}
       >
         <SidebarMenuSubButton asChild isActive={requestId === selectedRequestId}>
           <RequestView requestId={requestId} depth={depth} />

--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/RequestView.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/RequestView.tsx
@@ -22,6 +22,7 @@ export const RequestView = ({ requestId, depth = 0 }: NavRequestProps) => {
           'sidebar-request-list-item',
           'cursor-pointer',
           'flex',
+          'min-w-0',
           'py-3.5',
           'gap-2',
           'w-full',
@@ -29,11 +30,13 @@ export const RequestView = ({ requestId, depth = 0 }: NavRequestProps) => {
         )}
         onClick={handleMouseEvent(() => setSelectedRequest(requestId))}
       >
-        <div className={cn('text-xs leading-3 font-bold', httpMethodColor(request.method))}>
+        <div className={cn('text-xs leading-3 font-normal', httpMethodColor(request.method))}>
           {request.method}
         </div>
 
-        <p className="text-xs leading-3">{request.title ?? request.url}</p>
+        <p className="font-lato truncate text-xs leading-3 text-[var(--text-secondary)]">
+          {request.title ?? request.url.base}
+        </p>
 
         <div onClick={(e) => e.stopPropagation()} onPointerDown={(e) => e.stopPropagation()}>
           <RequestDropdown request={request} />

--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/RequestView.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/RequestView.tsx
@@ -16,29 +16,41 @@ export const RequestView = ({ requestId, depth = 0 }: NavRequestProps) => {
   const request = useCollectionStore((state) => selectRequest(state, requestId));
 
   return (
-    <div className={cn('hover:bg-[#333333]')}>
+    <div className={cn('group hover:bg-[#333333]')}>
       <span
         className={cn(
           'sidebar-request-list-item',
+          'relative',
           'cursor-pointer',
           'flex',
           'min-w-0',
           'py-3.5',
-          'gap-2',
+          'gap-3',
           'w-full',
           getIndentation(depth)
         )}
         onClick={handleMouseEvent(() => setSelectedRequest(requestId))}
       >
-        <div className={cn('text-xs leading-3 font-normal', httpMethodColor(request.method))}>
+        <div
+          className={cn(
+            'flex-shrink-0 text-xs leading-3 font-normal',
+            httpMethodColor(request.method)
+          )}
+        >
           {request.method}
         </div>
 
-        <p className="font-lato truncate text-xs leading-3 text-[var(--text-secondary)]">
-          {request.title ?? request.url.base}
-        </p>
+        <div className="flex min-w-0 flex-1 items-center">
+          <span className="font-lato flex-1 truncate text-xs leading-3 text-[var(--text-secondary)]">
+            {request.title ?? request.url.base}
+          </span>
+        </div>
 
-        <div onClick={(e) => e.stopPropagation()} onPointerDown={(e) => e.stopPropagation()}>
+        <div
+          className="sidebar-row-menu flex h-4 w-4 flex-shrink-0 items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
+          onClick={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
           <RequestDropdown request={request} />
         </div>
       </span>


### PR DESCRIPTION
This PR aligns the sidebar with the official Penpot design to improve visual consistency and UX.

### Changes
- Updated sidebar typography to use **Lato** and secondary text color
- Set HTTP method labels to **font-weight 400**
- Made request and folder context menus (three dots) visible **only on hover**
- Fixed text truncation to prevent overlap with context menu
- Ensured consistent hover behavior between requests and folders
- Fixed a TypeScript issue where a non-renderable URL object could be passed as a React child (fallback now uses `url.base`)

### Result
- Sidebar now visually matches the Penpot design
- Cleaner UI with less visual noise
- Improved readability for long request and folder names

Demo: short screen recording attached showing hover behavior and text truncation.

https://github.com/user-attachments/assets/2e02fefb-00c1-49b3-9a32-395a6a33b4c6



Closes #630
