### PR TITLE
feat(751): Import Postman Request Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ that is fast, user-friendly, and customizable. Below is an overview of current a
 | Cross-platform (Win / macOS / Linux)          | ✅ Implemented | Electron-based distribution with native packaging        |
 | Handling of large request & response payloads | ✅ Implemented | Streamed & chunked processing keeps UI responsive        |
 | Version control-friendly collections          | ✅ Implemented | Collections stored as JSON for easy diff & collaboration |
-| Third party collection import                 | 🚧 Partially   | Currently supports Postman                               |
+| Third party collection import                 | ✅ Implemented | Currently supports Postman                               |
 | Environment & variable management             | ✅ Implemented | Named environments with scoped variables                 |
 | Authentication (JWT, OAuth 2.0, Basic)        | ✅ Implemented | Strategy factory incl. OAuth2 client credentials         |
-| Scripting (custom request/response handling)  | 🚧 In Progress | Running scripts before and after requests                |
+| Scripting (custom request/response handling)  | ✅ Implemented | Running scripts before and after requests                |
 
 If you would like to contribute to this project, please check out our [Contributing Guidelines](./CONTRIBUTING.md).
 

--- a/src/main/import/service/postman-importer.test.ts
+++ b/src/main/import/service/postman-importer.test.ts
@@ -1,0 +1,183 @@
+import fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  AuthorizationType,
+  OAuth2ClientAuthenticationMethod,
+  OAuth2Method,
+  OAuth2PKCECodeChallengeMethod,
+} from 'shim/objects/auth';
+import { TrufosRequest } from 'shim/objects/request';
+import { describe, expect, it } from 'vitest';
+import { PostmanImporter } from './postman-importer';
+
+const createCollection = (auth: unknown) => ({
+  info: {
+    name: 'Auth Import Test',
+    id: 'test-collection-id',
+    schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+  },
+  item: [
+    {
+      id: 'test-request-id',
+      name: 'test request',
+      request: {
+        method: 'GET',
+        url: 'https://example.com/resource',
+        auth,
+      },
+    },
+  ],
+});
+
+describe('PostmanImporter', () => {
+  it('imports basic auth', async () => {
+    const collection = createCollection({
+      type: 'basic',
+      basic: [
+        { key: 'username', value: 'user1' },
+        { key: 'password', value: 'pass1' },
+      ],
+    });
+    const srcFilePath = path.join(tmpdir(), 'postman-basic.json');
+    await fs.writeFile(srcFilePath, JSON.stringify(collection));
+
+    const result = await new PostmanImporter().importCollection(srcFilePath);
+    const request = result.children[0] as TrufosRequest;
+
+    expect(request.auth).toEqual({
+      type: AuthorizationType.BASIC,
+      username: 'user1',
+      password: 'pass1',
+    });
+  });
+
+  it('imports bearer auth', async () => {
+    const collection = createCollection({
+      type: 'bearer',
+      bearer: [{ key: 'token', value: 'my-token-123' }],
+    });
+    const srcFilePath = path.join(tmpdir(), 'postman-bearer.json');
+    await fs.writeFile(srcFilePath, JSON.stringify(collection));
+
+    const result = await new PostmanImporter().importCollection(srcFilePath);
+    const request = result.children[0] as TrufosRequest;
+
+    expect(request.auth).toEqual({
+      type: AuthorizationType.BEARER,
+      token: 'my-token-123',
+    });
+  });
+
+  it('imports oauth2 client credentials auth', async () => {
+    const collection = createCollection({
+      type: 'oauth2',
+      oauth2: [
+        { key: 'grant_type', value: 'client_credentials' },
+        { key: 'accessTokenUrl', value: 'https://example.com/oauth/token' },
+        { key: 'clientId', value: 'client-id' },
+        { key: 'clientSecret', value: 'client-secret' },
+        { key: 'scope', value: 'read:all' },
+        { key: 'addTokenTo', value: 'header' },
+      ],
+    });
+    const srcFilePath = path.join(tmpdir(), 'postman-oauth2-cc.json');
+    await fs.writeFile(srcFilePath, JSON.stringify(collection));
+
+    const result = await new PostmanImporter().importCollection(srcFilePath);
+    const request = result.children[0] as TrufosRequest;
+
+    expect(request.auth).toEqual({
+      type: AuthorizationType.OAUTH2,
+      method: OAuth2Method.CLIENT_CREDENTIALS,
+      issuerUrl: '',
+      tokenUrl: 'https://example.com/oauth/token',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      scope: 'read:all',
+      clientAuthenticationMethod: OAuth2ClientAuthenticationMethod.BASIC_AUTH,
+    });
+  });
+
+  it('imports oauth2 authorization code auth', async () => {
+    const collection = createCollection({
+      type: 'oauth2',
+      oauth2: [
+        { key: 'grant_type', value: 'authorization_code' },
+        { key: 'authUrl', value: 'https://example.com/oauth/authorize' },
+        { key: 'accessTokenUrl', value: 'https://example.com/oauth/token' },
+        { key: 'clientId', value: 'client-id-2' },
+        { key: 'clientSecret', value: 'client-secret-2' },
+        { key: 'scope', value: 'write:all' },
+        { key: 'redirect_uri', value: 'http://localhost:3000/callback' },
+        { key: 'addTokenTo', value: 'header' },
+      ],
+    });
+    const srcFilePath = path.join(tmpdir(), 'postman-oauth2-ac.json');
+    await fs.writeFile(srcFilePath, JSON.stringify(collection));
+
+    const result = await new PostmanImporter().importCollection(srcFilePath);
+    const request = result.children[0] as TrufosRequest;
+
+    expect(request.auth).toEqual({
+      type: AuthorizationType.OAUTH2,
+      method: OAuth2Method.AUTHORIZATION_CODE,
+      issuerUrl: '',
+      tokenUrl: 'https://example.com/oauth/token',
+      clientId: 'client-id-2',
+      clientSecret: 'client-secret-2',
+      scope: 'write:all',
+      clientAuthenticationMethod: OAuth2ClientAuthenticationMethod.BASIC_AUTH,
+      authorizationUrl: 'https://example.com/oauth/authorize',
+      callbackUrl: 'http://localhost:3000/callback',
+    });
+  });
+
+  it('imports oauth2 authorization code pkce auth', async () => {
+    const collection = createCollection({
+      type: 'oauth2',
+      oauth2: [
+        { key: 'grant_type', value: 'authorization_code_with_pkce' },
+        { key: 'authUrl', value: 'https://example.com/oauth/authorize' },
+        { key: 'accessTokenUrl', value: 'https://example.com/oauth/token' },
+        { key: 'clientId', value: 'client-id-3' },
+        { key: 'clientSecret', value: 'client-secret-3' },
+        { key: 'scope', value: 'api:read' },
+        { key: 'redirect_uri', value: 'http://localhost:8080/callback' },
+        { key: 'code_verifier', value: 'my-code-verifier' },
+        { key: 'addTokenTo', value: 'request-body' },
+      ],
+    });
+    const srcFilePath = path.join(tmpdir(), 'postman-oauth2-pkce.json');
+    await fs.writeFile(srcFilePath, JSON.stringify(collection));
+
+    const result = await new PostmanImporter().importCollection(srcFilePath);
+    const request = result.children[0] as TrufosRequest;
+
+    expect(request.auth).toEqual({
+      type: AuthorizationType.OAUTH2,
+      method: OAuth2Method.AUTHORIZATION_CODE_PKCE,
+      issuerUrl: '',
+      tokenUrl: 'https://example.com/oauth/token',
+      clientId: 'client-id-3',
+      clientSecret: 'client-secret-3',
+      scope: 'api:read',
+      clientAuthenticationMethod: OAuth2ClientAuthenticationMethod.REQUEST_BODY,
+      authorizationUrl: 'https://example.com/oauth/authorize',
+      callbackUrl: 'http://localhost:8080/callback',
+      codeChallengeMethod: OAuth2PKCECodeChallengeMethod.S256,
+      codeVerifier: 'my-code-verifier',
+    });
+  });
+
+  it('imports request without auth', async () => {
+    const collection = createCollection(undefined);
+    const srcFilePath = path.join(tmpdir(), 'postman-no-auth.json');
+    await fs.writeFile(srcFilePath, JSON.stringify(collection));
+
+    const result = await new PostmanImporter().importCollection(srcFilePath);
+    const request = result.children[0] as TrufosRequest;
+
+    expect(request.auth).toBeUndefined();
+  });
+});

