### PR TITLE
fix: prevent creating collection without selecting directory

### DIFF
--- a/src/renderer/view/CollectionCreate.tsx
+++ b/src/renderer/view/CollectionCreate.tsx
@@ -49,9 +49,6 @@ export const CollectionCreate: React.FC<{
   const isCreationDisabled = !title || !targetEntry?.path;
 
   const createCollection = async () => {
-    if (!targetEntry?.path) {
-      return;
-    }
     try {
       await changeCollection(await eventService.createCollection(targetEntry.path, title));
 

--- a/src/renderer/view/CollectionCreate.tsx
+++ b/src/renderer/view/CollectionCreate.tsx
@@ -46,9 +46,12 @@ export const CollectionCreate: React.FC<{
   const [targetEntry, setTargetEntry] = useState<DroppedEntryInfo>();
   const [title, setTitle] = useState<string>('');
 
-  const isCreationDisabled = !title && !targetEntry?.name;
+  const isCreationDisabled = !title || !targetEntry?.path;
 
   const createCollection = async () => {
+    if (!targetEntry?.path) {
+      return;
+    }
     try {
       await changeCollection(await eventService.createCollection(targetEntry.path, title));
 


### PR DESCRIPTION
Fixes #726

Previously, the "Create Collection" button could be enabled even when no directory was selected due to incorrect validation logic.
Now the button is disabled unless both a title and a directory are provided.