### PR TITLE
feat(711): Form Data Support in Backend

### DIFF
--- a/src/main/network/service/http-service.test.ts
+++ b/src/main/network/service/http-service.test.ts
@@ -1,7 +1,7 @@
 import { HttpService } from './http-service';
-import { MockAgent } from 'undici';
+import { MockAgent, FormData } from 'undici';
 import fs from 'node:fs';
-import { TrufosRequest } from 'shim/objects/request';
+import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { parseUrl } from 'shim/objects/url';
 import { randomUUID } from 'node:crypto';
 import { RequestMethod } from 'shim/objects/request-method';
@@ -11,6 +11,7 @@ import { AuthorizationType } from 'shim/objects';
 import { EnvironmentService } from 'main/environment/service/environment-service';
 import { TemplateReplaceStream } from 'template-replace-stream';
 import { ResponseBodyService } from 'main/network/service/response-body-service';
+import { FileSystemService } from 'main/filesystem/filesystem-service';
 import { PersistenceService } from 'main/persistence/service/persistence-service';
 import { ScriptingService } from 'main/scripting/scripting-service';
 import { Readable } from 'node:stream';
@@ -18,6 +19,7 @@ import { Readable } from 'node:stream';
 const mockAgent = new MockAgent({ connections: 1 });
 const environmentService = EnvironmentService.instance;
 const responseBodyService = ResponseBodyService.instance;