--- a/src/main/import/service/postman-importer.test.ts
+++ b/src/main/import/service/postman-importer.test.ts
@@ -144,8 +144,9 @@ describe('PostmanImporter', () => {
         { key: 'clientSecret', value: 'client-secret-3' },
         { key: 'scope', value: 'api:read' },
         { key: 'redirect_uri', value: 'http://localhost:8080/callback' },
+        { key: 'client_authentication', value: 'body' },
+        { key: 'challengeAlgorithm', value: 'S256' },
         { key: 'code_verifier', value: 'my-code-verifier' },
-        { key: 'addTokenTo', value: 'request-body' },
       ],
     });
     const srcFilePath = path.join(tmpdir(), 'postman-oauth2-pkce.json');

--- a/src/main/import/service/postman-importer.ts
+++ b/src/main/import/service/postman-importer.ts
@@ -112,10 +112,6 @@ export class PostmanImporter implements CollectionImporter {
       }
     }
 
-    if (request.auth != null) {
-      this.importAuth(request.auth);
-    }
-
     const trufosRequest: TrufosRequest = {
       id: item.id,
       parentId: parent.id,
@@ -133,12 +129,15 @@ export class PostmanImporter implements CollectionImporter {
         type: RequestBodyType.TEXT,
         mimeType: DEFAULT_MIME_TYPE,
       },
+      auth: this.importAuth(request.auth),
     };
 
     parent.children.push(trufosRequest);
   }
 
