### PR TITLE
Feat/713 sort sidebar collection

### DIFF
--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -176,10 +176,22 @@ export class PersistenceService {
       newDirPath = object.dirPath;
     }
 
-    // Persist new title to the info file so that a reload reflects the change.
-    // We only need to update the primary info file. Draft info files (hidden) represent unsaved changes and
-    // will be updated when they are explicitly saved.
+    // Persist new title to the primary info file so that a reload reflects the change.
     await this.saveInfoFile(object, newDirPath);
+
+    // Also update the title in the draft info file if one exists, so the rename is reflected
+    // after a restart even when the request has unsaved changes. Only the title field is patched
+    // to preserve all other draft changes (body, headers, URL, etc.).
+    if (isRequest(object)) {
+      const draftInfoPath = path.join(
+        this.getDraftDirPath(newDirPath),
+        this.getInfoFileName('request')
+      );
+      if (await exists(draftInfoPath)) {
+        const draftInfo = JSON.parse(await fs.readFile(draftInfoPath, 'utf8'));
+        await this.writeJson(draftInfoPath, { ...draftInfo, title });
+      }
+    }
   }
 
   /**

--- a/src/renderer/components/mainWindow/MainTopBar.tsx
+++ b/src/renderer/components/mainWindow/MainTopBar.tsx
@@ -20,7 +20,7 @@ const eventService = RendererEventService.instance;
 export function MainTopBar() {
   const [isLoading, setIsLoading] = useState(false);
 
-  const { updateRequest, touchRequest } = useCollectionActions();
+  const { updateRequest } = useCollectionActions();
   const { addResponse } = useResponseActions();
   const request = useCollectionStore(selectRequest);
   const currentScriptType = useCollectionStore((state) => state.currentScriptType);
@@ -37,7 +37,6 @@ export function MainTopBar() {
           eventService.saveRequest(request, REQUEST_MODEL.getValue()),
           eventService.saveScript(request, currentScriptType, SCRIPT_MODEL.getValue()),
         ]);
-        touchRequest(request.id);
 
         const response = await httpService.sendRequest(request);
         addResponse(request.id, response);
@@ -57,7 +56,6 @@ export function MainTopBar() {
       // save request draft with the current editor content
       console.info('Saving request:', request);
       await eventService.saveRequest(request, REQUEST_MODEL.getValue());
-      touchRequest(request.id);
 
       // override existing request with the saved draft
       updateRequest(await eventService.saveChanges(request), true);

--- a/src/renderer/components/mainWindow/MainTopBar.tsx
+++ b/src/renderer/components/mainWindow/MainTopBar.tsx
@@ -20,7 +20,7 @@ const eventService = RendererEventService.instance;
 export function MainTopBar() {
   const [isLoading, setIsLoading] = useState(false);
 
-  const { updateRequest } = useCollectionActions();
+  const { updateRequest, touchRequest } = useCollectionActions();
   const { addResponse } = useResponseActions();
   const request = useCollectionStore(selectRequest);
   const currentScriptType = useCollectionStore((state) => state.currentScriptType);
@@ -37,6 +37,7 @@ export function MainTopBar() {
           eventService.saveRequest(request, REQUEST_MODEL.getValue()),
           eventService.saveScript(request, currentScriptType, SCRIPT_MODEL.getValue()),
         ]);
+        touchRequest(request.id);
 
         const response = await httpService.sendRequest(request);
         addResponse(request.id, response);
@@ -56,6 +57,7 @@ export function MainTopBar() {
       // save request draft with the current editor content
       console.info('Saving request:', request);
       await eventService.saveRequest(request, REQUEST_MODEL.getValue());
+      touchRequest(request.id);
 
       // override existing request with the saved draft
       updateRequest(await eventService.saveChanges(request), true);

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/ScriptTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/ScriptTab.tsx
@@ -20,7 +20,7 @@ export function ScriptTab() {
   const scriptType = useCollectionStore((state) => state.currentScriptType);
   const selectedRequestId = useCollectionStore((state) => state.selectedRequestId);
   const request = useCollectionStore(selectRequest);
-  const { setCurrentScriptType } = useCollectionActions();
+  const { setCurrentScriptType, setDraftFlag } = useCollectionActions();
 
   // Load content when request or script type changes; save current content on cleanup.
   // React guarantees cleanup runs before the next effect, so the model
@@ -52,6 +52,7 @@ export function ScriptTab() {
           className="absolute h-full"
           language="javascript"
           options={SCRIPT_EDITOR_OPTIONS}
+          onChange={setDraftFlag}
         />
       </div>
     </div>

--- a/src/renderer/components/sidebar/SidebarHeaderBar.test.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.test.tsx
@@ -39,7 +39,7 @@ vi.mock('@/components/sidebar/SidebarRequestList/Nav/Dropdown/modals/NamingModal
 describe('SidebarHeaderBar sort cycle', () => {
   beforeEach(() => {
     setSortModeMock.mockClear();
-    currentSortMode = 'default';
+    currentSortMode = SortMode.DEFAULT;
   });
 
   it('calls setSortMode with the next mode when sort button is clicked', () => {
@@ -48,22 +48,22 @@ describe('SidebarHeaderBar sort cycle', () => {
 
     fireEvent.click(sortButton);
 
-    expect(setSortModeMock).toHaveBeenCalledWith(SORT_CYCLE[1]); // 'az-asc'
+    expect(setSortModeMock).toHaveBeenCalledWith(SORT_CYCLE[1]); // SortMode.AZ_ASC
   });
 
   it('cycles back to default after the last mode', () => {
-    currentSortMode = SORT_CYCLE[SORT_CYCLE.length - 1]; // 'time-desc'
+    currentSortMode = SORT_CYCLE[SORT_CYCLE.length - 1]; // SortMode.TIME_ASC
     const { getByRole } = renderWithProvider(<SidebarHeaderBar />);
     const sortButton = getByRole('button', { name: /sort collection/i });
 
     fireEvent.click(sortButton);
 
-    expect(setSortModeMock).toHaveBeenCalledWith('default');
+    expect(setSortModeMock).toHaveBeenCalledWith(SortMode.DEFAULT);
   });
 
   it('shows the correct tooltip label when hovering the sort button', async () => {
     const user = userEvent.setup();
-    currentSortMode = 'az-asc';
+    currentSortMode = SortMode.AZ_ASC;
     renderWithProvider(<SidebarHeaderBar />);
 
     const sortButton = screen.getByRole('button', { name: /sort collection/i });

--- a/src/renderer/components/sidebar/SidebarHeaderBar.test.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.test.tsx
@@ -1,0 +1,74 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { SidebarHeaderBar } from './SidebarHeaderBar';
+import { SortMode, SORT_CYCLE } from './SidebarRequestList/treeUtilities';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+const renderWithProvider = (ui: React.ReactElement) =>
+  render(<TooltipProvider>{ui}</TooltipProvider>);
+
+const setSortModeMock = vi.fn();
+let currentSortMode: SortMode = 'default';
+
+vi.mock('@/state/collectionStore', () => ({
+  useCollectionStore: (selector: (state: any) => any) =>
+    selector({
+      collection: { id: 'col-1', title: 'Test Collection', type: 'collection', children: [] },
+      sortMode: currentSortMode,
+    }),
+  useCollectionActions: () => ({
+    setSortMode: setSortModeMock,
+    addNewRequest: vi.fn(),
+    addNewFolder: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/sidebar/CollectionDropdown', () => ({
+  default: () => <div>CollectionDropdown</div>,
+}));
+
+vi.mock('@/components/sidebar/CollectionSettings', () => ({
+  CollectionSettings: () => null,
+}));
+
+vi.mock('@/components/sidebar/SidebarRequestList/Nav/Dropdown/modals/NamingModal', () => ({
+  NamingModal: () => null,
+}));
+
+describe('SidebarHeaderBar sort cycle', () => {
+  beforeEach(() => {
+    setSortModeMock.mockClear();
+    currentSortMode = 'default';
+  });
+
+  it('calls setSortMode with the next mode when sort button is clicked', () => {
+    const { getByRole } = renderWithProvider(<SidebarHeaderBar />);
+    const sortButton = getByRole('button', { name: /sort collection/i });
+
+    fireEvent.click(sortButton);
+
+    expect(setSortModeMock).toHaveBeenCalledWith(SORT_CYCLE[1]); // 'az-asc'
+  });
+
+  it('cycles back to default after the last mode', () => {
+    currentSortMode = SORT_CYCLE[SORT_CYCLE.length - 1]; // 'time-desc'
+    const { getByRole } = renderWithProvider(<SidebarHeaderBar />);
+    const sortButton = getByRole('button', { name: /sort collection/i });
+
+    fireEvent.click(sortButton);
+
+    expect(setSortModeMock).toHaveBeenCalledWith('default');
+  });
+
+  it('shows the correct tooltip label when hovering the sort button', async () => {
+    const user = userEvent.setup();
+    currentSortMode = 'az-asc';
+    renderWithProvider(<SidebarHeaderBar />);
+
+    const sortButton = screen.getByRole('button', { name: /sort collection/i });
+    await user.hover(sortButton);
+
+    expect((await screen.findAllByText('A → Z')).length).toBeGreaterThan(0);
+  });
+});

--- a/src/renderer/components/sidebar/SidebarHeaderBar.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { SidebarHeader } from '@/components/ui/sidebar';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { AddFolderIcon, CreateRequestIcon, SettingsIcon } from '@/components/icons';
+import { AddFolderIcon, CreateRequestIcon, SettingsIcon, SwapIcon } from '@/components/icons';
+import { ArrowUpAZ, ArrowDownAZ, ClockArrowUp, ClockArrowDown } from 'lucide-react';
 import { NamingModal } from '@/components/sidebar/SidebarRequestList/Nav/Dropdown/modals/NamingModal';
 import { useCollectionStore } from '@/state/collectionStore';
 import { Collection } from 'shim/objects/collection';
@@ -10,14 +11,35 @@ import CollectionDropdown from '@/components/sidebar/CollectionDropdown';
 import { Divider } from '@/components/shared/Divider';
 import { CollectionSettings } from '@/components/sidebar/CollectionSettings';
 
+type SortMode = 'default' | 'az-asc' | 'az-desc' | 'time-asc' | 'time-desc';
+const SORT_CYCLE: SortMode[] = ['default', 'az-asc', 'az-desc', 'time-asc', 'time-desc'];
+
+const SortIcon = ({ mode }: { mode: SortMode }) => {
+  switch (mode) {
+    case 'az-asc':
+      return <ArrowUpAZ size={18} />;
+    case 'az-desc':
+      return <ArrowDownAZ size={18} />;
+    case 'time-asc':
+      return <ClockArrowUp size={18} />;
+    case 'time-desc':
+      return <ClockArrowDown size={18} />;
+    default:
+      return <SwapIcon size={16} viewBox="9 7 15 18" />;
+  }
+};
+
 export const SidebarHeaderBar = () => {
   const collection = useCollectionStore((state) => state.collection);
 
   const [creationModalState, setCreationModalState] = useState({ isOpen: false, type: null });
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [sortIndex, setSortIndex] = useState(0);
   const buttonClassName = cn('flex h-4 w-4 items-center justify-center gap-1');
 
   const openModal = (type: 'request' | 'folder') => setCreationModalState({ isOpen: true, type });
+  const cycleSortMode = () => setSortIndex((i) => (i + 1) % SORT_CYCLE.length);
+  const sortMode = SORT_CYCLE[sortIndex];
 
   return (
     <>
@@ -26,39 +48,52 @@ export const SidebarHeaderBar = () => {
 
         <Divider />
 
-        <div className="-mt-4 mb-2 flex w-full items-center justify-end gap-2">
+        <div className="-mt-4 mb-2 flex w-full items-center justify-between">
           <Button
-            className={buttonClassName}
+            className={cn(buttonClassName, 'text-text-secondary ml-3')}
             variant={'ghost'}
             type="button"
             size={'icon'}
-            onClick={() => openModal('request')}
-            aria-label="Add new request"
+            onClick={cycleSortMode}
+            aria-label="Sort collection"
           >
-            <CreateRequestIcon size={16} color={'secondary'} />
+            <SortIcon mode={sortMode} />
           </Button>
 
-          <Button
-            className={buttonClassName}
-            variant={'ghost'}
-            size={'icon'}
-            type="button"
-            onClick={() => openModal('folder')}
-            aria-label="Add new folder"
-          >
-            <AddFolderIcon size={16} color={'secondary'} />
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              className={buttonClassName}
+              variant={'ghost'}
+              type="button"
+              size={'icon'}
+              onClick={() => openModal('request')}
+              aria-label="Add new request"
+            >
+              <CreateRequestIcon size={16} color={'secondary'} />
+            </Button>
 
-          <Button
-            className={buttonClassName}
-            variant={'ghost'}
-            size={'icon'}
-            type="button"
-            onClick={() => setIsSettingsOpen(true)}
-            aria-label="Add new folder"
-          >
-            <SettingsIcon size={16} color={'secondary'} />
-          </Button>
+            <Button
+              className={buttonClassName}
+              variant={'ghost'}
+              size={'icon'}
+              type="button"
+              onClick={() => openModal('folder')}
+              aria-label="Add new folder"
+            >
+              <AddFolderIcon size={16} color={'secondary'} />
+            </Button>
+
+            <Button
+              className={buttonClassName}
+              variant={'ghost'}
+              size={'icon'}
+              type="button"
+              onClick={() => setIsSettingsOpen(true)}
+              aria-label="Collection settings"
+            >
+              <SettingsIcon size={16} color={'secondary'} />
+            </Button>
+          </div>
         </div>
       </SidebarHeader>
 

--- a/src/renderer/components/sidebar/SidebarHeaderBar.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.tsx
@@ -73,7 +73,10 @@ export const SidebarHeaderBar = () => {
                 <SortIcon mode={sortMode} />
               </Button>
             </TooltipTrigger>
-            <TooltipContent side="right" className="text-xs">
+            <TooltipContent
+              side="right"
+              className="bg-sidebar-accent text-sidebar-accent-foreground border-0 px-2.5 py-1 text-xs font-medium tracking-wide shadow-sm"
+            >
               {SORT_MODE_LABELS[sortMode]}
             </TooltipContent>
           </Tooltip>

--- a/src/renderer/components/sidebar/SidebarHeaderBar.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.tsx
@@ -14,22 +14,22 @@ import { SortMode, SORT_CYCLE } from '@/components/sidebar/SidebarRequestList/tr
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 const SORT_MODE_LABELS: Record<SortMode, string> = {
-  default: 'Manual order',
-  'az-asc': 'A → Z',
-  'az-desc': 'Z → A',
-  'time-desc': 'Recently modified',
-  'time-asc': 'Oldest modified',
+  [SortMode.DEFAULT]: 'Manual order',
+  [SortMode.AZ_ASC]: 'A → Z',
+  [SortMode.AZ_DESC]: 'Z → A',
+  [SortMode.TIME_DESC]: 'Recently modified',
+  [SortMode.TIME_ASC]: 'Oldest modified',
 };
 
 const SortIcon = ({ mode }: { mode: SortMode }) => {
   switch (mode) {
-    case 'az-asc':
+    case SortMode.AZ_ASC:
       return <ArrowUpAZ size={18} />;
-    case 'az-desc':
+    case SortMode.AZ_DESC:
       return <ArrowDownAZ size={18} />;
-    case 'time-asc':
+    case SortMode.TIME_ASC:
       return <ClockArrowUp size={18} />;
-    case 'time-desc':
+    case SortMode.TIME_DESC:
       return <ClockArrowDown size={18} />;
     default:
       return <SwapIcon size={16} viewBox="9 7 15 18" />;

--- a/src/renderer/components/sidebar/SidebarHeaderBar.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.tsx
@@ -5,14 +5,12 @@ import { cn } from '@/lib/utils';
 import { AddFolderIcon, CreateRequestIcon, SettingsIcon, SwapIcon } from '@/components/icons';
 import { ArrowUpAZ, ArrowDownAZ, ClockArrowUp, ClockArrowDown } from 'lucide-react';
 import { NamingModal } from '@/components/sidebar/SidebarRequestList/Nav/Dropdown/modals/NamingModal';
-import { useCollectionStore } from '@/state/collectionStore';
+import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
 import { Collection } from 'shim/objects/collection';
 import CollectionDropdown from '@/components/sidebar/CollectionDropdown';
 import { Divider } from '@/components/shared/Divider';
 import { CollectionSettings } from '@/components/sidebar/CollectionSettings';
-
-type SortMode = 'default' | 'az-asc' | 'az-desc' | 'time-asc' | 'time-desc';
-const SORT_CYCLE: SortMode[] = ['default', 'az-asc', 'az-desc', 'time-asc', 'time-desc'];
+import { SortMode, SORT_CYCLE } from '@/components/sidebar/SidebarRequestList/treeUtilities';
 
 const SortIcon = ({ mode }: { mode: SortMode }) => {
   switch (mode) {
@@ -32,14 +30,18 @@ const SortIcon = ({ mode }: { mode: SortMode }) => {
 export const SidebarHeaderBar = () => {
   const collection = useCollectionStore((state) => state.collection);
 
+  const sortMode = useCollectionStore((state) => state.sortMode);
+  const { setSortMode } = useCollectionActions();
+
   const [creationModalState, setCreationModalState] = useState({ isOpen: false, type: null });
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [sortIndex, setSortIndex] = useState(0);
   const buttonClassName = cn('flex h-4 w-4 items-center justify-center gap-1');
 
   const openModal = (type: 'request' | 'folder') => setCreationModalState({ isOpen: true, type });
-  const cycleSortMode = () => setSortIndex((i) => (i + 1) % SORT_CYCLE.length);
-  const sortMode = SORT_CYCLE[sortIndex];
+  const cycleSortMode = () => {
+    const currentIndex = SORT_CYCLE.indexOf(sortMode);
+    setSortMode(SORT_CYCLE[(currentIndex + 1) % SORT_CYCLE.length]);
+  };
 
   return (
     <>

--- a/src/renderer/components/sidebar/SidebarHeaderBar.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.tsx
@@ -11,6 +11,15 @@ import CollectionDropdown from '@/components/sidebar/CollectionDropdown';
 import { Divider } from '@/components/shared/Divider';
 import { CollectionSettings } from '@/components/sidebar/CollectionSettings';
 import { SortMode, SORT_CYCLE } from '@/components/sidebar/SidebarRequestList/treeUtilities';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+const SORT_MODE_LABELS: Record<SortMode, string> = {
+  default: 'Manual order',
+  'az-asc': 'A → Z',
+  'az-desc': 'Z → A',
+  'time-desc': 'Recently modified',
+  'time-asc': 'Oldest modified',
+};
 
 const SortIcon = ({ mode }: { mode: SortMode }) => {
   switch (mode) {
@@ -51,16 +60,23 @@ export const SidebarHeaderBar = () => {
         <Divider />
 
         <div className="-mt-4 mb-2 flex w-full items-center justify-between">
-          <Button
-            className={cn(buttonClassName, 'text-text-secondary ml-3')}
-            variant={'ghost'}
-            type="button"
-            size={'icon'}
-            onClick={cycleSortMode}
-            aria-label="Sort collection"
-          >
-            <SortIcon mode={sortMode} />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                className={cn(buttonClassName, 'text-text-secondary ml-3')}
+                variant={'ghost'}
+                type="button"
+                size={'icon'}
+                onClick={cycleSortMode}
+                aria-label="Sort collection"
+              >
+                <SortIcon mode={sortMode} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right" className="text-xs">
+              {SORT_MODE_LABELS[sortMode]}
+            </TooltipContent>
+          </Tooltip>
 
           <div className="flex items-center gap-2">
             <Button

--- a/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
@@ -14,7 +14,7 @@ import { useCollectionActions, useCollectionStore } from '@/state/collectionStor
 import { SidebarContent, SidebarMenu } from '@/components/ui/sidebar';
 import { NavFolder } from '@/components/sidebar/SidebarRequestList/Nav/NavFolder';
 import { NavRequest } from '@/components/sidebar/SidebarRequestList/Nav/NavRequest';
-import { flattenTree, removeChildrenOf, getProjection } from './treeUtilities';
+import { flattenTree, removeChildrenOf, getProjection, getMaxTimestamp } from './treeUtilities';
 import { FolderIcon, SmallArrow } from '@/components/icons';
 import { httpMethodColor } from '@/services/StyleHelper';
 import { cn } from '@/lib/utils';
@@ -27,6 +27,7 @@ export const SidebarRequestList = () => {
   const openFolders = useCollectionStore((state) => state.openFolders);
   const folders = useCollectionStore((state) => state.folders);
   const sortMode = useCollectionStore((state) => state.sortMode);
+  const requestTimestamps = useCollectionStore((state) => state.requestTimestamps);
   const { moveItem } = useCollectionActions();
 
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -40,8 +41,16 @@ export const SidebarRequestList = () => {
   const sortFn = useMemo((): ((a: TrufosRequest | Folder, b: TrufosRequest | Folder) => number) | null => {
     if (sortMode === 'az-asc') return (a, b) => a.title.localeCompare(b.title);
     if (sortMode === 'az-desc') return (a, b) => b.title.localeCompare(a.title);
+    if (sortMode === 'time-desc')
+      return (a, b) =>
+        getMaxTimestamp(b, requestTimestamps, folders) -
+        getMaxTimestamp(a, requestTimestamps, folders);
+    if (sortMode === 'time-asc')
+      return (a, b) =>
+        getMaxTimestamp(a, requestTimestamps, folders) -
+        getMaxTimestamp(b, requestTimestamps, folders);
     return null;
-  }, [sortMode]);
+  }, [sortMode, requestTimestamps, folders]);
 
   const sortedChildren = useMemo(
     () => (sortFn ? [...children].sort(sortFn) : children),

--- a/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
@@ -59,7 +59,7 @@ export const SidebarRequestList = () => {
   }, [sortMode, requests, folders]);
 
   const sortedChildren = useMemo(
-    () => (sortFn ? [...children].sort(sortFn) : children),
+    () => (sortFn ? children.toSorted(sortFn) : children),
     [children, sortFn]
   );
 

--- a/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
@@ -14,7 +14,13 @@ import { useCollectionActions, useCollectionStore } from '@/state/collectionStor
 import { SidebarContent, SidebarMenu } from '@/components/ui/sidebar';
 import { NavFolder } from '@/components/sidebar/SidebarRequestList/Nav/NavFolder';
 import { NavRequest } from '@/components/sidebar/SidebarRequestList/Nav/NavRequest';
-import { flattenTree, removeChildrenOf, getProjection, getMaxTimestamp } from './treeUtilities';
+import {
+  flattenTree,
+  removeChildrenOf,
+  getProjection,
+  getMaxTimestamp,
+  SortMode,
+} from './treeUtilities';
 import { FolderIcon, SmallArrow } from '@/components/icons';
 import { httpMethodColor } from '@/services/StyleHelper';
 import { cn } from '@/lib/utils';
@@ -26,8 +32,8 @@ export const SidebarRequestList = () => {
   const collectionId = useCollectionStore((state) => state.collection.id);
   const openFolders = useCollectionStore((state) => state.openFolders);
   const folders = useCollectionStore((state) => state.folders);
+  const requests = useCollectionStore((state) => state.requests);
   const sortMode = useCollectionStore((state) => state.sortMode);
-  const requestTimestamps = useCollectionStore((state) => state.requestTimestamps);
   const { moveItem } = useCollectionActions();
 
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -41,18 +47,16 @@ export const SidebarRequestList = () => {
   const sortFn = useMemo(():
     | ((a: TrufosRequest | Folder, b: TrufosRequest | Folder) => number)
     | null => {
-    if (sortMode === 'az-asc') return (a, b) => a.title.localeCompare(b.title);
-    if (sortMode === 'az-desc') return (a, b) => b.title.localeCompare(a.title);
-    if (sortMode === 'time-desc')
+    if (sortMode === SortMode.AZ_ASC) return (a, b) => a.title.localeCompare(b.title);
+    if (sortMode === SortMode.AZ_DESC) return (a, b) => b.title.localeCompare(a.title);
+    if (sortMode === SortMode.TIME_DESC)
       return (a, b) =>
-        getMaxTimestamp(b, requestTimestamps, folders) -
-        getMaxTimestamp(a, requestTimestamps, folders);
-    if (sortMode === 'time-asc')
+        getMaxTimestamp(b, requests, folders) - getMaxTimestamp(a, requests, folders);
+    if (sortMode === SortMode.TIME_ASC)
       return (a, b) =>
-        getMaxTimestamp(a, requestTimestamps, folders) -
-        getMaxTimestamp(b, requestTimestamps, folders);
+        getMaxTimestamp(a, requests, folders) - getMaxTimestamp(b, requests, folders);
     return null;
-  }, [sortMode, requestTimestamps, folders]);
+  }, [sortMode, requests, folders]);
 
   const sortedChildren = useMemo(
     () => (sortFn ? [...children].sort(sortFn) : children),
@@ -89,7 +93,7 @@ export const SidebarRequestList = () => {
   };
 
   const handleDragEnd = async ({ active, over, delta }: DragEndEvent) => {
-    if (!over || active.id === over.id || sortMode !== 'default') {
+    if (!over || active.id === over.id || sortMode !== SortMode.DEFAULT) {
       setActiveId(null);
       return;
     }

--- a/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
@@ -18,12 +18,15 @@ import { flattenTree, removeChildrenOf, getProjection } from './treeUtilities';
 import { FolderIcon, SmallArrow } from '@/components/icons';
 import { httpMethodColor } from '@/services/StyleHelper';
 import { cn } from '@/lib/utils';
+import { Folder } from 'shim/objects/folder';
+import { TrufosRequest } from 'shim/objects/request';
 
 export const SidebarRequestList = () => {
   const children = useCollectionStore((state) => state.collection.children);
   const collectionId = useCollectionStore((state) => state.collection.id);
   const openFolders = useCollectionStore((state) => state.openFolders);
   const folders = useCollectionStore((state) => state.folders);
+  const sortMode = useCollectionStore((state) => state.sortMode);
   const { moveItem } = useCollectionActions();
 
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -34,12 +37,32 @@ export const SidebarRequestList = () => {
     })
   );
 
+  const sortFn = useMemo((): ((a: TrufosRequest | Folder, b: TrufosRequest | Folder) => number) | null => {
+    if (sortMode === 'az-asc') return (a, b) => a.title.localeCompare(b.title);
+    if (sortMode === 'az-desc') return (a, b) => b.title.localeCompare(a.title);
+    return null;
+  }, [sortMode]);
+
+  const sortedChildren = useMemo(
+    () => (sortFn ? [...children].sort(sortFn) : children),
+    [children, sortFn]
+  );
+
+  const sortedFolders = useMemo(() => {
+    if (!sortFn) return folders;
+    const result = new Map<string, Folder>();
+    folders.forEach((folder, id) => {
+      result.set(id, { ...folder, children: [...folder.children].sort(sortFn) });
+    });
+    return result;
+  }, [folders, sortFn]);
+
   // Flatten the tree for a single SortableContext.
   // We pass the folders Map so flattenTree reads up-to-date children
   // (immer may not propagate Map mutations into tree references).
   const flattenedItems = useMemo(
-    () => flattenTree(children, openFolders, collectionId, folders),
-    [children, openFolders, collectionId, folders]
+    () => flattenTree(sortedChildren, openFolders, collectionId, sortedFolders),
+    [sortedChildren, openFolders, collectionId, sortedFolders]
   );
 
   // During drag: remove children of the dragged folder so they travel with it
@@ -55,7 +78,7 @@ export const SidebarRequestList = () => {
   };
 
   const handleDragEnd = async ({ active, over, delta }: DragEndEvent) => {
-    if (!over || active.id === over.id) {
+    if (!over || active.id === over.id || sortMode !== 'default') {
       setActiveId(null);
       return;
     }

--- a/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
@@ -43,6 +43,7 @@ export const SidebarRequestList = () => {
       activationConstraint: { distance: 5 },
     })
   );
+  const activeSensors = sortMode === SortMode.DEFAULT ? sensors : [];
 
   const sortFn = useMemo(():
     | ((a: TrufosRequest | Folder, b: TrufosRequest | Folder) => number)
@@ -124,7 +125,7 @@ export const SidebarRequestList = () => {
   return (
     <SidebarContent className="tabs-scrollbar -mr-6 -ml-6 flex-1 overflow-x-hidden overflow-y-auto">
       <DndContext
-        sensors={sensors}
+        sensors={activeSensors}
         collisionDetection={closestCenter}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}

--- a/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
@@ -38,7 +38,9 @@ export const SidebarRequestList = () => {
     })
   );
 
-  const sortFn = useMemo((): ((a: TrufosRequest | Folder, b: TrufosRequest | Folder) => number) | null => {
+  const sortFn = useMemo(():
+    | ((a: TrufosRequest | Folder, b: TrufosRequest | Folder) => number)
+    | null => {
     if (sortMode === 'az-asc') return (a, b) => a.title.localeCompare(b.title);
     if (sortMode === 'az-desc') return (a, b) => b.title.localeCompare(a.title);
     if (sortMode === 'time-desc')

--- a/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.test.ts
+++ b/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.test.ts
@@ -32,64 +32,66 @@ const makeFolder = (
 
 describe('getMaxTimestamp', () => {
   it('returns the timestamp for a request', () => {
-    const timestamps = new Map([['req-1', 1000]]);
+    const req = makeRequest('req-1', 1000);
+    const requests = new Map([['req-1', req]]);
     const folders = new Map<string, Folder>();
 
-    expect(getMaxTimestamp(makeRequest('req-1'), timestamps, folders)).toBe(1000);
+    expect(getMaxTimestamp(req, requests, folders)).toBe(1000);
   });
 
-  it('returns 0 for a request with no timestamp', () => {
-    const timestamps = new Map<string, number>();
+  it('returns 0 for a request with no entry in requests map', () => {
+    const req = makeRequest('req-1', 0);
+    const requests = new Map<string, TrufosRequest>();
     const folders = new Map<string, Folder>();
 
-    expect(getMaxTimestamp(makeRequest('req-1'), timestamps, folders)).toBe(0);
+    expect(getMaxTimestamp(req, requests, folders)).toBe(0);
   });
 
   it('returns max timestamp of direct children for a folder', () => {
-    const req1 = makeRequest('req-1');
-    const req2 = makeRequest('req-2');
+    const req1 = makeRequest('req-1', 500);
+    const req2 = makeRequest('req-2', 1500);
     const folder = makeFolder('folder-1', [req1, req2]);
 
-    const timestamps = new Map([
-      ['req-1', 500],
-      ['req-2', 1500],
+    const requests = new Map([
+      ['req-1', req1],
+      ['req-2', req2],
     ]);
     const folders = new Map([['folder-1', folder]]);
 
-    expect(getMaxTimestamp(folder, timestamps, folders)).toBe(1500);
+    expect(getMaxTimestamp(folder, requests, folders)).toBe(1500);
   });
 
   it('returns 0 for an empty folder', () => {
-    const folder = makeFolder('folder-1', []);
-    const timestamps = new Map<string, number>();
+    const folder = makeFolder('folder-1', [], 0);
+    const requests = new Map<string, TrufosRequest>();
     const folders = new Map([['folder-1', folder]]);
 
-    expect(getMaxTimestamp(folder, timestamps, folders)).toBe(0);
+    expect(getMaxTimestamp(folder, requests, folders)).toBe(0);
   });
 
   it('returns 0 for a folder not found in the folders map', () => {
-    const folder = makeFolder('folder-1', [makeRequest('req-1')]);
-    const timestamps = new Map([['req-1', 999]]);
+    const folder = makeFolder('folder-1', [makeRequest('req-1')], 0);
+    const requests = new Map<string, TrufosRequest>();
     const folders = new Map<string, Folder>(); // folder-1 not in map
 
-    expect(getMaxTimestamp(folder, timestamps, folders)).toBe(0);
+    expect(getMaxTimestamp(folder, requests, folders)).toBe(0);
   });
 
   it('returns max timestamp recursively for nested folders', () => {
-    const req1 = makeRequest('req-1');
-    const req2 = makeRequest('req-2');
+    const req1 = makeRequest('req-1', 100);
+    const req2 = makeRequest('req-2', 9000);
     const innerFolder = makeFolder('inner', [req2]);
     const outerFolder = makeFolder('outer', [req1, innerFolder]);
 
-    const timestamps = new Map([
-      ['req-1', 100],
-      ['req-2', 9000],
+    const requests = new Map([
+      ['req-1', req1],
+      ['req-2', req2],
     ]);
     const folders = new Map([
       ['outer', outerFolder],
       ['inner', innerFolder],
     ]);
 
-    expect(getMaxTimestamp(outerFolder, timestamps, folders)).toBe(9000);
+    expect(getMaxTimestamp(outerFolder, requests, folders)).toBe(9000);
   });
 });

--- a/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.test.ts
+++ b/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { getMaxTimestamp } from './treeUtilities';
+import { Folder } from 'shim/objects/folder';
+import { TrufosRequest } from 'shim/objects/request';
+
+const makeRequest = (id: string): TrufosRequest =>
+  ({
+    id,
+    type: 'request',
+    parentId: 'parent',
+    title: id,
+    url: { base: '', query: [] },
+    method: 'GET',
+    headers: [],
+    body: { type: 'text', mimeType: 'text/plain' },
+  }) as unknown as TrufosRequest;
+
+const makeFolder = (id: string, children: (TrufosRequest | Folder)[] = []): Folder =>
+  ({
+    id,
+    type: 'folder',
+    parentId: 'parent',
+    title: id,
+    children,
+  }) as unknown as Folder;
+
+describe('getMaxTimestamp', () => {
+  it('returns the timestamp for a request', () => {
+    const timestamps = new Map([['req-1', 1000]]);
+    const folders = new Map<string, Folder>();
+
+    expect(getMaxTimestamp(makeRequest('req-1'), timestamps, folders)).toBe(1000);
+  });
+
+  it('returns 0 for a request with no timestamp', () => {
+    const timestamps = new Map<string, number>();
+    const folders = new Map<string, Folder>();
+
+    expect(getMaxTimestamp(makeRequest('req-1'), timestamps, folders)).toBe(0);
+  });
+
+  it('returns max timestamp of direct children for a folder', () => {
+    const req1 = makeRequest('req-1');
+    const req2 = makeRequest('req-2');
+    const folder = makeFolder('folder-1', [req1, req2]);
+
+    const timestamps = new Map([
+      ['req-1', 500],
+      ['req-2', 1500],
+    ]);
+    const folders = new Map([['folder-1', folder]]);
+
+    expect(getMaxTimestamp(folder, timestamps, folders)).toBe(1500);
+  });
+
+  it('returns 0 for an empty folder', () => {
+    const folder = makeFolder('folder-1', []);
+    const timestamps = new Map<string, number>();
+    const folders = new Map([['folder-1', folder]]);
+
+    expect(getMaxTimestamp(folder, timestamps, folders)).toBe(0);
+  });
+
+  it('returns 0 for a folder not found in the folders map', () => {
+    const folder = makeFolder('folder-1', [makeRequest('req-1')]);
+    const timestamps = new Map([['req-1', 999]]);
+    const folders = new Map<string, Folder>(); // folder-1 not in map
+
+    expect(getMaxTimestamp(folder, timestamps, folders)).toBe(0);
+  });
+
+  it('returns max timestamp recursively for nested folders', () => {
+    const req1 = makeRequest('req-1');
+    const req2 = makeRequest('req-2');
+    const innerFolder = makeFolder('inner', [req2]);
+    const outerFolder = makeFolder('outer', [req1, innerFolder]);
+
+    const timestamps = new Map([
+      ['req-1', 100],
+      ['req-2', 9000],
+    ]);
+    const folders = new Map([
+      ['outer', outerFolder],
+      ['inner', innerFolder],
+    ]);
+
+    expect(getMaxTimestamp(outerFolder, timestamps, folders)).toBe(9000);
+  });
+});

--- a/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.test.ts
+++ b/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.test.ts
@@ -3,24 +3,30 @@ import { getMaxTimestamp } from './treeUtilities';
 import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
 
-const makeRequest = (id: string): TrufosRequest =>
+const makeRequest = (id: string, lastModified = 0): TrufosRequest =>
   ({
     id,
     type: 'request',
     parentId: 'parent',
     title: id,
+    lastModified,
     url: { base: '', query: [] },
     method: 'GET',
     headers: [],
     body: { type: 'text', mimeType: 'text/plain' },
   }) as unknown as TrufosRequest;
 
-const makeFolder = (id: string, children: (TrufosRequest | Folder)[] = []): Folder =>
+const makeFolder = (
+  id: string,
+  children: (TrufosRequest | Folder)[] = [],
+  lastModified = 0
+): Folder =>
   ({
     id,
     type: 'folder',
     parentId: 'parent',
     title: id,
+    lastModified,
     children,
   }) as unknown as Folder;
 

--- a/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.ts
+++ b/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.ts
@@ -2,6 +2,21 @@ import { arrayMove } from '@dnd-kit/sortable';
 import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
 
+/**
+ * Returns the most recent save timestamp for an item.
+ * For folders, recursively returns the max timestamp of all descendants.
+ */
+export function getMaxTimestamp(
+  item: TrufosRequest | Folder,
+  timestamps: Map<string, number>,
+  folders: Map<string, Folder>
+): number {
+  if (item.type === 'request') return timestamps.get(item.id) ?? 0;
+  const folder = folders.get(item.id);
+  if (!folder || folder.children.length === 0) return 0;
+  return Math.max(...folder.children.map((child) => getMaxTimestamp(child, timestamps, folders)));
+}
+
 export type SortMode = 'default' | 'az-asc' | 'az-desc' | 'time-asc' | 'time-desc';
 export const SORT_CYCLE: SortMode[] = ['default', 'az-asc', 'az-desc', 'time-asc', 'time-desc'];
 

