### PR TITLE
Feat/720 form data frontend

### DIFF
--- a/src/main/network/service/http-service.ts
+++ b/src/main/network/service/http-service.ts
@@ -179,8 +179,6 @@ export class HttpService {
           return body.mimeType ?? 'text/plain';
         case RequestBodyType.FILE:
           return body.mimeType ?? 'application/octet-stream';
-        case RequestBodyType.FORM_DATA:
-          return 'multipart/form-data';
       }
     }
   }

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTab.tsx
@@ -11,6 +11,7 @@ import {
 import { selectRequest, useCollectionActions, useCollectionStore } from '@/state/collectionStore';
 import BodyTabFileInput from './BodyTabFileInput';
 import BodyTabTextInput from './BodyTabTextInput';
+import { FormDataTab } from './FormDataTab';
 import { Button } from '@/components/ui/button';
 import { WandSparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -20,7 +21,8 @@ export const BodyTab = () => {
     useCollectionActions();
 
   const requestBody = useCollectionStore((state) => selectRequest(state).body);
-  const language = mimeTypeToLanguage(requestBody.mimeType);
+  const mimeType = 'mimeType' in requestBody ? requestBody.mimeType : undefined;
+  const language = mimeTypeToLanguage(mimeType);
   const canFormatRequestBody = isFormattableLanguage(language);
 
   const changeBodyType = useCallback(
@@ -32,10 +34,17 @@ export const BodyTab = () => {
         case RequestBodyType.FILE:
           setRequestBody({ type });
           break;
+        case RequestBodyType.FORM_DATA:
+          setRequestBody({ type, fields: [] });
+          break;
       }
     },
     [setRequestBody]
   );
+
+  if (requestBody.type === RequestBodyType.FORM_DATA) {
+    return <FormDataTab />;
+  }
 
   return (
     <div className="flex h-full flex-col gap-4">
@@ -48,6 +57,7 @@ export const BodyTab = () => {
               items={[
                 [RequestBodyType.TEXT, 'Text'],
                 [RequestBodyType.FILE, 'File'],
+                [RequestBodyType.FORM_DATA, 'Form Data'],
               ]}
             />
             {requestBody.type === RequestBodyType.TEXT && (
@@ -78,7 +88,7 @@ export const BodyTab = () => {
         <Divider />
       </div>
 
-      {requestBody?.type === RequestBodyType.FILE ? (
+      {requestBody.type === RequestBodyType.FILE ? (
         <BodyTabFileInput className="px-4 pb-2" />
       ) : (
         <BodyTabTextInput className="pr-4" language={language} />

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTab.tsx
@@ -42,10 +42,6 @@ export const BodyTab = () => {
     [setRequestBody]
   );
 
-  if (requestBody.type === RequestBodyType.FORM_DATA) {
-    return <FormDataTab />;
-  }
-
   return (
     <div className="flex h-full flex-col gap-4">
       <div className="space-y-2 px-4 pt-2">
@@ -88,7 +84,9 @@ export const BodyTab = () => {
         <Divider />
       </div>
 
-      {requestBody.type === RequestBodyType.FILE ? (
+      {requestBody.type === RequestBodyType.FORM_DATA ? (
+        <FormDataTab />
+      ) : requestBody.type === RequestBodyType.FILE ? (
         <BodyTabFileInput className="px-4 pb-2" />
       ) : (
         <BodyTabTextInput className="pr-4" language={language} />

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/FormDataTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/FormDataTab.tsx
@@ -1,0 +1,243 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { AddIcon, DeleteIcon, SwapIcon } from '@/components/icons';
+import { ActiveCheckbox } from '@/components/shared/ActiveCheckbox';
+import { Divider } from '@/components/shared/Divider';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  selectFormDataFields,
+  useCollectionActions,
+  useCollectionStore,
+} from '@/state/collectionStore';
+import { FileBody, RequestBodyType } from 'shim/objects/request';
+import FilePicker from '@/components/ui/file-picker';
+import { DroppedEntryInfo } from '@/components/ui/file-drop-zone';
+import { Paperclip, Type } from 'lucide-react';
+import { SimpleSelect } from '@/components/mainWindow/bodyTabs/InputTabs/SimpleSelect';
+
+export const FormDataTab = () => {
+  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
+
+  const { addFormDataField, updateFormDataField, deleteSelectedFormDataFields, setRequestBody } =
+    useCollectionActions();
+  const fields = useCollectionStore(selectFormDataFields);
+
+  const toggleSelect = (index: number) => {
+    setSelectedIndices((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  };
+
+  const toggleSelectAll = () => {
+    if (selectedIndices.size === fields.length) {
+      setSelectedIndices(new Set());
+    } else {
+      setSelectedIndices(new Set(fields.map((_, i) => i)));
+    }
+  };
+
+  const handleDeleteSelected = () => {
+    deleteSelectedFormDataFields(selectedIndices);
+    setSelectedIndices(new Set());
+  };
+
+  const toggleFieldType = (index: number) => {
+    const field = fields[index];
+    if (field.value.type === RequestBodyType.TEXT) {
+      updateFormDataField(index, { value: { type: RequestBodyType.FILE } });
+    } else {
+      updateFormDataField(index, { value: { type: RequestBodyType.TEXT, mimeType: 'text/plain' } });
+    }
+  };
+
+  const changeBodyType = (type: RequestBodyType) => {
+    if (type === RequestBodyType.TEXT) setRequestBody({ type, mimeType: 'text/plain' });
+    else if (type === RequestBodyType.FILE) setRequestBody({ type });
+  };
+
+  return (
+    <div className="relative h-full p-4">
+      <div className="absolute top-4 right-4 left-4 z-10">
+        <div className="flex justify-between">
+          <div className="flex items-center gap-2">
+            <SimpleSelect<RequestBodyType>
+              value={RequestBodyType.FORM_DATA}
+              onValueChange={changeBodyType}
+              items={[
+                [RequestBodyType.TEXT, 'Text'],
+                [RequestBodyType.FILE, 'File'],
+                [RequestBodyType.FORM_DATA, 'Form Data'],
+              ]}
+            />
+            <Button
+              className="h-fit gap-1 hover:bg-transparent"
+              size="sm"
+              variant="ghost"
+              onClick={addFormDataField}
+            >
+              <AddIcon />
+              Add Field
+            </Button>
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              className="h-fit gap-2 hover:bg-transparent"
+              size="sm"
+              variant="ghost"
+              onClick={toggleSelectAll}
+            >
+              <ActiveCheckbox
+                checked={fields.length > 0 && selectedIndices.size === fields.length}
+                onChange={toggleSelectAll}
+              />
+              Select All
+            </Button>
+
+            <Button
+              className="h-fit gap-3 hover:bg-transparent"
+              size="sm"
+              variant="ghost"
+              onClick={handleDeleteSelected}
+              disabled={selectedIndices.size === 0}
+            >
+              <DeleteIcon size={24} />
+              Delete Selected
+            </Button>
+          </div>
+        </div>
+
+        <Divider className="mt-2" />
+      </div>
+
+      <div className="absolute top-17 right-4 bottom-4 left-4">
+        <div className="pb-4">
+          <Table className="w-full table-auto">
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-auto">
+                  <div className="flex items-center gap-3">
+                    Name
+                    <SwapIcon size={18} viewBox="9 7 15 18" />
+                  </div>
+                </TableHead>
+                <TableHead className="w-full">
+                  <div className="flex items-center gap-3">
+                    Value
+                    <SwapIcon size={18} viewBox="9 7 15 18" />
+                  </div>
+                </TableHead>
+                <TableHead className="w-12">Type</TableHead>
+                <TableHead className="w-10" />
+              </TableRow>
+            </TableHeader>
+
+            <TableBody>
+              {fields.map((field, index) => {
+                const isFileType = field.value.type === RequestBodyType.FILE;
+                const fileValue = isFileType ? (field.value as FileBody) : null;
+                return (
+                  <TableRow key={index}>
+                    <TableCell className="w-1/3 break-all">
+                      <input
+                        type="text"
+                        value={field.key}
+                        onChange={(e) => updateFormDataField(index, { key: e.target.value })}
+                        className="w-full bg-transparent outline-hidden"
+                        placeholder="Name"
+                      />
+                    </TableCell>
+
+                    <TableCell className="w-full break-all">
+                      {isFileType ? (
+                        <FilePicker
+                          variant="compact"
+                          controlled
+                          entry={
+                            fileValue?.filePath
+                              ? ({
+                                  name: fileValue.fileName,
+                                  path: fileValue.filePath,
+                                  isDirectory: false,
+                                } as DroppedEntryInfo)
+                              : null
+                          }
+                          onFileSelected={(file) =>
+                            updateFormDataField(index, {
+                              value: {
+                                type: RequestBodyType.FILE,
+                                filePath: file.path,
+                                fileName: file.name,
+                                mimeType: file.mimeType,
+                              },
+                            })
+                          }
+                          onFileRemoved={() =>
+                            updateFormDataField(index, { value: { type: RequestBodyType.FILE } })
+                          }
+                        />
+                      ) : (
+                        <input
+                          type="text"
+                          value={
+                            field.value.type === RequestBodyType.TEXT
+                              ? (field.value.text ?? '')
+                              : ''
+                          }
+                          onChange={(e) =>
+                            updateFormDataField(index, {
+                              value: {
+                                type: RequestBodyType.TEXT,
+                                text: e.target.value,
+                                mimeType: 'text/plain',
+                              },
+                            })
+                          }
+                          className="w-full bg-transparent outline-hidden"
+                          placeholder="Value"
+                        />
+                      )}
+                    </TableCell>
+
+                    <TableCell className="w-12">
+                      <div className="flex items-center justify-center">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="text-text-secondary hover:text-accent-primary h-6 w-6 hover:bg-transparent"
+                          onClick={() => toggleFieldType(index)}
+                          title={isFileType ? 'Switch to text' : 'Switch to file'}
+                        >
+                          {isFileType ? <Paperclip size={14} /> : <Type size={14} />}
+                        </Button>
+                      </div>
+                    </TableCell>
+
+                    <TableCell className="w-10">
+                      <div className="flex items-center justify-center">
+                        <ActiveCheckbox
+                          checked={selectedIndices.has(index)}
+                          onChange={() => toggleSelect(index)}
+                        />
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/FormDataTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/FormDataTab.tsx
@@ -102,9 +102,10 @@ export const FormDataTab = () => {
                       />
                     </TableCell>
 
-                    <TableCell className="w-full break-all">
+                    <TableCell className="w-full max-w-0 overflow-hidden">
                       {isFileType ? (
                         <FilePicker
+                          className="w-full"
                           variant="compact"
                           controlled
                           entry={

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/FormDataTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/FormDataTab.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { AddIcon, DeleteIcon, SwapIcon } from '@/components/icons';
 import { ActiveCheckbox } from '@/components/shared/ActiveCheckbox';
@@ -11,45 +10,19 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import {
-  selectFormDataFields,
-  useCollectionActions,
-  useCollectionStore,
-} from '@/state/collectionStore';
+import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
 import { FileBody, RequestBodyType } from 'shim/objects/request';
 import FilePicker from '@/components/ui/file-picker';
 import { DroppedEntryInfo } from '@/components/ui/file-drop-zone';
 import { Paperclip, Type } from 'lucide-react';
-import { SimpleSelect } from '@/components/mainWindow/bodyTabs/InputTabs/SimpleSelect';
 
 export const FormDataTab = () => {
-  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
-
-  const { addFormDataField, updateFormDataField, deleteSelectedFormDataFields, setRequestBody } =
+  const { addFormDataField, updateFormDataField, deleteFormDataField, setRequestBody } =
     useCollectionActions();
-  const fields = useCollectionStore(selectFormDataFields);
-
-  const toggleSelect = (index: number) => {
-    setSelectedIndices((prev) => {
-      const next = new Set(prev);
-      if (next.has(index)) next.delete(index);
-      else next.add(index);
-      return next;
-    });
-  };
-
-  const toggleSelectAll = () => {
-    if (selectedIndices.size === fields.length) {
-      setSelectedIndices(new Set());
-    } else {
-      setSelectedIndices(new Set(fields.map((_, i) => i)));
-    }
-  };
-
-  const handleDeleteSelected = () => {
-    deleteSelectedFormDataFields(selectedIndices);
-    setSelectedIndices(new Set());
-  };
+  const fields = useCollectionStore((state) => {
+    const body = state.requests.get(state.selectedRequestId)?.body;
+    return body?.type === RequestBodyType.FORM_DATA ? body.fields : [];
+  });
 
   const toggleFieldType = (index: number) => {
     const field = fields[index];
@@ -60,25 +33,11 @@ export const FormDataTab = () => {
     }
   };
 
-  const changeBodyType = (type: RequestBodyType) => {
-    if (type === RequestBodyType.TEXT) setRequestBody({ type, mimeType: 'text/plain' });
-    else if (type === RequestBodyType.FILE) setRequestBody({ type });
-  };
-
   return (
     <div className="relative h-full p-4">
       <div className="absolute top-4 right-4 left-4 z-10">
         <div className="flex justify-between">
           <div className="flex items-center gap-2">
-            <SimpleSelect<RequestBodyType>
-              value={RequestBodyType.FORM_DATA}
-              onValueChange={changeBodyType}
-              items={[
-                [RequestBodyType.TEXT, 'Text'],
-                [RequestBodyType.FILE, 'File'],
-                [RequestBodyType.FORM_DATA, 'Form Data'],
-              ]}
-            />
             <Button
               className="h-fit gap-1 hover:bg-transparent"
               size="sm"
@@ -90,31 +49,16 @@ export const FormDataTab = () => {
             </Button>
           </div>
 
-          <div className="flex gap-2">
-            <Button
-              className="h-fit gap-2 hover:bg-transparent"
-              size="sm"
-              variant="ghost"
-              onClick={toggleSelectAll}
-            >
-              <ActiveCheckbox
-                checked={fields.length > 0 && selectedIndices.size === fields.length}
-                onChange={toggleSelectAll}
-              />
-              Select All
-            </Button>
-
-            <Button
-              className="h-fit gap-3 hover:bg-transparent"
-              size="sm"
-              variant="ghost"
-              onClick={handleDeleteSelected}
-              disabled={selectedIndices.size === 0}
-            >
-              <DeleteIcon size={24} />
-              Delete Selected
-            </Button>
-          </div>
+          <Button
+            className="h-fit gap-1 hover:bg-transparent"
+            size="sm"
+            variant="ghost"
+            onClick={() => setRequestBody({ type: RequestBodyType.FORM_DATA, fields: [] })}
+            disabled={fields.length === 0}
+          >
+            <DeleteIcon />
+            Delete All
+          </Button>
         </div>
 
         <Divider className="mt-2" />
@@ -138,7 +82,7 @@ export const FormDataTab = () => {
                   </div>
                 </TableHead>
                 <TableHead className="w-12">Type</TableHead>
-                <TableHead className="w-10" />
+                <TableHead className="w-16">Actions</TableHead>
               </TableRow>
             </TableHeader>
 
@@ -223,12 +167,20 @@ export const FormDataTab = () => {
                       </div>
                     </TableCell>
 
-                    <TableCell className="w-10">
-                      <div className="flex items-center justify-center">
+                    <TableCell className="w-16 text-right">
+                      <div className="flex items-center justify-center gap-2">
                         <ActiveCheckbox
-                          checked={selectedIndices.has(index)}
-                          onChange={() => toggleSelect(index)}
+                          checked={field.isActive}
+                          onChange={(checked) => updateFormDataField(index, { isActive: checked })}
                         />
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="hover:text-accent-primary active:text-accent-secondary h-6 w-6 hover:bg-transparent"
+                          onClick={() => deleteFormDataField(index)}
+                        >
+                          <DeleteIcon />
+                        </Button>
                       </div>
                     </TableCell>
                   </TableRow>

--- a/src/renderer/state/collectionStore.formData.test.ts
+++ b/src/renderer/state/collectionStore.formData.test.ts
@@ -145,6 +145,4 @@ describe('FormData store actions', () => {
       expect(store.getState().requests.get(REQ_ID)!.draft).toBe(true);
     });
   });
-
-
 });

--- a/src/renderer/state/collectionStore.formData.test.ts
+++ b/src/renderer/state/collectionStore.formData.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createCollectionStore, selectFormDataFields } from './collectionStore';
+import { Collection } from 'shim/objects/collection';
+import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
+import { RequestMethod } from 'shim/objects/request-method';
+
+vi.mock('@/lib/ipc-stream', () => ({
+  IpcPushStream: { open: vi.fn() },
+}));
+
+vi.mock('@/state/helper/collectionUtil', () => ({
+  isRequestInAParentFolder: vi.fn(() => false),
+}));
+
+vi.mock('@/services/event/renderer-event-service', () => ({
+  RendererEventService: { instance: {} },
+}));
+
+vi.mock('@/state/variableStore', () => ({
+  useVariableStore: { getState: () => ({ initialize: vi.fn() }) },
+}));
+
+vi.mock('@/state/environmentStore', () => ({
+  useEnvironmentStore: { getState: () => ({ initialize: vi.fn() }) },
+}));
+
+const makeRequest = (id: string, parentId: string): TrufosRequest =>
+  ({
+    id,
+    parentId,
+    type: 'request',
+    title: id,
+    url: { base: 'http://localhost', query: [] },
+    method: RequestMethod.GET,
+    headers: [],
+    body: { type: RequestBodyType.FORM_DATA, fields: [] },
+    draft: false,
+  }) as unknown as TrufosRequest;
+
+const makeCollection = (id: string, children: TrufosRequest[] = []): Collection =>
+  ({
+    id,
+    parentId: null,
+    type: 'collection',
+    title: 'Test',
+    dirPath: '/test',
+    children,
+    variables: [],
+    environments: [],
+  }) as unknown as Collection;
+
+const REQ_ID = 'req-1';
+const COL_ID = 'col-1';
+
+const buildStore = () => {
+  const request = makeRequest(REQ_ID, COL_ID);
+  const collection = makeCollection(COL_ID, [request]);
+  const store = createCollectionStore(collection);
+  store.getState().setSelectedRequest(REQ_ID);
+  return store;
+};
+
+describe('FormData store actions', () => {
+  let store: ReturnType<typeof buildStore>;
+
+  beforeEach(() => {
+    store = buildStore();
+  });
+
+  describe('addFormDataField', () => {
+    it('adds a new text field with empty key', () => {
+      store.getState().addFormDataField();
+
+      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
+      expect(fields).toHaveLength(1);
+      expect(fields[0].key).toBe('');
+      expect(fields[0].value.type).toBe(RequestBodyType.TEXT);
+    });
+
+    it('sets draft when adding a field', () => {
+      store.getState().addFormDataField();
+
+      expect(store.getState().requests.get(REQ_ID)!.draft).toBe(true);
+    });
+
+    it('accumulates multiple fields', () => {
+      store.getState().addFormDataField();
+      store.getState().addFormDataField();
+      store.getState().addFormDataField();
+
+      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
+      expect(fields).toHaveLength(3);
+    });
+  });
+
+  describe('updateFormDataField', () => {
+    beforeEach(() => {
+      store.getState().addFormDataField();
+    });
+
+    it('updates the key of an existing field', () => {
+      store.getState().updateFormDataField(0, { key: 'username' });
+
+      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
+      expect(fields[0].key).toBe('username');
+    });
+
+    it('updates value to file type', () => {
+      store.getState().updateFormDataField(0, {
+        value: { type: RequestBodyType.FILE, filePath: '/tmp/file.txt', fileName: 'file.txt' },
+      });
+
+      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
+      expect(fields[0].value.type).toBe(RequestBodyType.FILE);
+      expect(fields[0].value.filePath).toBe('/tmp/file.txt');
+    });
+
+    it('sets draft when updating a field', () => {
+      store.getState().updateFormDataField(0, { key: 'changed' });
+
+      expect(store.getState().requests.get(REQ_ID)!.draft).toBe(true);
+    });
+  });
+
+  describe('deleteFormDataField', () => {
+    beforeEach(() => {
+      store.getState().addFormDataField();
+      store.getState().updateFormDataField(0, { key: 'first' });
+      store.getState().addFormDataField();
+      store.getState().updateFormDataField(1, { key: 'second' });
+    });
+
+    it('removes the field at the given index', () => {
+      store.getState().deleteFormDataField(0);
+
+      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
+      expect(fields).toHaveLength(1);
+      expect(fields[0].key).toBe('second');
+    });
+
+    it('sets draft when deleting a field', () => {
+      store.getState().deleteFormDataField(0);
+
+      expect(store.getState().requests.get(REQ_ID)!.draft).toBe(true);
+    });
+  });
+
+  describe('deleteSelectedFormDataFields', () => {
+    beforeEach(() => {
+      ['a', 'b', 'c', 'd'].forEach((key, i) => {
+        store.getState().addFormDataField();
+        store.getState().updateFormDataField(i, { key });
+      });
+    });
+
+    it('removes only the selected indices', () => {
+      store.getState().deleteSelectedFormDataFields(new Set([0, 2]));
+
+      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
+      expect(fields.map((f: any) => f.key)).toEqual(['b', 'd']);
+    });
+
+    it('removes all fields when all indices are selected', () => {
+      store.getState().deleteSelectedFormDataFields(new Set([0, 1, 2, 3]));
+
+      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
+      expect(fields).toHaveLength(0);
+    });
+
+    it('keeps all fields when selection is empty', () => {
+      store.getState().deleteSelectedFormDataFields(new Set());
+
+      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
+      expect(fields).toHaveLength(4);
+    });
+  });
+
+  describe('selectFormDataFields', () => {
+    it('returns empty array when body is not form-data', () => {
+      store.getState().setRequestBody({ type: RequestBodyType.TEXT, mimeType: 'text/plain' });
+
+      const fields = selectFormDataFields(store.getState() as any);
+      expect(fields).toEqual([]);
+    });
+
+    it('returns fields array when body is form-data', () => {
+      store.getState().addFormDataField();
+      store.getState().updateFormDataField(0, { key: 'foo' });
+
+      const fields = selectFormDataFields(store.getState() as any);
+      expect(fields).toHaveLength(1);
+      expect(fields[0].key).toBe('foo');
+    });
+  });
+});

--- a/src/renderer/state/collectionStore.formData.test.ts
+++ b/src/renderer/state/collectionStore.formData.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createCollectionStore, selectFormDataFields } from './collectionStore';
+import { createCollectionStore } from './collectionStore';
 import { Collection } from 'shim/objects/collection';
 import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { RequestMethod } from 'shim/objects/request-method';
@@ -68,12 +68,13 @@ describe('FormData store actions', () => {
   });
 
   describe('addFormDataField', () => {
-    it('adds a new text field with empty key', () => {
+    it('adds a new text field with empty key, active by default', () => {
       store.getState().addFormDataField();
 
       const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
       expect(fields).toHaveLength(1);
       expect(fields[0].key).toBe('');
+      expect(fields[0].isActive).toBe(true);
       expect(fields[0].value.type).toBe(RequestBodyType.TEXT);
     });
 
@@ -145,51 +146,5 @@ describe('FormData store actions', () => {
     });
   });
 
-  describe('deleteSelectedFormDataFields', () => {
-    beforeEach(() => {
-      ['a', 'b', 'c', 'd'].forEach((key, i) => {
-        store.getState().addFormDataField();
-        store.getState().updateFormDataField(i, { key });
-      });
-    });
 
-    it('removes only the selected indices', () => {
-      store.getState().deleteSelectedFormDataFields(new Set([0, 2]));
-
-      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
-      expect(fields.map((f: any) => f.key)).toEqual(['b', 'd']);
-    });
-
-    it('removes all fields when all indices are selected', () => {
-      store.getState().deleteSelectedFormDataFields(new Set([0, 1, 2, 3]));
-
-      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
-      expect(fields).toHaveLength(0);
-    });
-
-    it('keeps all fields when selection is empty', () => {
-      store.getState().deleteSelectedFormDataFields(new Set());
-
-      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
-      expect(fields).toHaveLength(4);
-    });
-  });
-
-  describe('selectFormDataFields', () => {
-    it('returns empty array when body is not form-data', () => {
-      store.getState().setRequestBody({ type: RequestBodyType.TEXT, mimeType: 'text/plain' });
-
-      const fields = selectFormDataFields(store.getState() as any);
-      expect(fields).toEqual([]);
-    });
-
-    it('returns fields array when body is form-data', () => {
-      store.getState().addFormDataField();
-      store.getState().updateFormDataField(0, { key: 'foo' });
-
-      const fields = selectFormDataFields(store.getState() as any);
-      expect(fields).toHaveLength(1);
-      expect(fields[0].key).toBe('foo');
-    });
-  });
 });

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -301,7 +301,10 @@ export const createCollectionStore = (collection: Collection) => {
         set((state) => {
           const body = selectRequest(state).body;
           if (body.type !== RequestBodyType.FORM_DATA) return;
-          body.fields.push({ key: '', value: { type: RequestBodyType.TEXT, mimeType: 'text/plain' } });
+          body.fields.push({
+            key: '',
+            value: { type: RequestBodyType.TEXT, mimeType: 'text/plain' },
+          });
           selectRequest(state).draft = true;
         }),
 

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -11,7 +11,7 @@ import { isCollection, isRequest, TrufosObject } from 'shim/objects';
 import { AuthorizationInformation } from 'shim/objects';
 import { Collection } from 'shim/objects/collection';
 import { Folder } from 'shim/objects/folder';
-import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
+import { FormDataBody, RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { RequestMethod } from 'shim/objects/request-method';
 import { createStore } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
@@ -175,6 +175,7 @@ export const createCollectionStore = (collection: Collection) => {
 
       setRequestBodyMimeType(mimeType?: string) {
         const { body } = selectRequest(get());
+        if (body.type !== RequestBodyType.TEXT) return;
         const { setRequestBody } = get();
         setRequestBody({ ...body, mimeType });
       },
@@ -293,6 +294,39 @@ export const createCollectionStore = (collection: Collection) => {
         set((state) => {
           const queryParam = selectQueryParam(state, index);
           queryParam.isActive = isActive ?? !queryParam.isActive;
+          selectRequest(state).draft = true;
+        }),
+
+      addFormDataField: () =>
+        set((state) => {
+          const body = selectRequest(state).body;
+          if (body.type !== RequestBodyType.FORM_DATA) return;
+          body.fields.push({ key: '', value: { type: RequestBodyType.TEXT, mimeType: 'text/plain' } });
+          selectRequest(state).draft = true;
+        }),
+
+      updateFormDataField: (index, updatedField) =>
+        set((state) => {
+          const body = selectRequest(state).body;
+          if (body.type !== RequestBodyType.FORM_DATA) return;
+          body.fields[index] = { ...body.fields[index], ...updatedField };
+          selectRequest(state).draft = true;
+        }),
+
+      deleteFormDataField: (index) =>
+        set((state) => {
+          const body = selectRequest(state).body;
+          if (body.type !== RequestBodyType.FORM_DATA) return;
+          body.fields.splice(index, 1);
+          selectRequest(state).draft = true;
+        }),
+
+      deleteSelectedFormDataFields: (indices: Set<number>) =>
+        set((state) => {
+          const body = selectRequest(state).body as FormDataBody;
+          if (body.type !== RequestBodyType.FORM_DATA) return;
+          const remaining = body.fields.filter((_, i) => !indices.has(i));
+          body.fields.splice(0, body.fields.length, ...remaining);
           selectRequest(state).draft = true;
         }),
 
@@ -502,6 +536,10 @@ const selectObject = <T extends TrufosObject>(state: CollectionState, object: T)
 
 export const selectHeaders = (state: CollectionState) => selectRequest(state).headers;
 export const selectQueryParams = (state: CollectionState) => selectRequest(state).url.query;
+export const selectFormDataFields = (state: CollectionState) => {
+  const body = selectRequest(state).body;
+  return body.type === RequestBodyType.FORM_DATA ? body.fields : [];
+};
 const selectQueryParam = (state: CollectionState, index: number) =>
   selectQueryParams(state)?.[index];
 export const selectRequest = (state: CollectionState, requestId?: TrufosRequest['id']) =>

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -11,7 +11,7 @@ import { isCollection, isRequest, TrufosObject } from 'shim/objects';
 import { AuthorizationInformation } from 'shim/objects';
 import { Collection } from 'shim/objects/collection';
 import { Folder } from 'shim/objects/folder';
-import { FormDataBody, RequestBodyType, TrufosRequest } from 'shim/objects/request';
+import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { RequestMethod } from 'shim/objects/request-method';
 import { createStore } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
@@ -299,38 +299,33 @@ export const createCollectionStore = (collection: Collection) => {
 
       addFormDataField: () =>
         set((state) => {
-          const body = selectRequest(state).body;
+          const request = selectRequest(state);
+          const body = request.body;
           if (body.type !== RequestBodyType.FORM_DATA) return;
           body.fields.push({
             key: '',
+            isActive: true,
             value: { type: RequestBodyType.TEXT, mimeType: 'text/plain' },
           });
-          selectRequest(state).draft = true;
+          request.draft = true;
         }),
 
       updateFormDataField: (index, updatedField) =>
         set((state) => {
-          const body = selectRequest(state).body;
+          const request = selectRequest(state);
+          const body = request.body;
           if (body.type !== RequestBodyType.FORM_DATA) return;
           body.fields[index] = { ...body.fields[index], ...updatedField };
-          selectRequest(state).draft = true;
+          request.draft = true;
         }),
 
       deleteFormDataField: (index) =>
         set((state) => {
-          const body = selectRequest(state).body;
+          const request = selectRequest(state);
+          const body = request.body;
           if (body.type !== RequestBodyType.FORM_DATA) return;
           body.fields.splice(index, 1);
-          selectRequest(state).draft = true;
-        }),
-
-      deleteSelectedFormDataFields: (indices: Set<number>) =>
-        set((state) => {
-          const body = selectRequest(state).body as FormDataBody;
-          if (body.type !== RequestBodyType.FORM_DATA) return;
-          const remaining = body.fields.filter((_, i) => !indices.has(i));
-          body.fields.splice(0, body.fields.length, ...remaining);
-          selectRequest(state).draft = true;
+          request.draft = true;
         }),
 
       setDraftFlag: () =>
@@ -539,10 +534,7 @@ const selectObject = <T extends TrufosObject>(state: CollectionState, object: T)
 
 export const selectHeaders = (state: CollectionState) => selectRequest(state).headers;
 export const selectQueryParams = (state: CollectionState) => selectRequest(state).url.query;
-export const selectFormDataFields = (state: CollectionState) => {
-  const body = selectRequest(state).body;
-  return body.type === RequestBodyType.FORM_DATA ? body.fields : [];
-};
+
 const selectQueryParam = (state: CollectionState, index: number) =>
   selectQueryParams(state)?.[index];
 export const selectRequest = (state: CollectionState, requestId?: TrufosRequest['id']) =>

--- a/src/renderer/state/interface/CollectionStateActions.ts
+++ b/src/renderer/state/interface/CollectionStateActions.ts
@@ -134,14 +134,13 @@ export interface CollectionStateActions {
    */
   setQueryParamActive(index: number, active?: boolean): void;
 
-  /**
-   * Set the draft flag on the currently selected request
-   */
   addFormDataField(): void;
   updateFormDataField(index: number, updatedField: Partial<FormDataField>): void;
   deleteFormDataField(index: number): void;
-  deleteSelectedFormDataFields(indices: Set<number>): void;
 
+  /**
+   * Set the draft flag on the currently selected request
+   */
   setDraftFlag(): void;
 
   /**

--- a/src/renderer/state/interface/CollectionStateActions.ts
+++ b/src/renderer/state/interface/CollectionStateActions.ts
@@ -3,8 +3,10 @@ import { Collection } from 'shim/objects/collection';
 import { Folder } from 'shim/objects/folder';
 import { TrufosHeader } from 'shim/objects/headers';
 import { TrufosQueryParam } from 'shim/objects/query-param';
-import { RequestBody, TrufosRequest } from 'shim/objects/request';
+import { FormDataBody, RequestBody, TrufosRequest } from 'shim/objects/request';
 import { ScriptType } from 'shim/scripting';
+
+type FormDataField = FormDataBody['fields'][number];
 
 export interface CollectionStateActions {
   initialize(collection: Collection): void;
@@ -135,6 +137,11 @@ export interface CollectionStateActions {
   /**
    * Set the draft flag on the currently selected request
    */
+  addFormDataField(): void;
+  updateFormDataField(index: number, updatedField: Partial<FormDataField>): void;
+  deleteFormDataField(index: number): void;
+  deleteSelectedFormDataFields(indices: Set<number>): void;
+
   setDraftFlag(): void;
 
   /**

--- a/src/renderer/test-setup.ts
+++ b/src/renderer/test-setup.ts
@@ -1,5 +1,8 @@
 import { cleanup } from '@testing-library/react';
 import { vi, afterEach } from 'vitest';
+import { enableMapSet } from 'immer';
+
+enableMapSet();
 
 /**
  * Global test setup for renderer tests

--- a/src/shim/objects/request.ts
+++ b/src/shim/objects/request.ts
@@ -40,6 +40,7 @@ export const FormDataBody = z.object({
   fields: z.array(
     z.object({
       key: z.string(),
+      isActive: z.boolean(),
       value: z.discriminatedUnion('type', [TextBody, FileBody]),
     })
   ),


### PR DESCRIPTION
## Changes
Implements the Form Data body type in the request editor frontend (#720).

- 
- Added FormDataTab component with a table UI for managing form-data fields (key/value pairs)
- Each field supports two value types: text (free input) and file (file picker), toggleable per row via an icon button
- Wired FORM_DATA body type into BodyTab — selecting "Form Data" from the body type dropdown renders FormDataTab
- Added store actions: addFormDataField, updateFormDataField, deleteFormDataField, deleteSelectedFormDataFields
- Added selectFormDataFields selector to the collection store

## Testing

Automated tests:

collectionStore.formData.test.ts — 13 unit tests covering all FormData store actions and the selector
Added Immer MapSet plugin to test setup (required for store tests using Map)

https://github.com/user-attachments/assets/45fe2070-4cf0-4271-98d6-02bb0b7b5bb1


## Checklist

- [x] Issue has been linked to this PR
- [ ] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
