### PR TITLE
Feat/620 client certificate

### DIFF
--- a/examples/collection/collection.json
+++ b/examples/collection/collection.json
@@ -1,7 +1,7 @@
 {
   "id": "dbba497e-b5a1-47f3-86d4-5461c01e034f",
   "title": "New Collection",
-  "version": "2.2.0",
+  "version": "2.4.0",
   "variables": {
     "test": {
       "value": "I contain text",

--- a/examples/collection/echo/request.json
+++ b/examples/collection/echo/request.json
@@ -1,7 +1,7 @@
 {
   "id": "35efb7a3-84ab-4d28-a91c-2945c0591c6e",
   "title": "Echo",
-  "version": "2.2.0",
+  "version": "2.4.0",
   "url": {
     "base": "https://echo.free.beeceptor.com",
     "query": []

--- a/src/main/environment/service/environment-service.ts
+++ b/src/main/environment/service/environment-service.ts
@@ -2,7 +2,7 @@ import { Readable } from 'node:stream';
 import { TemplateReplaceStream } from 'template-replace-stream';
 import { Initializable } from 'main/shared/initializable';
 import { PersistenceService } from 'main/persistence/service/persistence-service';
-import { Collection, CollectionBase } from 'shim/objects/collection';
+import { ClientCertificate, Collection, CollectionBase } from 'shim/objects/collection';
 import { VariableMap } from 'shim/objects/variables';
 import { getSystemVariable, getSystemVariables } from './system-variable';
 import { SettingsService } from 'main/persistence/service/settings-service';
@@ -87,6 +87,10 @@ export class EnvironmentService implements Initializable {
   public setEnvironmentVariables(environmentVariables: EnvironmentMap) {
     logger.secret?.debug('Setting environment variables:', environmentVariables);
     this.currentCollection.environments = environmentVariables;
+  }
+
+  public setClientCertificate(clientCertificate: ClientCertificate | null) {
+    this.currentCollection.clientCertificate = clientCertificate ?? undefined;
   }
 
   /**

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -12,6 +12,7 @@ import type {
   IEventService,
   ImportStrategy,
 } from 'shim';
+import type { ClientCertificate } from 'shim/objects/collection';
 import { PersistenceService } from '../persistence/service/persistence-service';
 import { ImportService } from 'main/import/service/import-service';
 import { ScriptingService } from 'main/scripting/scripting-service';
@@ -150,6 +151,11 @@ export class MainEventService implements IEventService {
 
   async setEnvironmentVariables(environmentVariables: EnvironmentMap) {
     environmentService.setEnvironmentVariables(environmentVariables);
+    await persistenceService.saveCollection(environmentService.currentCollection);
+  }
+
+  async setClientCertificate(clientCertificate: ClientCertificate | null) {
+    environmentService.setClientCertificate(clientCertificate);
     await persistenceService.saveCollection(environmentService.currentCollection);
   }
 

--- a/src/main/network/service/http-service.test.ts
+++ b/src/main/network/service/http-service.test.ts
@@ -282,7 +282,7 @@ describe('HttpService', () => {
     const url = new URL('https://example.com/formtext');
     const mockClient = mockAgent.get(url.origin);
     mockClient.intercept({ path: url.pathname, method: 'POST' }).reply(200, 'OK');
-    const httpService = new HttpService(mockAgent);
+    const httpService = new HttpService(() => Promise.resolve(mockAgent));
     const request: TrufosRequest = {
       id: randomUUID(),
       parentId: randomUUID(),
@@ -322,7 +322,7 @@ describe('HttpService', () => {
     const url = new URL('https://example.com/formfile');
     const mockClient = mockAgent.get(url.origin);
     mockClient.intercept({ path: url.pathname, method: 'POST' }).reply(200, 'OK');
-    const httpService = new HttpService(mockAgent);
+    const httpService = new HttpService(() => Promise.resolve(mockAgent));
 
     const fileContent = 'test file content';
     const { Readable } = require('node:stream');
@@ -381,7 +381,7 @@ describe('HttpService', () => {
     const url = new URL('https://example.com/formvars');
     const mockClient = mockAgent.get(url.origin);
     mockClient.intercept({ path: url.pathname, method: 'POST' }).reply(200, 'OK');
-    const httpService = new HttpService(mockAgent);
+    const httpService = new HttpService(() => Promise.resolve(mockAgent));
 
     const request: TrufosRequest = {
       id: randomUUID(),
@@ -470,5 +470,5 @@ function setupMockHttpService(
 
   const mockClient = mockAgent.get(url.origin);
   mockClient.intercept({ path: url.pathname }).reply(200, bodyString, { headers: headers });
-  return new HttpService(mockAgent);
+  return new HttpService(() => Promise.resolve(mockAgent));
 }

--- a/src/main/network/service/http-service.test.ts
+++ b/src/main/network/service/http-service.test.ts
@@ -29,6 +29,7 @@ describe('HttpService', () => {
 
   beforeEach(() => {
     vi.spyOn(PersistenceService.instance, 'loadScript').mockResolvedValue(null);
+    vi.spyOn(environmentService, 'currentCollection', 'get').mockReturnValue({ clientCertificate: null } as never);
   });
 
   it('fetchAsync() should make an HTTP call and return the body on read', async () => {

--- a/src/main/network/service/http-service.test.ts
+++ b/src/main/network/service/http-service.test.ts
@@ -29,7 +29,9 @@ describe('HttpService', () => {
 
   beforeEach(() => {
     vi.spyOn(PersistenceService.instance, 'loadScript').mockResolvedValue(null);
-    vi.spyOn(environmentService, 'currentCollection', 'get').mockReturnValue({ clientCertificate: null } as never);
+    vi.spyOn(environmentService, 'currentCollection', 'get').mockReturnValue({
+      clientCertificate: null,
+    } as never);
   });
 
   it('fetchAsync() should make an HTTP call and return the body on read', async () => {

--- a/src/main/network/service/http-service.ts
+++ b/src/main/network/service/http-service.ts
@@ -3,6 +3,7 @@ import { getDurationFromNow, getSteadyTimestamp } from 'main/util/time-util';
 import { FileSystemService } from 'main/filesystem/filesystem-service';
 import { pipeline } from 'node:stream/promises';
 import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import { Readable } from 'stream';
 import { EnvironmentService } from 'main/environment/service/environment-service';
 import { RequestBody, RequestBodyType, TrufosRequest } from 'shim/objects/request';
@@ -36,6 +37,19 @@ export class HttpService {
 
   constructor(dispatcher?: Dispatcher) {
     this._dispatcher = dispatcher ?? new Agent({ connect: { rejectUnauthorized: false } }); // allow self-signed certificates
+  }
+
+  private async buildDispatcher(): Promise<Dispatcher> {
+    const cert = environmentService.currentCollection.clientCertificate;
+    if (cert == null) return this._dispatcher!;
+    return new Agent({
+      connect: {
+        rejectUnauthorized: false,
+        cert: await fsp.readFile(cert.certPath),
+        key: await fsp.readFile(cert.keyPath),
+        ca: cert.caPath ? await fsp.readFile(cert.caPath) : undefined,
+      },
+    });
   }
 
   /**
@@ -72,7 +86,7 @@ export class HttpService {
     // measure duration of the request
     const now = getSteadyTimestamp();
     const responseData = await undici.request(url, {
-      dispatcher: this._dispatcher,
+      dispatcher: await this.buildDispatcher(),
       method: request.method,
       headers: {
         ['content-type']: this.getContentType(request.body),

--- a/src/main/network/service/http-service.ts
+++ b/src/main/network/service/http-service.ts
@@ -26,6 +26,7 @@ const responseBodyService = ResponseBodyService.instance;
 const scriptingService = ScriptingService.instance;
 
 declare type HttpHeaders = Record<string, string[]>;
+declare type DispatcherProvider = () => Promise<Dispatcher>;
 
 /**
  * Singleton service for making HTTP requests
@@ -33,15 +34,17 @@ declare type HttpHeaders = Record<string, string[]>;
 export class HttpService {
   public static readonly instance = new HttpService();
 
-  private readonly _dispatcher?: Dispatcher;
+  private readonly _dispatcherProvider: DispatcherProvider;
 
-  constructor(dispatcher?: Dispatcher) {
-    this._dispatcher = dispatcher ?? new Agent({ connect: { rejectUnauthorized: false } }); // allow self-signed certificates
+  constructor(dispatcherProvider?: DispatcherProvider) {
+    this._dispatcherProvider = dispatcherProvider ?? this.buildDefaultDispatcher.bind(this);
   }
 
-  private async buildDispatcher(): Promise<Dispatcher> {
+  private async buildDefaultDispatcher(): Promise<Dispatcher> {
     const cert = environmentService.currentCollection.clientCertificate;
-    if (cert == null) return this._dispatcher!;
+    if (cert == null) {
+      return new Agent({ connect: { rejectUnauthorized: false } }); // allow self-signed certificates
+    }
     return new Agent({
       connect: {
         rejectUnauthorized: false,
@@ -86,7 +89,7 @@ export class HttpService {
     // measure duration of the request
     const now = getSteadyTimestamp();
     const responseData = await undici.request(url, {
-      dispatcher: await this.buildDispatcher(),
+      dispatcher: await this._dispatcherProvider(),
       method: request.method,
       headers: {
         ['content-type']: this.getContentType(request.body),

--- a/src/main/persistence/service/info-files/latest.ts
+++ b/src/main/persistence/service/info-files/latest.ts
@@ -4,11 +4,11 @@ import { Collection } from 'shim/objects/collection';
 import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
 import { VariableMap } from 'shim/objects/variables';
-import { InfoFile, VERSION, RequestInfoFile, FolderInfoFile, CollectionInfoFile } from './v2-2-0';
+import { InfoFile, VERSION, RequestInfoFile, FolderInfoFile, CollectionInfoFile } from './v2-4-0';
 import { SettingsService } from '../settings-service';
 
 export { createGitIgnore, GIT_IGNORE_FILE_NAME } from './v2-0-0';
-export { VERSION, InfoFile, CollectionInfoFile, FolderInfoFile, RequestInfoFile } from './v2-2-0';
+export { VERSION, InfoFile, CollectionInfoFile, FolderInfoFile, RequestInfoFile } from './v2-4-0';
 
 /**
  * Deep clones the given object and removes any properties that are not allowed in an info file.

--- a/src/main/persistence/service/info-files/migrators.ts
+++ b/src/main/persistence/service/info-files/migrators.ts
@@ -9,6 +9,8 @@ import { InfoFileMigrator as V1_4_0 } from './v1-4-0';
 import { InfoFileMigrator as V2_0_0 } from './v2-0-0';
 import { InfoFileMigrator as V2_1_0 } from './v2-1-0';
 import { InfoFileMigrator as V2_2_0 } from './v2-2-0';
+import { InfoFileMigrator as V2_3_0 } from './v2-3-0';
+import { InfoFileMigrator as V2_4_0 } from './v2-4-0';
 import { SemVer } from 'main/util/semver';
 
 // add new migrators here
@@ -21,6 +23,8 @@ const MIGRATOR_ARRAY = [
   new V2_0_0(),
   new V2_1_0(),
   new V2_2_0(),
+  new V2_3_0(),
+  new V2_4_0(),
 ];
 
 const MIGRATORS = new Map<string, AbstractInfoFileMigrator<VersionedObject, VersionedObject>>(

--- a/src/main/persistence/service/info-files/v2-4-0.ts
+++ b/src/main/persistence/service/info-files/v2-4-0.ts
@@ -1,0 +1,62 @@
+import {
+  TrufosURL,
+  RequestBody,
+  VariableMap,
+  EnvironmentMap,
+  RequestMethod,
+  TrufosHeader,
+  TrufosObjectType,
+  AuthorizationInformation,
+  AuthorizationInformationNoInherit,
+} from 'shim/objects';
+import { ClientCertificate } from 'shim/objects/collection';
+import { SemVer } from 'main/util/semver';
+import { AbstractInfoFileMigrator } from './migrator';
+import { InfoFile as OldInfoFile, VERSION as OLD_VERSION } from './v2-3-0';
+import z from 'zod';
+
+export const VERSION = new SemVer(2, 4, 0);
+
+export const InfoFileBase = z.object({
+  id: z.string(),
+  version: z.literal(VERSION.string),
+  title: z.string(),
+});
+export type InfoFileBase = z.infer<typeof InfoFileBase>;
+
+export const RequestInfoFile = InfoFileBase.extend({
+  url: TrufosURL,
+  method: z.enum(RequestMethod),
+  headers: TrufosHeader.array(),
+  body: RequestBody,
+  auth: AuthorizationInformation.optional(),
+});
+export type RequestInfoFile = z.infer<typeof RequestInfoFile>;
+
+export const FolderInfoFile = InfoFileBase;
+export type FolderInfoFile = z.infer<typeof FolderInfoFile>;
+
+export const CollectionInfoFile = InfoFileBase.extend({
+  environments: EnvironmentMap,
+  variables: VariableMap,
+  auth: AuthorizationInformationNoInherit.optional(),
+  clientCertificate: ClientCertificate.optional(),
+});
+export type CollectionInfoFile = z.infer<typeof CollectionInfoFile>;
+
+export const InfoFile = z.union([RequestInfoFile, FolderInfoFile, CollectionInfoFile]);
+export type InfoFile = z.infer<typeof InfoFile>;
+
+/**
+ * Migrates schema `v2.3.0` to `v2.4.0`.
+ *
+ * Changes:
+ * - Adds optional `clientCertificate` field to CollectionInfoFile for mTLS support.
+ */
+export class InfoFileMigrator extends AbstractInfoFileMigrator<OldInfoFile, InfoFile> {
+  public readonly fromVersion = OLD_VERSION.toString();
+
+  async migrate(old: OldInfoFile, type: TrufosObjectType, filePath: string): Promise<InfoFile> {
+    return Object.assign(old, { version: VERSION.toString() });
+  }
+}

--- a/src/renderer/components/shared/settings/SettingsModal.tsx
+++ b/src/renderer/components/shared/settings/SettingsModal.tsx
@@ -9,6 +9,7 @@ import {
 import { FiSettings } from 'react-icons/fi';
 import { VariableEditor } from '@/components/shared/settings/VariableTab/VariableEditor';
 import { EnvironmentEditor } from '@/components/shared/settings/EnvironmentTab/EnvironmentEditor';
+import { CertificateEditor } from '@/components/shared/settings/TlsTab/CertificateEditor';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { useEffect, useState } from 'react';
@@ -20,6 +21,11 @@ import {
   useEnvironmentStore,
 } from '@/state/environmentStore';
 import { variableArrayToMap, variableMapToArray } from '@/state/helper/variableMappers';
+import { useCollectionStore } from '@/state/collectionStore';
+import { ClientCertificate } from 'shim/objects/collection';
+import { RendererEventService } from '@/services/event/renderer-event-service';
+
+const eventService = RendererEventService.instance;
 
 export const SettingsModal = () => {
   const { setVariables } = useVariableActions();
@@ -28,10 +34,12 @@ export const SettingsModal = () => {
   const variables = useVariableStore(selectVariables);
   const environments = useEnvironmentStore(selectEnvironments);
   const selectedEnvironment = useEnvironmentStore(selectSelectedEnvironment);
+  const storedCertificate = useCollectionStore((s) => s.collection?.clientCertificate ?? null);
 
   const [editorVariables, setEditorVariables] = useState(variableMapToArray(variables));
   const [editorEnvironments, setEditorEnvironments] = useState(environments);
   const [editorSelectedEnvironment, setEditorSelectedEnvironment] = useState(selectedEnvironment);
+  const [editorCertificate, setEditorCertificate] = useState<ClientCertificate | null>(null);
   const [isValid, setValid] = useState(false);
   const [isEnvironmentValid, setEnvironmentValid] = useState(true);
   const [isOpen, setOpen] = useState(false);
@@ -42,6 +50,7 @@ export const SettingsModal = () => {
       setEditorVariables(variableMapToArray(variables));
       setEditorEnvironments(environments);
       setEditorSelectedEnvironment(selectedEnvironment);
+      setEditorCertificate(storedCertificate);
     }
   }, [isOpen]);
 
@@ -49,6 +58,7 @@ export const SettingsModal = () => {
     await setVariables(variableArrayToMap(editorVariables));
     await setEnvironments(editorEnvironments);
     await selectEnvironment(editorSelectedEnvironment);
+    await eventService.setClientCertificate(editorCertificate);
   };
 
   // We intentionally do NOT call cancel() after a successful save because cancel() reverts
@@ -86,6 +96,9 @@ export const SettingsModal = () => {
                 <TabsTrigger value="environments" className="font-light!">
                   Environments
                 </TabsTrigger>
+                <TabsTrigger value="tls" className="font-light!">
+                  TLS
+                </TabsTrigger>
               </TabsList>
             </div>
 
@@ -106,6 +119,13 @@ export const SettingsModal = () => {
                 onEnvironmentsChange={setEditorEnvironments}
                 onEnvironmentSelect={setEditorSelectedEnvironment}
                 onValidChange={setEnvironmentValid}
+              />
+            </TabsContent>
+
+            <TabsContent value="tls" className="m-0 min-h-0 flex-1 overflow-y-auto p-0">
+              <CertificateEditor
+                certificate={editorCertificate}
+                onCertificateChange={setEditorCertificate}
               />
             </TabsContent>
           </Tabs>

--- a/src/renderer/components/shared/settings/SettingsModal.tsx
+++ b/src/renderer/components/shared/settings/SettingsModal.tsx
@@ -23,9 +23,6 @@ import {
 import { variableArrayToMap, variableMapToArray } from '@/state/helper/variableMappers';
 import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
 import { ClientCertificate } from 'shim/objects/collection';
-import { RendererEventService } from '@/services/event/renderer-event-service';
-
-const eventService = RendererEventService.instance;
 
 export const SettingsModal = () => {
   const { setVariables } = useVariableActions();
@@ -59,8 +56,7 @@ export const SettingsModal = () => {
     await setVariables(variableArrayToMap(editorVariables));
     await setEnvironments(editorEnvironments);
     await selectEnvironment(editorSelectedEnvironment);
-    await eventService.setClientCertificate(editorCertificate);
-    setClientCertificate(editorCertificate);
+    await setClientCertificate(editorCertificate);
   };
 
   // We intentionally do NOT call cancel() after a successful save because cancel() reverts
@@ -99,7 +95,7 @@ export const SettingsModal = () => {
                   Environments
                 </TabsTrigger>
                 <TabsTrigger value="tls" className="font-light!">
-                  TLS
+                  mTLS
                 </TabsTrigger>
               </TabsList>
             </div>

--- a/src/renderer/components/shared/settings/SettingsModal.tsx
+++ b/src/renderer/components/shared/settings/SettingsModal.tsx
@@ -21,7 +21,7 @@ import {
   useEnvironmentStore,
 } from '@/state/environmentStore';
 import { variableArrayToMap, variableMapToArray } from '@/state/helper/variableMappers';
-import { useCollectionStore } from '@/state/collectionStore';
+import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
 import { ClientCertificate } from 'shim/objects/collection';
 import { RendererEventService } from '@/services/event/renderer-event-service';
 
@@ -30,6 +30,7 @@ const eventService = RendererEventService.instance;
 export const SettingsModal = () => {
   const { setVariables } = useVariableActions();
   const { setEnvironments, selectEnvironment } = useEnvironmentActions();
+  const { setClientCertificate } = useCollectionActions();
 
   const variables = useVariableStore(selectVariables);
   const environments = useEnvironmentStore(selectEnvironments);
@@ -59,6 +60,7 @@ export const SettingsModal = () => {
     await setEnvironments(editorEnvironments);
     await selectEnvironment(editorSelectedEnvironment);
     await eventService.setClientCertificate(editorCertificate);
+    setClientCertificate(editorCertificate);
   };
 
   // We intentionally do NOT call cancel() after a successful save because cancel() reverts

--- a/src/renderer/components/shared/settings/TlsTab/CertificateEditor.test.tsx
+++ b/src/renderer/components/shared/settings/TlsTab/CertificateEditor.test.tsx
@@ -76,4 +76,49 @@ describe('CertificateEditor', () => {
 
     expect(onChangeMock).toHaveBeenCalledWith({ certPath: '', keyPath: '', caPath: undefined });
   });
+
+  it('shows clear buttons only for fields that have a value', () => {
+    const partialCert: ClientCertificate = {
+      certPath: '/path/to/cert.pem',
+      keyPath: '',
+      caPath: undefined,
+    };
+    render(<CertificateEditor certificate={partialCert} onCertificateChange={vi.fn()} />);
+
+    const clearButtons = screen.getAllByRole('button', { name: /clear/i });
+    expect(clearButtons).toHaveLength(1); // only certPath has a value
+  });
+
+  it('clears certPath when its Clear button is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangeMock = vi.fn();
+    render(<CertificateEditor certificate={CERT} onCertificateChange={onChangeMock} />);
+
+    const clearButtons = screen.getAllByRole('button', { name: /clear/i });
+    await user.click(clearButtons[0]); // first Clear = certPath
+
+    expect(onChangeMock).toHaveBeenCalledWith({ ...CERT, certPath: '' });
+  });
+
+  it('clears keyPath when its Clear button is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangeMock = vi.fn();
+    render(<CertificateEditor certificate={CERT} onCertificateChange={onChangeMock} />);
+
+    const clearButtons = screen.getAllByRole('button', { name: /clear/i });
+    await user.click(clearButtons[1]); // second Clear = keyPath
+
+    expect(onChangeMock).toHaveBeenCalledWith({ ...CERT, keyPath: '' });
+  });
+
+  it('clears caPath when its Clear button is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangeMock = vi.fn();
+    render(<CertificateEditor certificate={CERT} onCertificateChange={onChangeMock} />);
+
+    const clearButtons = screen.getAllByRole('button', { name: /clear/i });
+    await user.click(clearButtons[2]); // third Clear = caPath
+
+    expect(onChangeMock).toHaveBeenCalledWith({ ...CERT, caPath: undefined });
+  });
 });

--- a/src/renderer/components/shared/settings/TlsTab/CertificateEditor.test.tsx
+++ b/src/renderer/components/shared/settings/TlsTab/CertificateEditor.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { CertificateEditor } from './CertificateEditor';
+import { ClientCertificate } from 'shim/objects/collection';
+
+const { showOpenDialogMock } = vi.hoisted(() => ({ showOpenDialogMock: vi.fn() }));
+
+vi.mock('@/services/event/renderer-event-service', () => ({
+  RendererEventService: {
+    instance: { showOpenDialog: showOpenDialogMock },
+  },
+}));
+
+const CERT: ClientCertificate = {
+  certPath: '/path/to/cert.pem',
+  keyPath: '/path/to/key.pem',
+  caPath: '/path/to/ca.pem',
+};
+
+describe('CertificateEditor', () => {
+  beforeEach(() => {
+    showOpenDialogMock.mockReset();
+  });
+
+  it('shows empty state when no certificate is configured', () => {
+    render(<CertificateEditor certificate={null} onCertificateChange={vi.fn()} />);
+    expect(screen.getByText(/no client certificate/i)).toBeTruthy();
+  });
+
+  it('shows configured certificate paths', () => {
+    render(<CertificateEditor certificate={CERT} onCertificateChange={vi.fn()} />);
+    expect(screen.getByDisplayValue('/path/to/cert.pem')).toBeTruthy();
+    expect(screen.getByDisplayValue('/path/to/key.pem')).toBeTruthy();
+    expect(screen.getByDisplayValue('/path/to/ca.pem')).toBeTruthy();
+  });
+
+  it('calls onCertificateChange with null when Remove is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangeMock = vi.fn();
+    render(<CertificateEditor certificate={CERT} onCertificateChange={onChangeMock} />);
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+    expect(onChangeMock).toHaveBeenCalledWith(null);
+  });
+
+  it('opens file dialog and updates certPath when Browse is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangeMock = vi.fn();
+    showOpenDialogMock.mockResolvedValue({ canceled: false, filePaths: ['/new/cert.pem'] });
+    render(<CertificateEditor certificate={CERT} onCertificateChange={onChangeMock} />);
+
+    const browseButtons = screen.getAllByRole('button', { name: /browse/i });
+    await user.click(browseButtons[0]); // first Browse = certPath
+
+    expect(onChangeMock).toHaveBeenCalledWith({ ...CERT, certPath: '/new/cert.pem' });
+  });
+
+  it('does not update when file dialog is canceled', async () => {
+    const user = userEvent.setup();
+    const onChangeMock = vi.fn();
+    showOpenDialogMock.mockResolvedValue({ canceled: true, filePaths: [] });
+    render(<CertificateEditor certificate={CERT} onCertificateChange={onChangeMock} />);
+
+    const browseButtons = screen.getAllByRole('button', { name: /browse/i });
+    await user.click(browseButtons[0]);
+
+    expect(onChangeMock).not.toHaveBeenCalled();
+  });
+
+  it('initializes empty certificate fields when Add Certificate is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangeMock = vi.fn();
+    render(<CertificateEditor certificate={null} onCertificateChange={onChangeMock} />);
+
+    await user.click(screen.getByRole('button', { name: /add certificate/i }));
+
+    expect(onChangeMock).toHaveBeenCalledWith({ certPath: '', keyPath: '', caPath: undefined });
+  });
+});

--- a/src/renderer/components/shared/settings/TlsTab/CertificateEditor.tsx
+++ b/src/renderer/components/shared/settings/TlsTab/CertificateEditor.tsx
@@ -1,0 +1,118 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { FolderOpen, Trash2 } from 'lucide-react';
+import { AddIcon } from '@/components/icons';
+import { RendererEventService } from '@/services/event/renderer-event-service';
+import { ClientCertificate } from 'shim/objects/collection';
+
+const eventService = RendererEventService.instance;
+
+export interface CertificateEditorProps {
+  certificate: ClientCertificate | null;
+  onCertificateChange: (certificate: ClientCertificate | null) => void;
+}
+
+async function pickFile(): Promise<string | null> {
+  const result = await eventService.showOpenDialog({ properties: ['openFile'] });
+  if (result.canceled || result.filePaths.length === 0) return null;
+  return result.filePaths[0];
+}
+
+export const CertificateEditor = ({ certificate, onCertificateChange }: CertificateEditorProps) => {
+  const handleBrowse = async (field: keyof ClientCertificate) => {
+    const path = await pickFile();
+    if (path == null) return;
+    onCertificateChange({ ...(certificate ?? { certPath: '', keyPath: '' }), [field]: path });
+  };
+
+  if (certificate == null) {
+    return (
+      <div className="flex h-full flex-col p-4">
+        <Button
+          className="h-fit gap-1 pl-0 hover:bg-transparent"
+          size="sm"
+          variant="ghost"
+          onClick={() => onCertificateChange({ certPath: '', keyPath: '', caPath: undefined })}
+        >
+          <AddIcon /> Add Certificate
+        </Button>
+
+        <div className="text-muted-foreground flex flex-1 items-center justify-center">
+          <div className="text-center">
+            <div className="mb-2 text-lg font-medium">No Client Certificate</div>
+            <div className="text-sm">Add a certificate to enable mutual TLS authentication</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="shrink-0 border-b p-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sidebar-foreground font-medium">Client Certificate</h3>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="hover:text-accent-primary active:text-accent-secondary w-5 hover:bg-transparent"
+            aria-label="Remove"
+            onClick={() => onCertificateChange(null)}
+          >
+            <Trash2 />
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex-1 space-y-6 overflow-y-auto p-4">
+        <CertField
+          label="Certificate"
+          value={certificate.certPath}
+          placeholder="Path to client certificate (.pem / .crt)"
+          onChange={(v) => onCertificateChange({ ...certificate, certPath: v })}
+          onBrowse={() => handleBrowse('certPath')}
+        />
+        <CertField
+          label="Private Key"
+          value={certificate.keyPath}
+          placeholder="Path to private key (.pem / .key)"
+          onChange={(v) => onCertificateChange({ ...certificate, keyPath: v })}
+          onBrowse={() => handleBrowse('keyPath')}
+        />
+        <CertField
+          label="CA Certificate (optional)"
+          value={certificate.caPath ?? ''}
+          placeholder="Path to CA certificate (.pem / .crt)"
+          onChange={(v) => onCertificateChange({ ...certificate, caPath: v || undefined })}
+          onBrowse={() => handleBrowse('caPath')}
+        />
+      </div>
+    </div>
+  );
+};
+
+interface CertFieldProps {
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+  onBrowse: () => void;
+}
+
+const CertField = ({ label, value, placeholder, onChange, onBrowse }: CertFieldProps) => (
+  <div className="space-y-1">
+    <label className="text-sm font-medium">{label}</label>
+    <div className="flex gap-2">
+      <Input
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        className="flex-1"
+      />
+      <Button variant="ghost" size="sm" className="shrink-0 gap-1 hover:bg-transparent" onClick={onBrowse}>
+        <FolderOpen className="h-4 w-4" />
+        Browse
+      </Button>
+    </div>
+  </div>
+);

--- a/src/renderer/components/shared/settings/TlsTab/CertificateEditor.tsx
+++ b/src/renderer/components/shared/settings/TlsTab/CertificateEditor.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Trash2 } from 'lucide-react';
-import { AddIcon, FolderSearchIcon } from '@/components/icons';
+import { AddIcon, DeleteIcon, FolderSearchIcon } from '@/components/icons';
 import { RendererEventService } from '@/services/event/renderer-event-service';
 import { ClientCertificate } from 'shim/objects/collection';
 
@@ -55,11 +54,11 @@ export const CertificateEditor = ({ certificate, onCertificateChange }: Certific
           <Button
             variant="ghost"
             size="icon"
-            className="hover:text-accent-primary active:text-accent-secondary w-5 hover:bg-transparent"
+            className="hover:text-accent-primary active:text-accent-secondary hover:bg-transparent"
             aria-label="Remove"
             onClick={() => onCertificateChange(null)}
           >
-            <Trash2 />
+            <DeleteIcon size={24} />
           </Button>
         </div>
       </div>
@@ -112,12 +111,23 @@ const CertField = ({ label, value, placeholder, onChange, onBrowse }: CertFieldP
       <Button
         variant="ghost"
         size="icon"
-        className="shrink-0 hover:bg-transparent [&_.fills_path]:fill-foreground [&_.strokes_path]:stroke-foreground hover:[&_.fills_path]:fill-accent-primary hover:[&_.strokes_path]:stroke-accent-primary"
+        className="[&_.fills_path]:fill-foreground [&_.strokes_path]:stroke-foreground hover:[&_.fills_path]:fill-accent-primary hover:[&_.strokes_path]:stroke-accent-primary shrink-0 hover:bg-transparent"
         aria-label="Browse"
         onClick={onBrowse}
       >
         <FolderSearchIcon size={28} />
       </Button>
+      {value && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="hover:text-accent-primary active:text-accent-secondary shrink-0 hover:bg-transparent"
+          aria-label="Clear"
+          onClick={() => onChange('')}
+        >
+          <DeleteIcon size={28} />
+        </Button>
+      )}
     </div>
   </div>
 );

--- a/src/renderer/components/shared/settings/TlsTab/CertificateEditor.tsx
+++ b/src/renderer/components/shared/settings/TlsTab/CertificateEditor.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { FolderOpen, Trash2 } from 'lucide-react';
-import { AddIcon } from '@/components/icons';
+import { Trash2 } from 'lucide-react';
+import { AddIcon, FolderSearchIcon } from '@/components/icons';
 import { RendererEventService } from '@/services/event/renderer-event-service';
 import { ClientCertificate } from 'shim/objects/collection';
 
@@ -109,9 +109,14 @@ const CertField = ({ label, value, placeholder, onChange, onBrowse }: CertFieldP
         onChange={(e) => onChange(e.target.value)}
         className="flex-1"
       />
-      <Button variant="ghost" size="sm" className="shrink-0 gap-1 hover:bg-transparent" onClick={onBrowse}>
-        <FolderOpen className="h-4 w-4" />
-        Browse
+      <Button
+        variant="ghost"
+        size="icon"
+        className="shrink-0 hover:bg-transparent [&_.fills_path]:fill-foreground [&_.strokes_path]:stroke-foreground hover:[&_.fills_path]:fill-accent-primary hover:[&_.strokes_path]:stroke-accent-primary"
+        aria-label="Browse"
+        onClick={onBrowse}
+      >
+        <FolderSearchIcon size={28} />
       </Button>
     </div>
   </div>

--- a/src/renderer/services/event/renderer-event-service.ts
+++ b/src/renderer/services/event/renderer-event-service.ts
@@ -69,4 +69,5 @@ export class RendererEventService implements IEventService {
   reorderItem = createEventMethod('reorderItem');
   updateApp = createEventMethod('updateApp');
   saveScript = createEventMethod('saveScript');
+  setClientCertificate = createEventMethod('setClientCertificate');
 }

--- a/src/renderer/state/collectionStore.test.ts
+++ b/src/renderer/state/collectionStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createCollectionStore } from './collectionStore';
-import { Collection } from 'shim/objects/collection';
+import { ClientCertificate, Collection } from 'shim/objects/collection';
 import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { RequestMethod } from 'shim/objects/request-method';
 
@@ -168,5 +168,40 @@ describe('initialize', () => {
     store.getState().initialize(makeCollection(COL_ID, [])); // request removed
 
     expect(store.getState().selectedRequestId).toBeUndefined();
+  });
+});
+
+describe('setClientCertificate', () => {
+  const CERT: ClientCertificate = {
+    certPath: '/path/to/cert.pem',
+    keyPath: '/path/to/key.pem',
+    caPath: '/path/to/ca.pem',
+  };
+
+  it('sets the client certificate on the collection', () => {
+    const store = createCollectionStore(makeCollection(COL_ID));
+
+    store.getState().setClientCertificate(CERT);
+
+    expect(store.getState().collection?.clientCertificate).toEqual(CERT);
+  });
+
+  it('clears the client certificate when called with null', () => {
+    const store = createCollectionStore(makeCollection(COL_ID));
+    store.getState().setClientCertificate(CERT);
+
+    store.getState().setClientCertificate(null);
+
+    expect(store.getState().collection?.clientCertificate).toBeUndefined();
+  });
+
+  it('replaces an existing certificate with a new one', () => {
+    const store = createCollectionStore(makeCollection(COL_ID));
+    store.getState().setClientCertificate(CERT);
+
+    const newCert: ClientCertificate = { certPath: '/new/cert.pem', keyPath: '/new/key.pem' };
+    store.getState().setClientCertificate(newCert);
+
+    expect(store.getState().collection?.clientCertificate).toEqual(newCert);
   });
 });

--- a/src/renderer/state/collectionStore.test.ts
+++ b/src/renderer/state/collectionStore.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/state/helper/collectionUtil', () => ({
 }));
 
 vi.mock('@/services/event/renderer-event-service', () => ({
-  RendererEventService: { instance: {} },
+  RendererEventService: { instance: { setClientCertificate: vi.fn() } },
 }));
 
 vi.mock('@/state/variableStore', () => ({

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -504,12 +504,13 @@ export const createCollectionStore = (collection: Collection) => {
         }
       },
 
-      setClientCertificate: (certificate) => {
+      setClientCertificate: async (certificate) => {
         set((state) => {
           if (state.collection) {
             state.collection.clientCertificate = certificate ?? undefined;
           }
         });
+        await eventService.setClientCertificate(certificate);
       },
     }))
   );

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -503,6 +503,14 @@ export const createCollectionStore = (collection: Collection) => {
           );
         }
       },