--- a/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.ts
+++ b/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.ts
@@ -11,10 +11,13 @@ export function getMaxTimestamp(
   timestamps: Map<string, number>,
   folders: Map<string, Folder>
 ): number {
-  if (item.type === 'request') return timestamps.get(item.id) ?? 0;
+  if (item.type === 'request') return timestamps.get(item.id) ?? item.lastModified;
   const folder = folders.get(item.id);
-  if (!folder || folder.children.length === 0) return 0;
-  return Math.max(...folder.children.map((child) => getMaxTimestamp(child, timestamps, folders)));
+  if (!folder || folder.children.length === 0) return item.lastModified;
+  return Math.max(
+    item.lastModified,
+    ...folder.children.map((child) => getMaxTimestamp(child, timestamps, folders))
+  );
 }
 
 export type SortMode = 'default' | 'az-asc' | 'az-desc' | 'time-asc' | 'time-desc';

--- a/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.ts
+++ b/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.ts
@@ -2,6 +2,9 @@ import { arrayMove } from '@dnd-kit/sortable';
 import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
 
+export type SortMode = 'default' | 'az-asc' | 'az-desc' | 'time-asc' | 'time-desc';
+export const SORT_CYCLE: SortMode[] = ['default', 'az-asc', 'az-desc', 'time-asc', 'time-desc'];
+
 export interface FlattenedItem {
   id: string;
   type: 'request' | 'folder';

--- a/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.ts
+++ b/src/renderer/components/sidebar/SidebarRequestList/treeUtilities.ts
@@ -8,20 +8,32 @@ import { TrufosRequest } from 'shim/objects/request';
  */
 export function getMaxTimestamp(
   item: TrufosRequest | Folder,
-  timestamps: Map<string, number>,
+  requests: Map<string, TrufosRequest>,
   folders: Map<string, Folder>
 ): number {
-  if (item.type === 'request') return timestamps.get(item.id) ?? item.lastModified;
+  if (item.type === 'request') return requests.get(item.id)?.lastModified ?? item.lastModified;
   const folder = folders.get(item.id);
   if (!folder || folder.children.length === 0) return item.lastModified;
   return Math.max(
     item.lastModified,
-    ...folder.children.map((child) => getMaxTimestamp(child, timestamps, folders))
+    ...folder.children.map((child) => getMaxTimestamp(child, requests, folders))
   );
 }
 
-export type SortMode = 'default' | 'az-asc' | 'az-desc' | 'time-asc' | 'time-desc';
-export const SORT_CYCLE: SortMode[] = ['default', 'az-asc', 'az-desc', 'time-asc', 'time-desc'];
+export enum SortMode {
+  DEFAULT = 'default',
+  AZ_ASC = 'az-asc',
+  AZ_DESC = 'az-desc',
+  TIME_DESC = 'time-desc',
+  TIME_ASC = 'time-asc',
+}
+export const SORT_CYCLE: SortMode[] = [
+  SortMode.DEFAULT,
+  SortMode.AZ_ASC,
+  SortMode.AZ_DESC,
+  SortMode.TIME_DESC,
+  SortMode.TIME_ASC,
+];
 
 export interface FlattenedItem {
   id: string;

--- a/src/renderer/state/collectionStore.test.ts
+++ b/src/renderer/state/collectionStore.test.ts
@@ -61,7 +61,7 @@ const buildStore = () => {
 };
 
 describe('markDraft', () => {
-  it('setDraftFlag sets draft and updates requestTimestamps', () => {
+  it('setDraftFlag sets draft and updates lastModified', () => {
     const store = buildStore();
     const before = Date.now();
 
@@ -69,10 +69,10 @@ describe('markDraft', () => {
 
     const state = store.getState();
     expect(state.requests.get(REQ_ID).draft).toBe(true);
-    expect(state.requestTimestamps.get(REQ_ID)).toBeGreaterThanOrEqual(before);
+    expect(state.requests.get(REQ_ID).lastModified).toBeGreaterThanOrEqual(before);
   });
 
-  it('updateHeader sets draft and updates requestTimestamps', () => {
+  it('updateHeader sets draft and updates lastModified', () => {
     const store = buildStore();
     store.getState().addHeader();
     const before = Date.now();
@@ -81,10 +81,10 @@ describe('markDraft', () => {
 
     const state = store.getState();
     expect(state.requests.get(REQ_ID).draft).toBe(true);
-    expect(state.requestTimestamps.get(REQ_ID)).toBeGreaterThanOrEqual(before);
+    expect(state.requests.get(REQ_ID).lastModified).toBeGreaterThanOrEqual(before);
   });
 
-  it('addHeader sets draft and updates requestTimestamps', () => {
+  it('addHeader sets draft and updates lastModified', () => {
     const store = buildStore();
     const before = Date.now();
 
@@ -92,10 +92,10 @@ describe('markDraft', () => {
 
     const state = store.getState();
     expect(state.requests.get(REQ_ID).draft).toBe(true);
-    expect(state.requestTimestamps.get(REQ_ID)).toBeGreaterThanOrEqual(before);
+    expect(state.requests.get(REQ_ID).lastModified).toBeGreaterThanOrEqual(before);
   });
 
-  it('deleteHeader sets draft and updates requestTimestamps', () => {
+  it('deleteHeader sets draft and updates lastModified', () => {
     const store = buildStore();
     store.getState().addHeader();
     const before = Date.now();
@@ -104,10 +104,10 @@ describe('markDraft', () => {
 
     const state = store.getState();
     expect(state.requests.get(REQ_ID).draft).toBe(true);
-    expect(state.requestTimestamps.get(REQ_ID)).toBeGreaterThanOrEqual(before);
+    expect(state.requests.get(REQ_ID).lastModified).toBeGreaterThanOrEqual(before);
   });
 
-  it('updateQueryParam sets draft and updates requestTimestamps', () => {
+  it('updateQueryParam sets draft and updates lastModified', () => {
     const store = buildStore();
     store.getState().addQueryParam();
     const before = Date.now();
@@ -116,10 +116,10 @@ describe('markDraft', () => {
 
     const state = store.getState();
     expect(state.requests.get(REQ_ID).draft).toBe(true);
-    expect(state.requestTimestamps.get(REQ_ID)).toBeGreaterThanOrEqual(before);
+    expect(state.requests.get(REQ_ID).lastModified).toBeGreaterThanOrEqual(before);
   });
 
-  it('updateAuthorization on a request sets draft and updates requestTimestamps', () => {
+  it('updateAuthorization on a request sets draft and updates lastModified', () => {
     const store = buildStore();
     const before = Date.now();
     const request = store.getState().requests.get(REQ_ID);
@@ -128,7 +128,7 @@ describe('markDraft', () => {
 
     const state = store.getState();
     expect(state.requests.get(REQ_ID).draft).toBe(true);
-    expect(state.requestTimestamps.get(REQ_ID)).toBeGreaterThanOrEqual(before);
+    expect(state.requests.get(REQ_ID).lastModified).toBeGreaterThanOrEqual(before);
   });
 });
 

--- a/src/renderer/state/collectionStore.test.ts
+++ b/src/renderer/state/collectionStore.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createCollectionStore } from './collectionStore';
+import { Collection } from 'shim/objects/collection';
+import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
+import { RequestMethod } from 'shim/objects/request-method';
+
+vi.mock('@/lib/ipc-stream', () => ({
+  IpcPushStream: { open: vi.fn() },
+}));
+
+vi.mock('@/state/helper/collectionUtil', () => ({
+  isRequestInAParentFolder: vi.fn(() => false),
+}));
+
+vi.mock('@/services/event/renderer-event-service', () => ({
+  RendererEventService: { instance: {} },
+}));
+
+vi.mock('@/state/variableStore', () => ({
+  useVariableStore: { getState: () => ({ initialize: vi.fn() }) },
+}));
+
+vi.mock('@/state/environmentStore', () => ({
+  useEnvironmentStore: { getState: () => ({ initialize: vi.fn() }) },
+}));
+
+const makeRequest = (id: string, parentId: string): TrufosRequest =>
+  ({
+    id,
+    parentId,
+    type: 'request',
+    title: id,
+    url: { base: 'http://localhost', query: [] },
+    method: RequestMethod.GET,
+    headers: [],
+    body: { type: RequestBodyType.TEXT, mimeType: 'text/plain' },
+    draft: false,
+  }) as unknown as TrufosRequest;
+
+const makeCollection = (id: string, children: TrufosRequest[] = []): Collection =>
+  ({
+    id,
+    parentId: null,
+    type: 'collection',
+    title: 'Test',
+    dirPath: '/test',
+    children,
+    variables: [],
+    environments: [],
+  }) as unknown as Collection;
+
+const REQ_ID = 'req-1';
+const COL_ID = 'col-1';
+
+const buildStore = () => {
+  const request = makeRequest(REQ_ID, COL_ID);
+  const collection = makeCollection(COL_ID, [request]);
+  const store = createCollectionStore(collection);
+  store.getState().setSelectedRequest(REQ_ID);
+  return store;
+};
+
+describe('markDraft', () => {
+  it('setDraftFlag sets draft and updates requestTimestamps', () => {
+    const store = buildStore();
+    const before = Date.now();
+
+    store.getState().setDraftFlag();
+
+    const state = store.getState();
+    expect(state.requests.get(REQ_ID).draft).toBe(true);
+    expect(state.requestTimestamps.get(REQ_ID)).toBeGreaterThanOrEqual(before);
+  });
+
+  it('updateHeader sets draft and updates requestTimestamps', () => {
+    const store = buildStore();
+    store.getState().addHeader();
+    const before = Date.now();
+
+    store.getState().updateHeader(0, { key: 'X-Test', value: '1', isActive: true });
+
+    const state = store.getState();
+    expect(state.requests.get(REQ_ID).draft).toBe(true);
+    expect(state.requestTimestamps.get(REQ_ID)).toBeGreaterThanOrEqual(before);
+  });
+
+  it('addHeader sets draft and updates requestTimestamps', () => {
+    const store = buildStore();
+    const before = Date.now();
+
+    store.getState().addHeader();
+
+    const state = store.getState();
+    expect(state.requests.get(REQ_ID).draft).toBe(true);
+    expect(state.requestTimestamps.get(REQ_ID)).toBeGreaterThanOrEqual(before);
+  });
+
+  it('deleteHeader sets draft and updates requestTimestamps', () => {
+    const store = buildStore();
+    store.getState().addHeader();
+    const before = Date.now();
+
+    store.getState().deleteHeader(0);
+
+    const state = store.getState();
+    expect(state.requests.get(REQ_ID).draft).toBe(true);
+    expect(state.requestTimestamps.get(REQ_ID)).toBeGreaterThanOrEqual(before);
+  });
+
+  it('updateQueryParam sets draft and updates requestTimestamps', () => {
+    const store = buildStore();
+    store.getState().addQueryParam();
+    const before = Date.now();
+
+    store.getState().updateQueryParam(0, { key: 'foo', value: 'bar' });
+
+    const state = store.getState();
+    expect(state.requests.get(REQ_ID).draft).toBe(true);
+    expect(state.requestTimestamps.get(REQ_ID)).toBeGreaterThanOrEqual(before);
+  });
+
+  it('updateAuthorization on a request sets draft and updates requestTimestamps', () => {
+    const store = buildStore();
+    const before = Date.now();
+    const request = store.getState().requests.get(REQ_ID);
+
+    store.getState().updateAuthorization(request, { type: 'bearer', token: 'abc' } as any);
+
+    const state = store.getState();
+    expect(state.requests.get(REQ_ID).draft).toBe(true);
+    expect(state.requestTimestamps.get(REQ_ID)).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe('initialize', () => {
+  it('preserves openFolders when reinitializing the same collection', () => {
+    const store = buildStore();
+    store.getState().setFolderOpen('folder-a');
+
+    store.getState().initialize(makeCollection(COL_ID));
+
+    expect(store.getState().openFolders.has('folder-a')).toBe(false); // pruned (folder not in new map)
+  });
+
+  it('resets openFolders and selectedRequestId when switching to a different collection', () => {
+    const store = buildStore();
+    store.getState().setFolderOpen('folder-a');
+
+    store.getState().initialize(makeCollection('col-2'));
+
+    const state = store.getState();
+    expect(state.openFolders.size).toBe(0);
+    expect(state.selectedRequestId).toBeUndefined();
+  });
+
+  it('keeps selectedRequestId when reinitializing with the same collection and request still exists', () => {
+    const request = makeRequest(REQ_ID, COL_ID);
+    const store = buildStore();
+
+    store.getState().initialize(makeCollection(COL_ID, [request]));
+
+    expect(store.getState().selectedRequestId).toBe(REQ_ID);
+  });
+
+  it('clears selectedRequestId when reinitializing and the selected request no longer exists', () => {
+    const store = buildStore();
+
+    store.getState().initialize(makeCollection(COL_ID, [])); // request removed
+
+    expect(store.getState().selectedRequestId).toBeUndefined();
+  });
+});

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -17,6 +17,7 @@ import { createStore } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { parseUrl } from 'shim/objects/url';
 import { ScriptType } from 'shim/scripting';
+import { SortMode } from '@/components/sidebar/SidebarRequestList/treeUtilities';
 
 const eventService = RendererEventService.instance;
 
@@ -41,6 +42,9 @@ interface CollectionState {
 
   /** The currently active script type in the script editor */
   currentScriptType: ScriptType;
+
+  /** The currently active sort mode for the sidebar */
+  sortMode: SortMode;
 }
 
 type CollectionStore = StoreApi<CollectionState & CollectionStateActions>;
@@ -86,6 +90,7 @@ export const createCollectionStore = (collection: Collection) => {
       collection,
       openFolders: new Set(),
       currentScriptType: ScriptType.PRE_REQUEST,
+      sortMode: 'default' as SortMode,
       ...buildCollectionItemMaps(collection),
 
       initialize: (collection) => {
@@ -203,6 +208,10 @@ export const createCollectionStore = (collection: Collection) => {
 
       setCurrentScriptType: (type) => {
         set({ currentScriptType: type });
+      },
+
+      setSortMode: (mode) => {
+        set({ sortMode: mode });
       },
 
       deleteRequest: async (id) => {

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -44,9 +44,6 @@ interface CollectionState {
 
   /** The currently active sort mode for the sidebar */
   sortMode: SortMode;
-
-  /** In-memory timestamps of when each request was last saved (not persisted) */
-  requestTimestamps: Map<TrufosRequest['id'], number>;
 }
 
 type CollectionStore = StoreApi<CollectionState & CollectionStateActions>;
@@ -92,8 +89,7 @@ export const createCollectionStore = (collection: Collection) => {
       collection,
       openFolders: new Set(),
       currentScriptType: ScriptType.PRE_REQUEST,
-      sortMode: 'default' as SortMode,
-      requestTimestamps: new Map(),
+      sortMode: SortMode.DEFAULT,
       ...buildCollectionItemMaps(collection),
 
       initialize: (collection) => {
@@ -217,7 +213,8 @@ export const createCollectionStore = (collection: Collection) => {
 
       touchRequest: (id) => {
         set((state) => {
-          state.requestTimestamps.set(id, Date.now());
+          const request = state.requests.get(id);
+          if (request) request.lastModified = Date.now();
         });
       },
 
@@ -545,8 +542,9 @@ const selectObject = <T extends TrufosObject>(state: CollectionState, object: T)
       : (selectFolder(state, object.id) as T);
 
 const markDraft = (state: CollectionState) => {
-  selectRequest(state).draft = true;
-  state.requestTimestamps.set(state.selectedRequestId, Date.now());
+  const request = selectRequest(state);
+  request.draft = true;
+  request.lastModified = Date.now();
 };
 
 export const selectHeaders = (state: CollectionState) => selectRequest(state).headers;

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -211,13 +211,6 @@ export const createCollectionStore = (collection: Collection) => {
         set({ sortMode: mode });
       },
 
-      touchRequest: (id) => {
-        set((state) => {
-          const request = state.requests.get(id);
-          if (request) request.lastModified = Date.now();
-        });
-      },
-
       deleteRequest: async (id) => {
         await eventService.deleteObject(selectRequest(get(), id));
 

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -45,6 +45,9 @@ interface CollectionState {
 
   /** The currently active sort mode for the sidebar */
   sortMode: SortMode;
+
+  /** In-memory timestamps of when each request was last saved (not persisted) */
+  requestTimestamps: Map<TrufosRequest['id'], number>;
 }
 
 type CollectionStore = StoreApi<CollectionState & CollectionStateActions>;
@@ -91,6 +94,7 @@ export const createCollectionStore = (collection: Collection) => {
       openFolders: new Set(),
       currentScriptType: ScriptType.PRE_REQUEST,
       sortMode: 'default' as SortMode,
+      requestTimestamps: new Map(),
       ...buildCollectionItemMaps(collection),
 
       initialize: (collection) => {
@@ -170,6 +174,7 @@ export const createCollectionStore = (collection: Collection) => {
               draft: true,
               ...updatedRequest,
             });
+            state.requestTimestamps.set(state.selectedRequestId, Date.now());
           }
         });
       },
@@ -212,6 +217,12 @@ export const createCollectionStore = (collection: Collection) => {
 
       setSortMode: (mode) => {
         set({ sortMode: mode });
+      },
+
+      touchRequest: (id) => {
+        set((state) => {
+          state.requestTimestamps.set(id, Date.now());
+        });
       },
 
       deleteRequest: async (id) => {
@@ -341,6 +352,7 @@ export const createCollectionStore = (collection: Collection) => {
       setDraftFlag: () =>
         set((state) => {
           selectRequest(state).draft = true;
+          state.requestTimestamps.set(state.selectedRequestId, Date.now());
         }),
 
       addNewFolder: async (title?, parentId?) => {

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -7,8 +7,7 @@ import { CollectionStateActions } from '@/state/interface/CollectionStateActions
 import { useVariableStore } from '@/state/variableStore';
 import { useEnvironmentStore } from '@/state/environmentStore';
 import { editor } from 'monaco-editor';
-import { isCollection, isRequest, TrufosObject } from 'shim/objects';
-import { AuthorizationInformation } from 'shim/objects';
+import { isCollection, isRequest, TrufosObject, AuthorizationInformation } from 'shim/objects';
 import { Collection } from 'shim/objects/collection';
 import { Folder } from 'shim/objects/folder';
 import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
@@ -103,11 +102,12 @@ export const createCollectionStore = (collection: Collection) => {
 
         // (re)set initial state
         set((state) => {
+          const isNewCollection = state.collection?.id !== collection.id;
           state.collection = collection;
           state.requests = requests;
           state.folders = folders;
 
-          if (state.collection?.id !== collection.id) {
+          if (isNewCollection) {
             state.selectedRequestId = undefined;
             state.openFolders = new Set();
           } else {
@@ -169,12 +169,8 @@ export const createCollectionStore = (collection: Collection) => {
           if (overwrite) {
             state.requests.set(state.selectedRequestId, updatedRequest as TrufosRequest);
           } else {
-            state.requests.set(state.selectedRequestId, {
-              ...request,
-              draft: true,
-              ...updatedRequest,
-            });
-            state.requestTimestamps.set(state.selectedRequestId, Date.now());
+            state.requests.set(state.selectedRequestId, { ...request, ...updatedRequest });
+            markDraft(state);
           }
         });
       },
@@ -264,58 +260,58 @@ export const createCollectionStore = (collection: Collection) => {
       addHeader: () =>
         set((state) => {
           selectHeaders(state).push({ key: '', value: '', isActive: false });
-          selectRequest(state).draft = true;
+          markDraft(state);
         }),
 
       updateHeader: (index, updatedHeader) =>
         set((state) => {
           const headers = selectHeaders(state);
           headers[index] = { ...headers[index], ...updatedHeader };
-          selectRequest(state).draft = true;
+          markDraft(state);
         }),
 
       deleteHeader: (index) =>
         set((state) => {
           selectHeaders(state).splice(index, 1);
-          selectRequest(state).draft = true;
+          markDraft(state);
         }),
 
       clearHeaders: () =>
         set((state) => {
           selectRequest(state).headers = [];
-          selectRequest(state).draft = true;
+          markDraft(state);
         }),
 
       addQueryParam: () =>
         set((state) => {
           selectQueryParams(state).push({ key: '', value: '', isActive: true });
-          selectRequest(state).draft = true;
+          markDraft(state);
         }),
 
       updateQueryParam: (index, updatedParam) =>
         set((state) => {
           const queryParam = selectQueryParam(state, index);
           selectQueryParams(state)[index] = { ...queryParam, ...updatedParam };
-          selectRequest(state).draft = true;
+          markDraft(state);
         }),
 
       deleteQueryParam: (index) =>
         set((state) => {
           selectQueryParams(state).splice(index, 1);
-          selectRequest(state).draft = true;
+          markDraft(state);
         }),
 
       clearQueryParams: () =>
         set((state) => {
           selectRequest(state).url.query = [];
-          selectRequest(state).draft = true;
+          markDraft(state);
         }),
 
       setQueryParamActive: (index, isActive) =>
         set((state) => {
           const queryParam = selectQueryParam(state, index);
           queryParam.isActive = isActive ?? !queryParam.isActive;
-          selectRequest(state).draft = true;
+          markDraft(state);
         }),
 
       addFormDataField: () =>
@@ -349,11 +345,7 @@ export const createCollectionStore = (collection: Collection) => {
           request.draft = true;
         }),
 
-      setDraftFlag: () =>
-        set((state) => {
-          selectRequest(state).draft = true;
-          state.requestTimestamps.set(state.selectedRequestId, Date.now());
-        }),
+      setDraftFlag: () => set(markDraft),
 
       addNewFolder: async (title?, parentId?) => {
         await eventService.saveFolder({
@@ -395,10 +387,7 @@ export const createCollectionStore = (collection: Collection) => {
 
         await eventService.rename(folder, title);
         set((state) => {
-          state.folders.set(id, {
-            ...folder,
-            title: title,
-          });
+          state.folders.set(id, { ...folder, title });
         });
       },
 
@@ -439,7 +428,7 @@ export const createCollectionStore = (collection: Collection) => {
           }
 
           if (isRequest(object)) {
-            object.draft = true;
+            markDraft(state);
           }
         });
       },
@@ -554,6 +543,11 @@ const selectObject = <T extends TrufosObject>(state: CollectionState, object: T)
     : isRequest(object)
       ? (selectRequest(state, object.id) as T)
       : (selectFolder(state, object.id) as T);
+
+const markDraft = (state: CollectionState) => {
+  selectRequest(state).draft = true;
+  state.requestTimestamps.set(state.selectedRequestId, Date.now());
+};
 
 export const selectHeaders = (state: CollectionState) => selectRequest(state).headers;
 export const selectQueryParams = (state: CollectionState) => selectRequest(state).url.query;

--- a/src/renderer/state/interface/CollectionStateActions.ts
+++ b/src/renderer/state/interface/CollectionStateActions.ts
@@ -5,6 +5,7 @@ import { TrufosHeader } from 'shim/objects/headers';
 import { TrufosQueryParam } from 'shim/objects/query-param';
 import { FormDataBody, RequestBody, TrufosRequest } from 'shim/objects/request';
 import { ScriptType } from 'shim/scripting';
+import { SortMode } from '@/components/sidebar/SidebarRequestList/treeUtilities';
 
 type FormDataField = FormDataBody['fields'][number];
 
@@ -64,6 +65,8 @@ export interface CollectionStateActions {
    * @param type The script type to switch to
    */
   setCurrentScriptType(type: ScriptType): void;
+
+  setSortMode(mode: SortMode): void;
 
   deleteRequest(id: TrufosRequest['id']): Promise<void>;
 

--- a/src/renderer/state/interface/CollectionStateActions.ts
+++ b/src/renderer/state/interface/CollectionStateActions.ts
@@ -68,6 +68,9 @@ export interface CollectionStateActions {
 
   setSortMode(mode: SortMode): void;
 
+  /** Mark a request as recently modified (in-memory only) */
+  touchRequest(id: TrufosRequest['id']): void;
+
   deleteRequest(id: TrufosRequest['id']): Promise<void>;
 
   /**

--- a/src/renderer/state/interface/CollectionStateActions.ts
+++ b/src/renderer/state/interface/CollectionStateActions.ts
@@ -68,7 +68,7 @@ export interface CollectionStateActions {
 
   setSortMode(mode: SortMode): void;
 
-  /** Mark a request as recently modified (in-memory only) */
+  /** Update the lastModified timestamp of a request to now */
   touchRequest(id: TrufosRequest['id']): void;
 
   deleteRequest(id: TrufosRequest['id']): Promise<void>;

--- a/src/renderer/state/interface/CollectionStateActions.ts
+++ b/src/renderer/state/interface/CollectionStateActions.ts
@@ -68,9 +68,6 @@ export interface CollectionStateActions {
 
   setSortMode(mode: SortMode): void;
 
-  /** Update the lastModified timestamp of a request to now */
-  touchRequest(id: TrufosRequest['id']): void;
-
   deleteRequest(id: TrufosRequest['id']): Promise<void>;
 
   /**


### PR DESCRIPTION
## Changes

Added a sort button to the sidebar header that lets you cycle through different sort modes with a single click.

The button cycles through these 5 states:

- Default — keeps the manual order you set via drag & drop
- A → Z — sorts everything alphabetically ascending, including folder contents
- Z → A — same but descending
- Recently modified — requests you edited most recently appear at the top
- Oldest modified — the other way around
- Sorting is view-only and doesn't touch the saved order in the backend.

For the time-based sorting I integrated the lastModified timestamps from #722 — so the sort works correctly even after restarting the app, not just within the current session. If you edited something in the current session without saving, that takes priority over the filesystem timestamp.

Drag & drop is automatically disabled when you're not in the default mode since reordering while sorted wouldn't make sense.

I also added a tooltip on the sort button that shows the current sort mode on hover, styled to match the sidebar's color palette.
Additionally I fixed a bug where renaming a request with unsaved changes would still show the old name after restarting the app. The rename now also updates the draft info file so the new name is correctly reflected on the next load.
## Testing

- Cycled through all 5 sort modes — icons and tooltips update correctly
- A → Z and Z → A sort folder contents recursively
- Closed and reopened the app — time sort still works correctly based on file timestamps
- Editing a request moves it to the top when sorting by recently modified
- Drag & drop is blocked in non-default modes, re-enabled when switching back to default
- Renamed a request with unsaved changes, restarted the app — new name is now shown correctly

https://streamable.com/5y0dq2

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