+const fileSystemService = FileSystemService.instance;
 
 describe('HttpService', () => {
   beforeAll(() => {
@@ -270,6 +272,148 @@ describe('HttpService', () => {
     expect(lastCall.headers['x-trace-id']).toEqual(['abc', 'def']);
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
+  });
+
+  it('fetchAsync() should send form data with text fields', async () => {
+    // Arrange
+    const url = new URL('https://example.com/formtext');
+    const mockClient = mockAgent.get(url.origin);
+    mockClient.intercept({ path: url.pathname, method: 'POST' }).reply(200, 'OK');
+    const httpService = new HttpService(mockAgent);
+    const request: TrufosRequest = {
+      id: randomUUID(),
+      parentId: randomUUID(),
+      type: 'request',
+      title: 'Form Data Text Request',
+      url: parseUrl(url.toString()),
+      method: RequestMethod.POST,
+      headers: [],
+      body: {
+        type: RequestBodyType.FORM_DATA,
+        fields: [
+          {
+            key: 'name',
+            value: { type: RequestBodyType.TEXT, text: 'John', mimeType: 'text/plain' },
+          },
+          {
+            key: 'email',
+            value: { type: RequestBodyType.TEXT, text: 'john@example.com', mimeType: 'text/plain' },
+          },
+        ],
+      },
+    };
+
+    // Act
+    await httpService.fetchAsync(request);
+
+    // Assert
+    const lastCall = mockAgent.getCallHistory()?.lastCall();
+    expect(lastCall).toBeDefined();
+    const body: FormData = lastCall.body as unknown as FormData;
+    expect(body).toBeInstanceOf(FormData);
+    expect(body.get('name')).toEqual('John');
+  });
+
+  it('fetchAsync() should send form data with file fields', async () => {
+    // Arrange
+    const url = new URL('https://example.com/formfile');
+    const mockClient = mockAgent.get(url.origin);
+    mockClient.intercept({ path: url.pathname, method: 'POST' }).reply(200, 'OK');
+    const httpService = new HttpService(mockAgent);
+
+    const fileContent = 'test file content';
+    const { Readable } = require('node:stream');
+    vi.spyOn(fileSystemService, 'readFile').mockResolvedValue(Readable.from([fileContent]));
+    vi.spyOn(fs, 'statSync').mockReturnValue({ size: fileContent.length } as fs.Stats);
+
+    const request: TrufosRequest = {
+      id: randomUUID(),
+      parentId: randomUUID(),
+      type: 'request',
+      title: 'Form Data File Request',
+      url: parseUrl(url.toString()),
+      method: RequestMethod.POST,
+      headers: [],
+      body: {
+        type: RequestBodyType.FORM_DATA,
+        fields: [
+          {
+            key: 'file',
+            value: {
+              type: RequestBodyType.FILE,
+              filePath: '/mock/test.txt',
+              fileName: 'test.txt',
+              mimeType: 'text/plain',
+            },
+          },
+        ],
+      },
+    };
+
+    // Act
+    await httpService.fetchAsync(request);
+
+    // Assert
+    const lastCall = mockAgent.getCallHistory().lastCall();
+    expect(lastCall).toBeDefined();
+    const body: FormData = lastCall.body as unknown as FormData;
+    expect(body).toBeInstanceOf(FormData);
+    const file = body.get('file') as Blob as File;
+    expect(file).toBeInstanceOf(File);
+    expect(await file.arrayBuffer()).toEqual(Buffer.from(fileContent).buffer);
+  });
+
+  it('fetchAsync() should replace variables in form data fields', async () => {
+    // Arrange
+    const variables = new Map([
+      ['username', 'alice'],
+      ['token', 'secret123'],
+    ]);
+    const spy = vi
+      .spyOn(environmentService, 'setVariablesInString')
+      .mockImplementation((input: string) =>
+        TemplateReplaceStream.replaceStringAsync(input, variables)
+      );
+
+    const url = new URL('https://example.com/formvars');
+    const mockClient = mockAgent.get(url.origin);
+    mockClient.intercept({ path: url.pathname, method: 'POST' }).reply(200, 'OK');
+    const httpService = new HttpService(mockAgent);
+
+    const request: TrufosRequest = {
+      id: randomUUID(),
+      parentId: randomUUID(),
+      type: 'request',
+      title: 'Form Data Variables Request',
+      url: parseUrl(url.toString()),
+      method: RequestMethod.POST,
+      headers: [],
+      body: {
+        type: RequestBodyType.FORM_DATA,
+        fields: [
+          {
+            key: 'user',
+            value: { type: RequestBodyType.TEXT, text: '{{ username }}', mimeType: 'text/plain' },
+          },
+          {
+            key: 'apikey',
+            value: { type: RequestBodyType.TEXT, text: '{{ token }}', mimeType: 'text/plain' },
+          },
+        ],
+      },
+    };
+
+    // Act
+    await httpService.fetchAsync(request);
+
+    // Assert
+    const lastCall = mockAgent.getCallHistory().lastCall();
+    expect(lastCall).toBeDefined();
+    const body: FormData = lastCall.body as unknown as FormData;
+    expect(body).toBeInstanceOf(FormData);
+    expect(spy).toHaveBeenCalled();
+    expect(body.get('user')).toEqual('alice');
+    expect(body.get('apikey')).toEqual('secret123');
   });
 
   it('fetchAsync() should execute scripts when provided', async () => {

--- a/src/main/network/service/http-service.ts
+++ b/src/main/network/service/http-service.ts
@@ -1,11 +1,11 @@
-import undici, { Agent, Dispatcher } from 'undici';
+import undici, { Agent, Dispatcher, FormData } from 'undici';
 import { getDurationFromNow, getSteadyTimestamp } from 'main/util/time-util';
 import { FileSystemService } from 'main/filesystem/filesystem-service';
 import { pipeline } from 'node:stream/promises';
 import fs from 'node:fs';
 import { Readable } from 'stream';
 import { EnvironmentService } from 'main/environment/service/environment-service';
-import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
+import { RequestBody, RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { buildUrl } from 'shim/objects/url';
 import { TrufosResponse } from 'shim/objects/response';
 import { PersistenceService } from 'main/persistence/service/persistence-service';
@@ -16,7 +16,7 @@ import process from 'node:process';
 import { ResponseBodyService } from 'main/network/service/response-body-service';
 import { ScriptingService } from 'main/scripting/scripting-service';
 import { ScriptType } from 'shim/scripting';
-import { text } from 'node:stream/consumers';
+import { text, buffer } from 'node:stream/consumers';
 
 const fileSystemService = FileSystemService.instance;
 const environmentService = EnvironmentService.instance;
@@ -25,11 +25,6 @@ const responseBodyService = ResponseBodyService.instance;
 const scriptingService = ScriptingService.instance;
 
 declare type HttpHeaders = Record<string, string[]>;
-
-type RequestBodyResult = {
-  stream: Readable | null;
-  size?: number;
-};
 
 /**
  * Singleton service for making HTTP requests
@@ -72,7 +67,7 @@ export class HttpService {
     // execute pre-request script if it exists
     await this.executeScript(request, ScriptType.PRE_REQUEST);
 
-    const { stream, size } = await this.readBody(request);
+    const [body, size] = await this.readBody(request);
 
     // measure duration of the request
     const now = getSteadyTimestamp();
@@ -80,13 +75,13 @@ export class HttpService {
       dispatcher: this._dispatcher,
       method: request.method,
       headers: {
-        ['content-type']: this.getContentType(request),
+        ['content-type']: this.getContentType(request.body),
         ['authorization']: authorization,
         ['content-length']: size?.toString(),
         ['user-agent']: `Trufos/${app.getVersion()} (${process.platform} ${process.getSystemVersion()}; ${process.arch})`,
         ...headers,
       },
-      body: stream,
+      body,
     });
 
     const duration = getDurationFromNow(now);
@@ -127,42 +122,65 @@ export class HttpService {
    * @param request request object
    * @returns request body as stream or null if there is no body
    */
-  private async readBody(request: TrufosRequest): Promise<RequestBodyResult> {
+  private async readBody(request: TrufosRequest): Promise<[(Readable | FormData)?, number?]> {
     if (request.body == null) {
-      return { stream: null };
+      return [];
     }
 
     switch (request.body.type) {
       case RequestBodyType.TEXT: {
         const requestBodyStream = await persistenceService.loadTextBodyOfRequest(request);
-        return {
-          stream: environmentService.setVariablesInStream(requestBodyStream) as Readable,
-        };
+        return [environmentService.setVariablesInStream(requestBodyStream) as Readable];
       }
       case RequestBodyType.FILE:
-        if (request.body.filePath == null) return { stream: null };
-        const stats = fs.statSync(request.body.filePath);
-        const fileStream = await fileSystemService.readFile(request.body.filePath);
-        return {
-          stream: fileStream,
-          size: stats.size,
-        };
+        return this.readFileBody(request.body.filePath);
+      case RequestBodyType.FORM_DATA:
+        const form = new FormData();
+        for (const field of request.body.fields) {
+          switch (field.value.type) {
+            case RequestBodyType.TEXT:
+              form.append(
+                field.key,
+                await environmentService.setVariablesInString(field.value.text ?? '')
+              );
+              break;
+            case RequestBodyType.FILE:
+              const [body] = await this.readFileBody(field.value.filePath);
+              if (body != null) {
+                const fileName = field.value.fileName ?? 'file';
+                const mimeType = this.getContentType(field.value);
+                const value = new File([await buffer(body)], fileName, { type: mimeType });
+                form.append(field.key, value);
+              }
+              break;
+            default:
+              throw new Error('Unknown form data field value type');
+          }
+        }
+        return [form];
       default:
         throw new Error('Unknown body type');
     }
   }
 
+  private async readFileBody(filePath?: string): Promise<[Readable?, number?]> {
+    if (filePath == null) return [];
+    return [await fileSystemService.readFile(filePath), fs.statSync(filePath).size];
+  }
+
   /**
    * Get the content type of the request body
-   * @param request request object
+   * @param body request body
    */
-  private getContentType(request: TrufosRequest) {
-    if (request.body != null) {
-      switch (request.body.type) {
+  private getContentType(body?: RequestBody) {
+    if (body != null) {
+      switch (body.type) {
         case RequestBodyType.TEXT:
-          return request.body.mimeType ?? 'text/plain';
+          return body.mimeType ?? 'text/plain';
         case RequestBodyType.FILE:
-          return request.body.mimeType ?? 'application/octet-stream';
+          return body.mimeType ?? 'application/octet-stream';
+        case RequestBodyType.FORM_DATA:
+          return 'multipart/form-data';
       }
     }
   }

--- a/src/shim/objects/request.ts
+++ b/src/shim/objects/request.ts
@@ -9,6 +9,7 @@ export const TEXT_BODY_FILE_NAME = 'request-body.txt';
 export enum RequestBodyType {
   TEXT = 'text',
   FILE = 'file',
+  FORM_DATA = 'form-data',
 }
 
 export const TextBody = z.object({
@@ -29,7 +30,18 @@ export const FileBody = z.object({
 });
 export type FileBody = z.infer<typeof FileBody>;
 
-export const RequestBody = z.discriminatedUnion('type', [TextBody, FileBody]);
+export enum FormDataValueType {
+  TEXT = 'text',
+  FILE = 'file',
+}
+
+export const FormDataBody = z.object({
+  type: z.literal(RequestBodyType.FORM_DATA),
+  data: z.record(z.string(), z.discriminatedUnion('type', [TextBody, FileBody])),
+});
+export type FormDataBody = z.infer<typeof FormDataBody>;
+
+export const RequestBody = z.discriminatedUnion('type', [TextBody, FileBody, FormDataBody]);
 export type RequestBody = z.infer<typeof RequestBody>;
 
 export const TrufosRequest = z.object({

--- a/src/shim/objects/request.ts
+++ b/src/shim/objects/request.ts
@@ -14,7 +14,7 @@ export enum RequestBodyType {
 
 export const TextBody = z.object({
   type: z.literal(RequestBodyType.TEXT),
-  /** The body content as a string. Used for importing from third party collections. Usually, this is only stored on the file system */
+  /** The body content as a string. Used for form data content or importing from third party collections. Usually, this is only stored on the file system */
   text: z.string().optional(),
   /** The mime type of the file content, e.g. "application/json". May include an encoding */
   mimeType: z.string(),
@@ -37,7 +37,12 @@ export enum FormDataValueType {
 
 export const FormDataBody = z.object({
   type: z.literal(RequestBodyType.FORM_DATA),
-  data: z.record(z.string(), z.discriminatedUnion('type', [TextBody, FileBody])),
+  fields: z.array(
+    z.object({
+      key: z.string(),
+      value: z.discriminatedUnion('type', [TextBody, FileBody]),
+    })
+  ),
 });
 export type FormDataBody = z.infer<typeof FormDataBody>;
 


### PR DESCRIPTION
## Changes

- Add new request body type `"form-data"` that supports multiple key-value pairs
- Form data values may be plaintext or a file
- Increase info file version to prevent unexpected errors when using form data requests on older app versions

## Testing

- Automated tests only since it's currently on backend only

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [ ] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