+
+      setClientCertificate: (certificate) => {
+        set((state) => {
+          if (state.collection) {
+            state.collection.clientCertificate = certificate ?? undefined;
+          }
+        });
+      },
     }))
   );
 };

--- a/src/renderer/state/interface/CollectionStateActions.ts
+++ b/src/renderer/state/interface/CollectionStateActions.ts
@@ -222,8 +222,8 @@ export interface CollectionStateActions {
   moveItem(itemId: string, newParentId: string, position: number): Promise<void>;
 
   /**
-   * Update the client certificate of the current collection in the local store.
+   * Update the client certificate of the current collection and persist it to the backend.
    * @param certificate The certificate to set, or null to clear it.
    */
-  setClientCertificate(certificate: ClientCertificate | null): void;
+  setClientCertificate(certificate: ClientCertificate | null): Promise<void>;
 }

--- a/src/renderer/state/interface/CollectionStateActions.ts
+++ b/src/renderer/state/interface/CollectionStateActions.ts
@@ -1,5 +1,5 @@
 import { editor } from 'monaco-editor';
-import { Collection } from 'shim/objects/collection';
+import { ClientCertificate, Collection } from 'shim/objects/collection';
 import { Folder } from 'shim/objects/folder';
 import { TrufosHeader } from 'shim/objects/headers';
 import { TrufosQueryParam } from 'shim/objects/query-param';