-  private importAuth(postmanAuth: PostmanRequestAuth): TrufosRequest['auth'] {
+  private importAuth(postmanAuth?: PostmanRequestAuth): TrufosRequest['auth'] {
+    if (postmanAuth == null) return;
+
     const parameters = new Map<string, string>();
     for (const param of postmanAuth.parameters().all()) {
       if (param.key != null && param.key !== '') parameters.set(param.key, param.value);

--- a/src/main/import/service/postman-importer.ts
+++ b/src/main/import/service/postman-importer.ts
@@ -158,6 +158,9 @@ export class PostmanImporter implements CollectionImporter {
       case 'oauth2': {
         return this.importOAuth2(parameters);
       }
+      default:
+        logger.warn('Unsupported auth type while importing from Postman:', postmanAuth.type);
+        return;
     }
   }
 
@@ -192,9 +195,9 @@ export class PostmanImporter implements CollectionImporter {
           authorizationUrl: parameters.get('authUrl') ?? '',
           callbackUrl: parameters.get('redirect_uri') ?? '',
           codeChallengeMethod:
-            parameters.get('challengeAlgorithm') === 'S256'
-              ? OAuth2PKCECodeChallengeMethod.S256
-              : OAuth2PKCECodeChallengeMethod.PLAIN,
+            parameters.get('challengeAlgorithm') === 'plain'
+              ? OAuth2PKCECodeChallengeMethod.PLAIN
+              : OAuth2PKCECodeChallengeMethod.S256,
           codeVerifier: parameters.get('code_verifier'),
         };
       case 'client_credentials':

--- a/src/main/import/service/postman-importer.ts
+++ b/src/main/import/service/postman-importer.ts
@@ -172,9 +172,9 @@ export class PostmanImporter implements CollectionImporter {
       clientSecret: parameters.get('clientSecret') ?? '',
       scope: parameters.get('scope') ?? '',
       clientAuthenticationMethod:
-        parameters.get('addTokenTo') === 'header'
-          ? OAuth2ClientAuthenticationMethod.BASIC_AUTH
-          : OAuth2ClientAuthenticationMethod.REQUEST_BODY,
+        parameters.get('client_authentication') === 'body'
+          ? OAuth2ClientAuthenticationMethod.REQUEST_BODY
+          : OAuth2ClientAuthenticationMethod.BASIC_AUTH,
     };
 
     switch (parameters.get('grant_type')) {
@@ -191,7 +191,10 @@ export class PostmanImporter implements CollectionImporter {
           method: OAuth2Method.AUTHORIZATION_CODE_PKCE,
           authorizationUrl: parameters.get('authUrl') ?? '',
           callbackUrl: parameters.get('redirect_uri') ?? '',
-          codeChallengeMethod: OAuth2PKCECodeChallengeMethod.S256,
+          codeChallengeMethod:
+            parameters.get('challengeAlgorithm') === 'S256'
+              ? OAuth2PKCECodeChallengeMethod.S256
+              : OAuth2PKCECodeChallengeMethod.PLAIN,
           codeVerifier: parameters.get('code_verifier'),
         };
       case 'client_credentials':

--- a/src/main/import/service/postman-importer.ts
+++ b/src/main/import/service/postman-importer.ts
@@ -4,6 +4,7 @@ import {
   CollectionDefinition,
   Item,
   ItemGroup,
+  RequestAuth as PostmanRequestAuth,
 } from 'postman-collection';
 import { Collection as TrufosCollection } from 'shim/objects/collection';
 import { Folder as TrufosFolder } from 'shim/objects/folder';
@@ -12,6 +13,14 @@ import { parseUrl } from 'shim/objects/url';
 import { RequestMethod } from 'shim/objects/request-method';
 import fs from 'node:fs/promises';
 import { VARIABLE_NAME_REGEX, VariableObject } from 'shim/objects/variables';
+import {
+  AuthorizationType,
+  OAuth2AuthorizationInformation,
+  OAuth2ClientAuthenticationMethod,
+  OAuth2Method,
+  OAuth2PKCECodeChallengeMethod,
+  Oauth2BaseAuthorizationInformation,
+} from 'shim';
 
 const DEFAULT_MIME_TYPE = 'text/plain';
 
@@ -44,6 +53,7 @@ export class PostmanImporter implements CollectionImporter {
     const collection: TrufosCollection = {
       id: postmanCollection.id,
       type: 'collection',
+      lastModified: Date.now(),
       title: postmanCollection.name,
       dirPath: '', // must be set after import
       children: [],
@@ -52,49 +62,44 @@ export class PostmanImporter implements CollectionImporter {
     };
 
     // import children
-    await this.importItems(collection, postmanCollection.items.all());
+    this.importItems(collection, postmanCollection.items.all());
     return collection;
   }
 
-  private async importItems(
-    parent: TrufosCollection | TrufosFolder,
-    items: (Item | ItemGroup<Item>)[]
-  ) {
+  private importItems(parent: TrufosCollection | TrufosFolder, items: (Item | ItemGroup<Item>)[]) {
     for (const item of items) {
       if (item instanceof ItemGroup) {
-        await this.importFolder(parent, item);
+        this.importFolder(parent, item);
       } else if (item instanceof Item) {
-        await this.importRequest(parent, item);
+        this.importRequest(parent, item);
       }
     }
   }
 
-  private async importFolder(
-    parent: TrufosCollection | TrufosFolder,
-    postmanFolder: ItemGroup<Item>
-  ) {
+  private importFolder(parent: TrufosCollection | TrufosFolder, postmanFolder: ItemGroup<Item>) {
     const folder: TrufosFolder = {
       id: postmanFolder.id,
       parentId: parent.id,
       type: 'folder',
+      lastModified: Date.now(),
       title: postmanFolder.name,
       children: [],
     };
 
-    await this.importItems(folder, postmanFolder.items.all());
+    this.importItems(folder, postmanFolder.items.all());
     parent.children.push(folder);
   }
 
-  private async importRequest(parent: TrufosCollection | TrufosFolder, item: Item) {
+  private importRequest(parent: TrufosCollection | TrufosFolder, item: Item) {
     const { request } = item;
 
     let bodyInfo: RequestBody | null = null;
-    if (request.body !== undefined) {
+    if (request.body != null) {
       switch (request.body.mode) {
         case 'file':
           bodyInfo = {
             type: RequestBodyType.FILE,
-            filePath: request.body.file.src,
+            filePath: request.body.file?.src,
           };
           break;
         case 'raw':
@@ -107,10 +112,15 @@ export class PostmanImporter implements CollectionImporter {
       }
     }
 
+    if (request.auth != null) {
+      this.importAuth(request.auth);
+    }
+
     const trufosRequest: TrufosRequest = {
       id: item.id,
       parentId: parent.id,
       type: 'request',
+      lastModified: Date.now(),
       title: item.name,
       url: parseUrl(request.url.toString()),
       headers: request.headers.all().map((header) => ({
@@ -126,5 +136,70 @@ export class PostmanImporter implements CollectionImporter {
     };
 
     parent.children.push(trufosRequest);
+  }
+
+  private importAuth(postmanAuth: PostmanRequestAuth): TrufosRequest['auth'] {
+    const parameters = new Map<string, string>();
+    for (const param of postmanAuth.parameters().all()) {
+      if (param.key != null && param.key !== '') parameters.set(param.key, param.value);
+    }
+
+    switch (postmanAuth.type) {
+      case 'basic':
+        return {
+          type: AuthorizationType.BASIC,
+          username: parameters.get('username') ?? '',
+          password: parameters.get('password') ?? '',
+        };
+      case 'bearer':
+        return {
+          type: AuthorizationType.BEARER,
+          token: parameters.get('token') ?? '',
+        };
+      case 'oauth2': {
+        return this.importOAuth2(parameters);
+      }
+    }
+  }
+
+  private importOAuth2(
+    parameters: Map<string, string>
+  ): OAuth2AuthorizationInformation | undefined {
+    const base: Omit<Oauth2BaseAuthorizationInformation, 'method'> = {
+      type: AuthorizationType.OAUTH2,
+      issuerUrl: '',
+      tokenUrl: parameters.get('accessTokenUrl') ?? '',
+      clientId: parameters.get('clientId') ?? '',
+      clientSecret: parameters.get('clientSecret') ?? '',
+      scope: parameters.get('scope') ?? '',
+      clientAuthenticationMethod:
+        parameters.get('addTokenTo') === 'header'
+          ? OAuth2ClientAuthenticationMethod.BASIC_AUTH
+          : OAuth2ClientAuthenticationMethod.REQUEST_BODY,
+    };
+
+    switch (parameters.get('grant_type')) {
+      case 'authorization_code':
+        return {
+          ...base,
+          method: OAuth2Method.AUTHORIZATION_CODE,
+          authorizationUrl: parameters.get('authUrl') ?? '',
+          callbackUrl: parameters.get('redirect_uri') ?? '',
+        };
+      case 'authorization_code_with_pkce':
+        return {
+          ...base,
+          method: OAuth2Method.AUTHORIZATION_CODE_PKCE,
+          authorizationUrl: parameters.get('authUrl') ?? '',
+          callbackUrl: parameters.get('redirect_uri') ?? '',
+          codeChallengeMethod: OAuth2PKCECodeChallengeMethod.S256,
+          codeVerifier: parameters.get('code_verifier'),
+        };
+      case 'client_credentials':
+        return {
+          ...base,
+          method: OAuth2Method.CLIENT_CREDENTIALS,
+        };
+    }
   }
 }

--- a/src/renderer/components/sidebar/CollectionDropdown.tsx
+++ b/src/renderer/components/sidebar/CollectionDropdown.tsx
@@ -67,7 +67,7 @@ export default function CollectionDropdown() {
             </DropdownMenuItem>
 
             <DropdownMenuItem onClick={() => setShowImport(true)} className={'px-4 py-3'}>
-              <span>Open Collection</span>
+              <span>Import Collection</span>
             </DropdownMenuItem>
           </DropdownMenuGroup>
 

--- a/src/shim/objects/auth.ts
+++ b/src/shim/objects/auth.ts
@@ -32,6 +32,7 @@ export const Oauth2BaseAuthorizationInformation = z.object({
   /** To persist retrieved access tokens. Not configurable */
   tokens: z.object<TokenEndpointResponse>().optional(),
 });
+export type Oauth2BaseAuthorizationInformation = z.infer<typeof Oauth2BaseAuthorizationInformation>;
 
 export const OAuth2ClientCrentialsAuthorizationInformation =
   Oauth2BaseAuthorizationInformation.extend({


### PR DESCRIPTION
## Changes

- When importing Postman collections, the request auth is now imported as well
- Rename "Open Collection" to "Import Collection"
- Update README project status

## Testing

- Automated tests added
- Manually tested for [this official Postman collection](https://github.com/postmanlabs/postman-collection/blob/develop/examples/collection-v2.json)

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
