### PR TITLE
Feat/725 sync script variables

### DIFF
--- a/src/main/event/main-event-service.test.ts
+++ b/src/main/event/main-event-service.test.ts
@@ -196,7 +196,7 @@ describe('MainEventService', () => {
       expect(webContentsSend).not.toHaveBeenCalled();
     });
 
-    it('persists and pushes when ScriptingService triggers onVariablesChanged', async () => {
+    it('persists and pushes when ScriptingService emits variables-changed', async () => {
       const collection = makeCollection({ x: { value: 'before' } });
       vi.spyOn(EnvironmentService.instance, 'currentCollection', 'get').mockReturnValue(collection);
 
@@ -209,7 +209,8 @@ describe('MainEventService', () => {
       eventService.webContents = { send: webContentsSend } as never;
 
       const { ScriptingService } = await import('main/scripting/scripting-service');
-      await ScriptingService.instance.onVariablesChanged!();
+      ScriptingService.instance.emit('variables-changed');
+      await Promise.resolve(); // flush microtask queue for the async .then() chain
 
       expect(saveCollectionSpy).toHaveBeenCalledWith(collection);
       expect(webContentsSend).toHaveBeenCalledWith('collection-variables-updated', {

--- a/src/main/event/main-event-service.test.ts
+++ b/src/main/event/main-event-service.test.ts
@@ -196,15 +196,8 @@ describe('MainEventService', () => {
       expect(webContentsSend).not.toHaveBeenCalled();
     });
 
-    it('persists and pushes when script changes a collection variable', async () => {
+    it('persists and pushes when ScriptingService triggers onVariablesChanged', async () => {
       const collection = makeCollection({ x: { value: 'before' } });
-
-      const { HttpService } = await import('main/network/service/http-service');
-      vi.mocked(HttpService.instance.fetchAsync).mockImplementation(async () => {
-        collection.variables['x'] = { value: 'after' };
-        return {} as never;
-      });
-
       vi.spyOn(EnvironmentService.instance, 'currentCollection', 'get').mockReturnValue(collection);
 
       const saveCollectionSpy = vi
@@ -215,7 +208,8 @@ describe('MainEventService', () => {
       const eventService = new MainEventService();
       eventService.webContents = { send: webContentsSend } as never;
 
-      await eventService.sendRequest(makeRequest());
+      const { ScriptingService } = await import('main/scripting/scripting-service');
+      await ScriptingService.instance.onVariablesChanged!();
 
       expect(saveCollectionSpy).toHaveBeenCalledWith(collection);
       expect(webContentsSend).toHaveBeenCalledWith('collection-variables-updated', {

--- a/src/main/event/main-event-service.test.ts
+++ b/src/main/event/main-event-service.test.ts
@@ -140,4 +140,88 @@ describe('MainEventService', () => {
       expect(saveRequestSpy).toHaveBeenCalledWith(request, 'body text');
     });
   });
+
+  describe('sendRequest', () => {
+    let EnvironmentService: Awaited<
+      ReturnType<typeof import('main/environment/service/environment-service')>
+    >['EnvironmentService'];
+
+    const makeCollection = (variables = {}): Collection => ({
+      id: randomUUID(),
+      type: 'collection',
+      title: 'Test',
+      isDefault: false,
+      children: [],
+      variables,
+      environments: {},
+      dirPath: '/test',
+      lastModified: Date.now(),
+    });
+
+    const makeRequest = (): TrufosRequest => ({
+      id: randomUUID(),
+      type: 'request',
+      title: 'Test Request',
+      parentId: randomUUID(),
+      method: RequestMethod.GET,
+      url: { base: 'http://example.com', query: [] },
+      headers: [],
+      body: { type: RequestBodyType.TEXT, mimeType: 'text/plain' },
+      draft: false,
+      lastModified: Date.now(),
+    });
+
+    beforeEach(async () => {
+      ({ EnvironmentService } = await import('main/environment/service/environment-service'));
+    });
+
+    it('does not persist or push when script does not change variables', async () => {
+      const collection = makeCollection({ x: { value: 'before' } });
+      vi.spyOn(EnvironmentService.instance, 'currentCollection', 'get').mockReturnValue(collection);
+
+      const { HttpService } = await import('main/network/service/http-service');
+      vi.mocked(HttpService.instance.fetchAsync).mockResolvedValue({} as never);
+
+      const saveCollectionSpy = vi
+        .spyOn(PersistenceService.instance, 'saveCollection')
+        .mockResolvedValue(undefined);
+
+      const webContentsSend = vi.fn();
+      const eventService = new MainEventService();
+      eventService.webContents = { send: webContentsSend } as never;
+
+      await eventService.sendRequest(makeRequest());
+
+      expect(saveCollectionSpy).not.toHaveBeenCalled();
+      expect(webContentsSend).not.toHaveBeenCalled();
+    });
+
+    it('persists and pushes when script changes a collection variable', async () => {
+      const collection = makeCollection({ x: { value: 'before' } });
+
+      const { HttpService } = await import('main/network/service/http-service');
+      vi.mocked(HttpService.instance.fetchAsync).mockImplementation(async () => {
+        collection.variables['x'] = { value: 'after' };
+        return {} as never;
+      });
+
+      vi.spyOn(EnvironmentService.instance, 'currentCollection', 'get').mockReturnValue(collection);
+
+      const saveCollectionSpy = vi
+        .spyOn(PersistenceService.instance, 'saveCollection')
+        .mockResolvedValue(undefined);
+
+      const webContentsSend = vi.fn();
+      const eventService = new MainEventService();
+      eventService.webContents = { send: webContentsSend } as never;
+
+      await eventService.sendRequest(makeRequest());
+
+      expect(saveCollectionSpy).toHaveBeenCalledWith(collection);
+      expect(webContentsSend).toHaveBeenCalledWith('collection-variables-updated', {
+        variables: collection.variables,
+        environments: collection.environments,
+      });
+    });
+  });
 });

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -1,4 +1,4 @@
-import { app, dialog, ipcMain } from 'electron';
+import { app, dialog, ipcMain, WebContents } from 'electron';
 import { EnvironmentService } from 'main/environment/service/environment-service';
 import { HttpService } from 'main/network/service/http-service';
 import type {
@@ -70,6 +70,7 @@ function toError(error: unknown) {
  */
 export class MainEventService implements IEventService {
   public static readonly instance = new MainEventService();
+  public webContents: WebContents | null = null;
 
   private constructor() {
     for (const propertyName of Reflect.ownKeys(MainEventService.prototype)) {
@@ -92,7 +93,24 @@ export class MainEventService implements IEventService {
   }
 
   async sendRequest(request: TrufosRequest) {
-    return await HttpService.instance.fetchAsync(request);
+    const { variables, environments } = environmentService.currentCollection;
+    const before = JSON.stringify({ variables, environments });
+
+    const response = await HttpService.instance.fetchAsync(request);
+
+    const { variables: newVariables, environments: newEnvironments } =
+      environmentService.currentCollection;
+    const after = JSON.stringify({ variables: newVariables, environments: newEnvironments });
+
+    if (before !== after) {
+      await persistenceService.saveCollection(environmentService.currentCollection);
+      this.webContents?.send('collection-variables-updated', {
+        variables: newVariables,
+        environments: newEnvironments,
+      });
+    }
+
+    return response;
   }
 
   async saveRequest(request: TrufosRequest, textBody?: string) {

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -52,8 +52,9 @@ function registerEvent<T>(instance: T, functionName: keyof T) {
   const method = instance[functionName];
   if (typeof method === 'function') {
     logger.debug(`Registering event function "${functionName}()" on backend`);
+    const boundMethod = (method as unknown as AsyncFunction<unknown>).bind(instance);
     ipcMain.handle(functionName as string, (_event, ...args) =>
-      wrapWithErrorHandler(method as unknown as AsyncFunction<unknown>)(...args)
+      wrapWithErrorHandler(boundMethod)(...args)
     );
   }
 }

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -14,6 +14,7 @@ import type {
 } from 'shim';
 import { PersistenceService } from '../persistence/service/persistence-service';
 import { ImportService } from 'main/import/service/import-service';
+import { ScriptingService } from 'main/scripting/scripting-service';
 import { updateElectronApp } from 'update-electron-app';
 
 // register stream events
@@ -77,6 +78,11 @@ export class MainEventService implements IEventService {
     for (const propertyName of Reflect.ownKeys(MainEventService.prototype)) {
       registerEvent(this, propertyName as keyof MainEventService);
     }
+    ScriptingService.instance.onVariablesChanged = async () => {
+      const { variables, environments } = environmentService.currentCollection;
+      await persistenceService.saveCollection(environmentService.currentCollection);
+      this.webContents?.send('collection-variables-updated', { variables, environments });
+    };
     logger.debug('Registered event channels on backend');
   }
 
@@ -94,24 +100,7 @@ export class MainEventService implements IEventService {
   }
 
   async sendRequest(request: TrufosRequest) {
-    const { variables, environments } = environmentService.currentCollection;
-    const before = JSON.stringify({ variables, environments });
-
-    const response = await HttpService.instance.fetchAsync(request);
-
-    const { variables: newVariables, environments: newEnvironments } =
-      environmentService.currentCollection;
-    const after = JSON.stringify({ variables: newVariables, environments: newEnvironments });
-
-    if (before !== after) {
-      await persistenceService.saveCollection(environmentService.currentCollection);
-      this.webContents?.send('collection-variables-updated', {
-        variables: newVariables,
-        environments: newEnvironments,
-      });
-    }
-
-    return response;
+    return await HttpService.instance.fetchAsync(request);
   }
 
   async saveRequest(request: TrufosRequest, textBody?: string) {

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -78,11 +78,15 @@ export class MainEventService implements IEventService {
     for (const propertyName of Reflect.ownKeys(MainEventService.prototype)) {
       registerEvent(this, propertyName as keyof MainEventService);
     }
-    ScriptingService.instance.onVariablesChanged = async () => {
+    ScriptingService.instance.on('variables-changed', () => {
       const { variables, environments } = environmentService.currentCollection;
-      await persistenceService.saveCollection(environmentService.currentCollection);
-      this.webContents?.send('collection-variables-updated', { variables, environments });
-    };
+      void persistenceService
+        .saveCollection(environmentService.currentCollection)
+        .then(() =>
+          this.webContents?.send('collection-variables-updated', { variables, environments })
+        )
+        .catch((err) => logger.error('Failed to persist variable changes', err));
+    });
     logger.debug('Registered event channels on backend');
   }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -52,6 +52,9 @@ const createWindow = async () => {
       show: false,
     });
 
+    // pass webContents to MainEventService for push notifications
+    mainEventService.webContents = mainWindow.webContents;
+
     // show once rendered
     once(mainWindow, 'ready-to-show').then(() => mainWindow.show());
 

--- a/src/main/scripting/scripting-service.test.ts
+++ b/src/main/scripting/scripting-service.test.ts
@@ -278,6 +278,47 @@ describe('ScriptingService', () => {
     });
   });
 
+  describe('executeScript() - variables-changed Event', () => {
+    it('should emit variables-changed when a collection variable is set', () => {
+      const listener = vi.fn();
+      service.on('variables-changed', listener);
+
+      service.executeScript(`trufos.setCollectionVariable('x', 'y');`);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should emit variables-changed only once even when multiple variables are set', () => {
+      const listener = vi.fn();
+      service.on('variables-changed', listener);
+
+      service.executeScript(`
+        trufos.setCollectionVariable('a', '1');
+        trufos.setCollectionVariable('b', '2');
+      `);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should emit variables-changed when an environment variable is set', () => {
+      const listener = vi.fn();
+      service.on('variables-changed', listener);
+
+      service.executeScript(`trufos.setEnvironmentVariable('baseUrl', 'http://localhost:9000');`);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not emit variables-changed when no variables are set', () => {
+      const listener = vi.fn();
+      service.on('variables-changed', listener);
+
+      service.executeScript(`const x = 1 + 1;`);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
   describe('executeScriptFromFile()', () => {
     it('should read and execute script from file', async () => {
       // Arrange

--- a/src/main/scripting/scripting-service.ts
+++ b/src/main/scripting/scripting-service.ts
@@ -4,18 +4,24 @@ import { createContext, Script } from 'node:vm';
 import { GlobalScriptingApi, VariableMap, VariableObject } from 'shim';
 import fs from 'node:fs/promises';
 import { getDurationStringFromNow, getSteadyTimestamp } from 'main/util/time-util';
+import { EventEmitter } from 'node:events';
 
 const environmentService = EnvironmentService.instance;
 
 const SCRIPT_TIMEOUT_SECONDS = 5;
 
+// Interface-Merging for typed event signatures
+export interface ScriptingService {
+  on(event: 'variables-changed', listener: () => void): this;
+  emit(event: 'variables-changed'): boolean;
+}
+
 /**
  * Service for executing user-provided scripts in an isolated VM context.
  * Scripts run in a Node.js vm context with access to the scripting API.
  */
-export class ScriptingService {
+export class ScriptingService extends EventEmitter {
   public static _instance: ScriptingService | null = null;
-  public onVariablesChanged?: () => Promise<void>;
   private _variablesChanged = false;
 
   private get api() {
@@ -106,9 +112,7 @@ export class ScriptingService {
       logger.info('Script execution error', err);
     }
     if (this._variablesChanged) {
-      void this.onVariablesChanged?.().catch((err) =>
-        logger.error('onVariablesChanged error', err)
-      );
+      this.emit('variables-changed');
     }
   }
 }

--- a/src/main/scripting/scripting-service.ts
+++ b/src/main/scripting/scripting-service.ts
@@ -15,8 +15,11 @@ const SCRIPT_TIMEOUT_SECONDS = 5;
  */
 export class ScriptingService {
   public static _instance: ScriptingService | null = null;
+  public onVariablesChanged?: () => Promise<void>;
+  private _variablesChanged = false;
 
   private get api() {
+    const self = this;
     return Object.freeze<GlobalScriptingApi>({
       trufos: {
         version: app.getVersion(),
@@ -27,6 +30,7 @@ export class ScriptingService {
 
         setCollectionVariable(name, value) {
           ScriptingService.setVariable(environmentService.currentCollection.variables, name, value);
+          self._variablesChanged = true;
         },
 
         getEnvironmentVariable(name, environment) {
@@ -37,6 +41,7 @@ export class ScriptingService {
         setEnvironmentVariable(name, value, environment) {
           const variables = ScriptingService.getEnvironmentVariables(environment);
           ScriptingService.setVariable(variables, name, value);
+          self._variablesChanged = true;
         },
       },
     });
@@ -90,6 +95,7 @@ export class ScriptingService {
       logger.info('Script compilation error', err);
       return;
     }
+    this._variablesChanged = false;
     try {
       const context = createContext(this.api, { name: 'Trufos Scripting Context' });
       const now = getSteadyTimestamp();
@@ -98,6 +104,11 @@ export class ScriptingService {
     } catch (err) {
       // TODO: Show error to user instead of just logging it.
       logger.info('Script execution error', err);
+    }
+    if (this._variablesChanged) {
+      void this.onVariablesChanged?.().catch((err) =>
+        logger.error('onVariablesChanged error', err)
+      );
     }
   }
 }

--- a/src/renderer/state/CollectionStoreProvider.test.tsx
+++ b/src/renderer/state/CollectionStoreProvider.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import { CollectionStoreProvider } from './CollectionStoreProvider';
+import { useVariableStore } from '@/state/variableStore';
+import { useEnvironmentStore } from '@/state/environmentStore';
+
+const listeners: Record<string, (...args: unknown[]) => void> = {};
+
+vi.mock('@/services/event/renderer-event-service', () => ({
+  RendererEventService: {
+    instance: {
+      on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+        listeners[event] = listener;
+      }),
+      emit: vi.fn(),
+      loadCollection: vi.fn().mockResolvedValue({
+        id: 'col-1',
+        type: 'collection',
+        title: 'Test',
+        dirPath: '/test',
+        children: [],
+        variables: {},
+        environments: {},
+        lastModified: 0,
+        isDefault: false,
+      }),
+    },
+  },
+}));
+
+vi.mock('@/lib/ipc-stream', () => ({
+  IpcPushStream: { open: vi.fn() },
+}));
+
+vi.mock('@/lib/monaco/models', () => ({
+  REQUEST_MODEL: { getValue: vi.fn() },
+  SCRIPT_MODEL: { getValue: vi.fn() },
+}));
+
+vi.mock('@/error/errorHandler', () => ({
+  showError: vi.fn(),
+}));
+
+vi.mock('@/state/helper/collectionUtil', () => ({
+  isRequestInAParentFolder: vi.fn(() => false),
+}));
+
+beforeEach(() => {
+  useVariableStore.getState().initialize({});
+  useEnvironmentStore.getState().initialize({});
+});
+
+describe('CollectionStoreProvider', () => {
+  it('updates variableStore and environmentStore when collection-variables-updated is received', async () => {
+    render(
+      <CollectionStoreProvider>
+        <div />
+      </CollectionStoreProvider>
+    );
+
+    await waitFor(() => expect(listeners['collection-variables-updated']).toBeDefined());
+
+    const testVariables = { apiKey: { value: 'test-123' } };
+    const testEnvironments = { dev: { variables: { host: { value: 'localhost' } } } };
+
+    act(() => {
+      listeners['collection-variables-updated'](
+        {}, // ipcRendererEvent (ignored)
+        { variables: testVariables, environments: testEnvironments }
+      );
+    });
+
+    expect(useVariableStore.getState().variables).toEqual(testVariables);
+    expect(useEnvironmentStore.getState().environments).toEqual(testEnvironments);
+  });
+
+  it('does not update stores when event is not fired', async () => {
+    render(
+      <CollectionStoreProvider>
+        <div />
+      </CollectionStoreProvider>
+    );
+
+    await waitFor(() => expect(listeners['collection-variables-updated']).toBeDefined());
+
+    expect(useVariableStore.getState().variables).toEqual({});
+    expect(useEnvironmentStore.getState().environments).toEqual({});
+  });
+});

--- a/src/renderer/state/CollectionStoreProvider.tsx
+++ b/src/renderer/state/CollectionStoreProvider.tsx
@@ -26,10 +26,13 @@ export const CollectionStoreProvider: FC<PropsWithChildren> = ({ children }) => 
         storeRef.current = createCollectionStore(collection);
 
         // Sync variables changed by scripts back to the frontend stores
-        rendererEventService.on('collection-variables-updated', ({ variables, environments }) => {
-          useVariableStore.getState().initialize(variables);
-          useEnvironmentStore.getState().initialize(environments);
-        });
+        rendererEventService.on(
+          'collection-variables-updated',
+          (_ipcEvent, { variables, environments }) => {
+            useVariableStore.getState().initialize(variables);
+            useEnvironmentStore.getState().initialize(environments);
+          }
+        );
 
         // Set up before-close handler with access to store instance
         rendererEventService.on('before-close', async () => {

--- a/src/renderer/state/CollectionStoreProvider.tsx
+++ b/src/renderer/state/CollectionStoreProvider.tsx
@@ -8,6 +8,8 @@ import {
 } from '@/state/collectionStore';
 import { REQUEST_MODEL, SCRIPT_MODEL } from '@/lib/monaco/models';
 import { showError } from '@/error/errorHandler';
+import { useVariableStore } from '@/state/variableStore';
+import { useEnvironmentStore } from '@/state/environmentStore';
 
 const rendererEventService = RendererEventService.instance;
 
@@ -22,6 +24,12 @@ export const CollectionStoreProvider: FC<PropsWithChildren> = ({ children }) => 
 
         // Create store with loaded collection
         storeRef.current = createCollectionStore(collection);
+
+        // Sync variables changed by scripts back to the frontend stores
+        rendererEventService.on('collection-variables-updated', ({ variables, environments }) => {
+          useVariableStore.getState().initialize(variables);
+          useEnvironmentStore.getState().initialize(environments);
+        });
 
         // Set up before-close handler with access to store instance
         rendererEventService.on('before-close', async () => {


### PR DESCRIPTION
## Changes

Variables set via `trufos.setCollectionVariable()` or `trufos.setEnvironmentVariable()` in a pre/post-request script are now persisted to disk and immediately reflected in the UI.

- After executing a request, the backend compares the variable state before and after. If anything changed, it persists the collection info file and pushes a `collection-variables-updated` IPC event to the renderer
- The frontend listens for this event and updates the variable and environment stores accordingly
- Only persists and notifies when variables actually changed (optimized as suggested in the issue)

## Testing

Unit tests verify that `saveCollection` and the IPC push are only triggered when a script actually changes variables, and not on requests without script side effects.

Frontend tests verify that the `collection-variables-updated` listener correctly updates both the variable and environment stores.

Manual testing was performed with a pre-request script that increments a counter and sets a timestamp on each request. The attached video (https://streamable.com/hk905y) demonstrates that variable changes are immediately visible in the UI and persist correctly after restarting the app.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