@@ -220,4 +220,10 @@ export interface CollectionStateActions {
   closeCollection(dirPath?: string): Promise<void>;
 
   moveItem(itemId: string, newParentId: string, position: number): Promise<void>;
+
+  /**
+   * Update the client certificate of the current collection in the local store.
+   * @param certificate The certificate to set, or null to clear it.
+   */
+  setClientCertificate(certificate: ClientCertificate | null): void;
 }

--- a/src/shim/event-service.ts
+++ b/src/shim/event-service.ts
@@ -9,6 +9,7 @@ import {
   VariableObject,
   EnvironmentMap,
 } from './objects';
+import { ClientCertificate } from './objects/collection';
 import { ScriptType } from './scripting';
 
 export type ImportStrategy = 'Postman' | 'Bruno' | 'Insomnia';
@@ -92,6 +93,12 @@ export interface IEventService {
    * @param variables The variables of the Collection to set.
    */
   setCollectionVariables(variables: VariableMap): void;
+
+  /**
+   * Set or clear the client certificate for the current collection.
+   * @param clientCertificate The client certificate to set, or null to clear it.
+   */
+  setClientCertificate(clientCertificate: ClientCertificate | null): Promise<void>;
 
   /**
    * Replace all existing environment variables with the given ones.

--- a/src/shim/objects/collection.ts
+++ b/src/shim/objects/collection.ts
@@ -5,6 +5,14 @@ import { EnvironmentMap } from './environment';
 import { AuthorizationInformationNoInherit } from './auth';
 import z from 'zod';
 
+/** File paths for a client certificate used in mutual TLS (mTLS). */
+export const ClientCertificate = z.object({
+  certPath: z.string(),
+  keyPath: z.string(),
+  caPath: z.string().optional(),
+});
+export type ClientCertificate = z.infer<typeof ClientCertificate>;
+
 /** Minimal information about a collection. */
 export const CollectionBase = z.object({
   id: z.string(),
@@ -21,6 +29,7 @@ export const Collection = CollectionBase.extend({
   variables: VariableMap,
   environments: EnvironmentMap,
   auth: AuthorizationInformationNoInherit.optional(),
+  clientCertificate: ClientCertificate.optional(),
   children: z.discriminatedUnion('type', [Folder, TrufosRequest]).array(),
 });
 export type Collection = z.infer<typeof Collection>;


### PR DESCRIPTION
## Changes

- Added client certificate support to the backend using Undici's Agent with connect options (cert, key, ca)
- Added a TLS tab to Collection Settings where a client certificate, private key, and optional CA certificate can be configured via file path inputs
- Client certificate is persisted in the collection and synced to the collection store on save
- Added frontend tests for CertificateEditor and the collection store certificate sync

## Testing

Tested manually using a local mTLS server (Node.js https module with requestCert: true). The server returns "mTLS OK!" with authorized: true when the configured client certificate is sent correctly.

<img width="1149" height="748" alt="grafik" src="https://github.com/user-attachments/assets/c77e6b02-ae17-409e-9eb2-a4f53c28816e" />


## Checklist

- [x] Issue has been linked to this PR
- [ ] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [ ] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
