### PR TITLE
fix(#696): expand min-width for OPTIONS and CONNECT in method selector

### DIFF
--- a/src/renderer/components/mainWindow/mainTopBar/HttpMethodSelect.tsx
+++ b/src/renderer/components/mainWindow/mainTopBar/HttpMethodSelect.tsx
@@ -53,7 +53,7 @@ export const HttpMethodSelect: FC<HttpMethodSelectProps> = ({
       open={isOpen}
     >
       <SelectTrigger
-        className={`cursor-pointer border ${isOpen ? 'border-accent-primary rounded-tl-3xl rounded-bl-none' : 'border-border rounded-l-full'} ease min-w-[102px] p-[8px_8px_8px_16px] transition-colors duration-300`}
+        className={`cursor-pointer border ${isOpen ? 'border-accent-primary rounded-tl-3xl rounded-bl-none' : 'border-border rounded-l-full'} ease ${[RequestMethod.OPTIONS, RequestMethod.CONNECT].includes(selectedHttpMethod) ? 'min-w-32' : 'min-w-25.5'} p-[8px_8px_8px_16px] transition-colors duration-300`}
         isOpen={isOpen}
       >
         <SelectValue ref={httpMethodSelectRef}>


### PR DESCRIPTION
## Changes

The HTTP method selector was too narrow to fully display OPTIONS and CONNECT. I added a conditional min-width that kicks in specifically for those two methods, so the text is no longer cut off. All other methods keep the original width.

## Testing

Selected OPTIONS and CONNECT in a non-maximized window — both are now fully visible
Verified all other methods (GET, POST, PUT, etc.) look unchanged

<img width="1003" height="716" alt="grafik" src="https://github.com/user-attachments/assets/b03e60bf-2f38-4a16-98f5-62a9a02f561a" />


<img width="1007" height="718" alt="grafik" src="https://github.com/user-attachments/assets/8e624eb5-688c-476e-a8a2-345282e92e2f" />

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
