### PR TITLE
Fix/701 folders collapse on cross parent move

### DIFF
--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -440,8 +440,6 @@ export const createCollectionStore = (collection: Collection) => {
           // Persist new order to backend
           await eventService.reorderItem(newParent, itemId, newIndex);
         } else {
-          const oldParent = selectParent(state, item.parentId);
-
           // Update frontend state immediately to avoid visual snap-back
           set((state) => {
             // Remove item from old parent
@@ -454,10 +452,10 @@ export const createCollectionStore = (collection: Collection) => {
             newParentState.children.splice(newIndex, 0, updatedItem);
 
             // Update maps
-            if (isRequest(item)) {
-              state.requests.set(itemId, updatedItem as TrufosRequest);
+            if (isRequest(updatedItem)) {
+              state.requests.set(itemId, updatedItem);
             } else {
-              state.folders.set(itemId, updatedItem as Folder);
+              state.folders.set(itemId, updatedItem);
             }
 
             // Open the target folder so the moved item is visible
@@ -468,7 +466,12 @@ export const createCollectionStore = (collection: Collection) => {
 
           // Persist to backend
           if (isRequest(item)) await eventService.saveRequest(item);
-          await eventService.moveItem(item, oldParent, newParent, newIndex);
+          await eventService.moveItem(
+            item,
+            selectParent(state, item.parentId),
+            newParent,
+            newIndex
+          );
         }
       },
     }))


### PR DESCRIPTION
## Changes

When dragging a request into a different folder (cross-parent move), all open folders in the sidebar collapsed. This was caused by `moveItem `calling `initialize()` to reload the full collection from the backend, which reset `openFolders`.

The fix updates the frontend state directly instead of reloading:

- Remove the item from the old parent's children
- Insert the item into the new parent's children at the correct position
- Update the item's `parentId `in the requests/folders map
- Open the target folder so the moved item is visible
- Persist the change to the backend afterwards

This preserves `openFolders `entirely and also eliminates the visual snap-back animation that occurred when dragging upward.

## Testing

https://github.com/user-attachments/assets/bbf9ae0f-d843-4f81-9e8d-4a9fcb9a0af1


## Checklist

- [x] Issue has been linked to this PR
- [ ] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
