### PR TITLE
Fix/745 inconsistent focus color

### DIFF
--- a/src/renderer/components/shared/settings/EnvironmentTab/EnvironmentEditor.tsx
+++ b/src/renderer/components/shared/settings/EnvironmentTab/EnvironmentEditor.tsx
@@ -163,7 +163,7 @@ export const EnvironmentEditor = ({
                 value={newEnvironmentName}
                 onChange={(e) => setNewEnvironmentName(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && addEnvironment()}
-                className="bg-background focus-visible:ring-sidebar-ring h-8 w-full pr-10 text-sm shadow-none focus-visible:ring-2"
+                className="bg-background h-8 w-full pr-10 text-sm shadow-none"
               />
               <TooltipProvider>
                 <Tooltip>

--- a/src/renderer/components/shared/settings/EnvironmentTab/EnvironmentEditor.tsx
+++ b/src/renderer/components/shared/settings/EnvironmentTab/EnvironmentEditor.tsx
@@ -163,7 +163,7 @@ export const EnvironmentEditor = ({
                 value={newEnvironmentName}
                 onChange={(e) => setNewEnvironmentName(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && addEnvironment()}
-                className="bg-background h-8 w-full pr-10 text-sm shadow-none"
+                className="bg-background focus:border-accent-primary focus-visible:border-accent-primary h-8 w-full pr-10 text-sm shadow-none"
               />
               <TooltipProvider>
                 <Tooltip>

--- a/src/renderer/components/ui/input.tsx
+++ b/src/renderer/components/ui/input.tsx
@@ -12,7 +12,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         className={cn(
           'border-border flex h-10 w-full rounded-full border' +
             ' focus-visible:ring-none focus-visible:outline-hidden' +
-            ' focus:border-accent-primary focus-visible:border-accent-primary' +
+            ' focus:border-accent-secondary focus-visible:border-accent-secondary' +
             ' bg-background placeholder:text-muted-foreground px-3 py-2 text-sm' +
             ' disabled:cursor-not-allowed disabled:opacity-50' +
             ' color-text-secondary',

--- a/src/renderer/components/ui/input.tsx
+++ b/src/renderer/components/ui/input.tsx
@@ -12,7 +12,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         className={cn(
           'border-border flex h-10 w-full rounded-full border' +
             ' focus-visible:ring-none focus-visible:outline-hidden' +
-            ' focus:border-accent-secondary focus-visible:border-accent-secondary' +
+            ' focus:border-accent-primary focus-visible:border-accent-primary' +
             ' bg-background placeholder:text-muted-foreground px-3 py-2 text-sm' +
             ' disabled:cursor-not-allowed disabled:opacity-50' +
             ' color-text-secondary',


### PR DESCRIPTION
## Changes

Fixed the focus border color of the "new environment" input in Collection Settings to use accent-primary instead of accent-secondary, so it matches the active tab highlight in the same modal.

<img width="1066" height="816" alt="grafik" src="https://github.com/user-attachments/assets/a13cd4e6-6761-417b-ba73-ea6e57def6df" />


## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [ ] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person
