### PR TITLE
feat(722): Modification Timestamp on Trufos Objects

### DIFF
--- a/src/main/persistence/service/default-collection.ts
+++ b/src/main/persistence/service/default-collection.ts
@@ -13,6 +13,7 @@ export function generateDefaultCollection(dirPath: string): Collection {
   return {
     id: collectionId,
     type: 'collection',
+    lastModified: Date.now(),
     isDefault: true,
     title: 'Default Collection',
     dirPath,
@@ -34,6 +35,7 @@ export function generateDefaultCollection(dirPath: string): Collection {
         id: exampleRequestId,
         parentId: collectionId,
         type: 'request',
+        lastModified: Date.now(),
         title: 'Example Request',
         url: parseUrl('https://echo.free.beeceptor.com'),
         method: RequestMethod.GET,
@@ -48,12 +50,14 @@ export function generateDefaultCollection(dirPath: string): Collection {
         id: folderId,
         parentId: collectionId,
         type: 'folder',
+        lastModified: Date.now(),
         title: 'Example Folder',
         children: [
           {
             id: anotherRequestId,
             parentId: folderId,
             type: 'request',
+            lastModified: Date.now(),
             title: 'Another Request',
             url: parseUrl('https://exxeta.com/'),
             method: RequestMethod.GET,

--- a/src/main/persistence/service/info-files/latest.ts
+++ b/src/main/persistence/service/info-files/latest.ts
@@ -25,22 +25,24 @@ export function toInfoFile(object: TrufosObject): InfoFile {
 
   switch (infoFile.type) {
     case 'request':
-      return omit(infoFile, 'type', 'parentId', 'draft');
+      return omit(infoFile, 'type', 'lastModified', 'parentId', 'draft');
     case 'collection':
-      return omit(infoFile, 'type', 'isDefault', 'dirPath', 'children');
+      return omit(infoFile, 'type', 'lastModified', 'isDefault', 'dirPath', 'children');
     case 'folder':
-      return omit(infoFile, 'type', 'parentId', 'children');
+      return omit(infoFile, 'type', 'lastModified', 'parentId', 'children');
   }
 }
 
 export function fromCollectionInfoFile(
   infoFile: CollectionInfoFile,
+  lastModified: number,
   dirPath: string,
   children: Collection['children']
 ): Collection {
   delete infoFile.version;
   return Object.assign(infoFile, {
     type: 'collection' as const,
+    lastModified,
     isDefault: SettingsService.DEFAULT_COLLECTION_DIR === dirPath,
     dirPath,
     children,
@@ -49,20 +51,22 @@ export function fromCollectionInfoFile(
 
 export function fromFolderInfoFile(
   infoFile: FolderInfoFile,
+  lastModified: number,
   parentId: Folder['parentId'],
   children: Folder['children']
 ): Folder {
   delete infoFile.version;
-  return Object.assign(infoFile, { type: 'folder' as const, parentId, children });
+  return Object.assign(infoFile, { type: 'folder' as const, lastModified, parentId, children });
 }
 
 export function fromRequestInfoFile(
   infoFile: RequestInfoFile,
+  lastModified: number,
   parentId: TrufosRequest['parentId'],
   draft: boolean
 ): TrufosRequest {
   delete infoFile.version;
-  return Object.assign(infoFile, { type: 'request' as const, parentId, draft });
+  return Object.assign(infoFile, { type: 'request' as const, lastModified, parentId, draft });
 }
 
 /**

--- a/src/main/persistence/service/persistence-service.test.ts
+++ b/src/main/persistence/service/persistence-service.test.ts
@@ -23,6 +23,7 @@ function getExampleCollection(): Collection {
   return {
     id: randomUUID(),
     type: 'collection',
+    lastModified: Date.now(),
     title: 'collection',
     isDefault: false,
     children: [],
@@ -36,6 +37,7 @@ function getExampleFolder(parentId: string): Folder {
   return {
     id: randomUUID(),
     type: 'folder',
+    lastModified: Date.now(),
     title: 'folder',
     children: [],
     parentId,
@@ -63,6 +65,7 @@ function getExampleRequest(parentId: string): TrufosRequest {
     url: { base: 'https://example.com', query: [] },
     headers: [],
     type: 'request',
+    lastModified: Date.now(),
     title: 'request',
     draft: false,
     parentId,
@@ -859,6 +862,14 @@ describe('PersistenceService', () => {
     expect(result.children).toHaveLength(1);
     result.children[0].id = folder.id;
     result.children[0].parentId = collection.id;
+
+    expect(result.children[0].lastModified).toBeTypeOf('number');
+    delete result.children[0].lastModified;
+    delete collection.children[0].lastModified;
+
+    expect(result.lastModified).toBeTypeOf('number');
+    delete result.lastModified;
+    delete collection.lastModified;
     expect(result).toEqual(collection);
   });
 
@@ -873,6 +884,9 @@ describe('PersistenceService', () => {
     const result = await persistenceService.loadCollection(collection.dirPath, false);
 
     // Assert
+    delete result.lastModified;
+    delete collection.lastModified;
+
     expect(result).toEqual(Object.assign(collection, { children: [] }));
   });
 

--- a/src/main/persistence/service/persistence-service.test.ts
+++ b/src/main/persistence/service/persistence-service.test.ts
@@ -1,6 +1,6 @@
 import { exists, USER_DATA_DIR } from 'main/util/fs-util';
 import { randomUUID } from 'node:crypto';
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import fs, { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 import { Collection } from 'shim/objects/collection';
@@ -8,7 +8,7 @@ import { Folder } from 'shim/objects/folder';
 import { RequestBodyType, TEXT_BODY_FILE_NAME, TrufosRequest } from 'shim/objects/request';
 import { RequestMethod } from 'shim/objects/request-method';
 import { VariableMap, VariableObject } from 'shim/objects/variables';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { generateDefaultCollection } from './default-collection';
 import { sanitizeTitle } from 'shim/fs';
 import { CollectionInfoFile, RequestInfoFile, GIT_IGNORE_FILE_NAME } from './info-files/latest';
@@ -18,6 +18,7 @@ import { DRAFT_DIR_NAME, SECRETS_FILE_NAME } from 'main/persistence/constants';
 const persistenceService = PersistenceService.instance;
 
 const collectionDirPath = path.join(USER_DATA_DIR, 'default-collection');
+const FIXED_MTIME_MS = 1700000000000;
 
 function getExampleCollection(): Collection {
   return {
@@ -84,9 +85,20 @@ async function streamToString(stream: Readable) {
 
 describe('PersistenceService', () => {
   let collection: Collection;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(FIXED_MTIME_MS);
     collection = getExampleCollection();
     await mkdir(collection.dirPath, { recursive: true });
+    const originalStat = fs.stat.bind(fs);
+    vi.spyOn(fs, 'stat').mockImplementation(async (...args: Parameters<typeof fs.stat>) => {
+      const stats = await originalStat(...args);
+      return { ...stats, mtimeMs: FIXED_MTIME_MS } as Awaited<ReturnType<typeof fs.stat>>;
+    });
   });
 
   it('createDefaultCollectionIfNotExists() should not create if it already exists', async () => {
@@ -863,13 +875,8 @@ describe('PersistenceService', () => {
     result.children[0].id = folder.id;
     result.children[0].parentId = collection.id;
 
-    expect(result.children[0].lastModified).toBeTypeOf('number');
-    delete result.children[0].lastModified;
-    delete collection.children[0].lastModified;
-
-    expect(result.lastModified).toBeTypeOf('number');
-    delete result.lastModified;
-    delete collection.lastModified;
+    expect(result.children[0].lastModified).toBe(FIXED_MTIME_MS);
+    expect(result.lastModified).toBe(FIXED_MTIME_MS);
     expect(result).toEqual(collection);
   });
 
@@ -884,10 +891,8 @@ describe('PersistenceService', () => {
     const result = await persistenceService.loadCollection(collection.dirPath, false);
 
     // Assert
-    delete result.lastModified;
-    delete collection.lastModified;
-
-    expect(result).toEqual(Object.assign(collection, { children: [] }));
+    expect(result.lastModified).toBe(FIXED_MTIME_MS);
+    expect(result).toEqual({ ...collection, children: [] });
   });
 
   it('loadCollection() should merge ~secrets.json.bin with collection.json', async () => {

--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -606,23 +606,13 @@ export class PersistenceService {
     }
   }
 
-  private readInfoFile(
-    dirPath: string,
-    type: Collection['type']
-  ): Promise<CollectionInfoFile & { lastModified: number }>;
-  private readInfoFile(
-    dirPath: string,
-    type: Folder['type']
-  ): Promise<FolderInfoFile & { lastModified: number }>;
-  private readInfoFile(
-    dirPath: string,
-    type: TrufosRequest['type']
-  ): Promise<RequestInfoFile & { lastModified: number }>;
+  private readInfoFile(dirPath: string, type: Collection['type']): Promise<CollectionInfoFile>;
+  private readInfoFile(dirPath: string, type: Folder['type']): Promise<FolderInfoFile>;
+  private readInfoFile(dirPath: string, type: TrufosRequest['type']): Promise<RequestInfoFile>;
 
   private async readInfoFile<T extends TrufosObject>(dirPath: string, type: T['type']) {
     const filePath = path.join(dirPath, this.getInfoFileName(type));
     try {
-      const fileStats = await fs.stat(filePath);
       const info = assign(
         JSON.parse(await fs.readFile(filePath, 'utf8')) as InfoFile,
         await this.loadSecrets(dirPath)

--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -471,6 +471,7 @@ export class PersistenceService {
       id: null,
       title,
       type: 'collection',
+      lastModified: Date.now(),
       isDefault: false,
       dirPath,
       variables: {},
@@ -496,7 +497,9 @@ export class PersistenceService {
 
     this.idToPathMap.set(info.id, dirPath);
     const children = recursive ? await this.loadChildren(info.id, dirPath) : [];
-    return fromCollectionInfoFile(info, dirPath, children);
+
+    const lastModified = await this.getInfoFileModifactionTime(dirPath, type);
+    return fromCollectionInfoFile(info, lastModified, dirPath, children);
   }
 
   private async loadRequest(
@@ -509,7 +512,11 @@ export class PersistenceService {
     const info = await this.readInfoFile(draft ? this.getDraftDirPath(dirPath) : dirPath, type);
     this.idToPathMap.set(info.id, dirPath);
 
-    return fromRequestInfoFile(info, parentId, draft);
+    const lastModified = await this.getInfoFileModifactionTime(
+      draft ? this.getDraftDirPath(dirPath) : dirPath,
+      type
+    );
+    return fromRequestInfoFile(info, lastModified, parentId, draft);
   }
 
   private async loadFolder(parentId: string, dirPath: string): Promise<Folder> {
@@ -518,7 +525,17 @@ export class PersistenceService {
     this.idToPathMap.set(info.id, dirPath);
     const children = await this.loadChildren(info.id, dirPath);
 
-    return fromFolderInfoFile(info, parentId, children);
+    const lastModified = await this.getInfoFileModifactionTime(dirPath, type);
+    return fromFolderInfoFile(info, lastModified, parentId, children);
+  }
+
+  private async getInfoFileModifactionTime(
+    dirPath: string,
+    type: TrufosObject['type']
+  ): Promise<number> {
+    const infoFilePath = path.join(dirPath, this.getInfoFileName(type));
+    const stats = await fs.stat(infoFilePath);
+    return stats.mtimeMs;
   }
 
   private async loadChildren(
@@ -589,17 +606,27 @@ export class PersistenceService {
     }
   }
 
-  private readInfoFile(dirPath: string, type: Collection['type']): Promise<CollectionInfoFile>;
-  private readInfoFile(dirPath: string, type: Folder['type']): Promise<FolderInfoFile>;
-  private readInfoFile(dirPath: string, type: TrufosRequest['type']): Promise<RequestInfoFile>;
+  private readInfoFile(
+    dirPath: string,
+    type: Collection['type']
+  ): Promise<CollectionInfoFile & { lastModified: number }>;
+  private readInfoFile(
+    dirPath: string,
+    type: Folder['type']
+  ): Promise<FolderInfoFile & { lastModified: number }>;
+  private readInfoFile(
+    dirPath: string,
+    type: TrufosRequest['type']
+  ): Promise<RequestInfoFile & { lastModified: number }>;
 
   private async readInfoFile<T extends TrufosObject>(dirPath: string, type: T['type']) {
     const filePath = path.join(dirPath, this.getInfoFileName(type));
-    const info = assign(
-      JSON.parse(await fs.readFile(filePath, 'utf8')) as InfoFile,
-      await this.loadSecrets(dirPath)
-    );
     try {
+      const fileStats = await fs.stat(filePath);
+      const info = assign(
+        JSON.parse(await fs.readFile(filePath, 'utf8')) as InfoFile,
+        await this.loadSecrets(dirPath)
+      );
       const latest = await migrateInfoFile(info, type, filePath); // (potentially) migrate the info file to the latest version
       await InfoFile.parseAsync(latest); // validate the info file
       return latest;

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -129,6 +129,7 @@ export const createCollectionStore = (collection: Collection) => {
           id: null,
           parentId: actualParentId,
           type: 'request',
+          lastModified: Date.now(),
           title: title ?? (Math.random() + 1).toString(36).substring(7),
           headers: [],
           body: {
@@ -175,7 +176,7 @@ export const createCollectionStore = (collection: Collection) => {
 
       setRequestBodyMimeType(mimeType?: string) {
         const { body } = selectRequest(get());
-        if (body.type !== RequestBodyType.TEXT) return;
+        if (body.type === RequestBodyType.FORM_DATA) return; // form data bodies don't have a mime type
         const { setRequestBody } = get();
         setRequestBody({ ...body, mimeType });
       },
@@ -339,6 +340,7 @@ export const createCollectionStore = (collection: Collection) => {
           parentId: parentId ?? get().collection.id,
           type: 'folder',
           title: title ?? (Math.random() + 1).toString(36).substring(7),
+          lastModified: Date.now(),
           children: [],
         });
 

--- a/src/shim/objects/collection.ts
+++ b/src/shim/objects/collection.ts
@@ -16,6 +16,7 @@ export type CollectionBase = z.infer<typeof CollectionBase>;
 /** A collection of folders and requests. */
 export const Collection = CollectionBase.extend({
   type: z.literal('collection'),
+  lastModified: z.number(),
   isDefault: z.boolean().optional(),
   variables: VariableMap,
   environments: EnvironmentMap,

--- a/src/shim/objects/folder.ts
+++ b/src/shim/objects/folder.ts
@@ -5,6 +5,7 @@ export const Folder = z.object({
   id: z.string(),
   parentId: z.string(),
   type: z.literal('folder'),
+  lastModified: z.number(),
   title: z.string(),
   get children() {
     return z.union([Folder, TrufosRequest]).array();

--- a/src/shim/objects/request.ts
+++ b/src/shim/objects/request.ts
@@ -54,6 +54,7 @@ export const TrufosRequest = z.object({
   id: z.string(),
   parentId: z.string(),
   type: z.literal('request'),
+  lastModified: z.number(),
   title: z.string(),
   url: TrufosURL,
   method: z.enum(RequestMethod),


### PR DESCRIPTION
## Changes
- Add `lastModified` property on all `TrufosObject` instances containing unix timestamp in ms

## Testing
- Added automated tests

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [ ] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
