### PR TITLE
fix: make key for mTLS optional

### DIFF
--- a/src/main/network/service/http-service.ts
+++ b/src/main/network/service/http-service.ts
@@ -49,7 +49,7 @@ export class HttpService {
       connect: {
         rejectUnauthorized: false,
         cert: await fsp.readFile(cert.certPath),
-        key: await fsp.readFile(cert.keyPath),
+        key: cert.keyPath ? await fsp.readFile(cert.keyPath) : undefined,
         ca: cert.caPath ? await fsp.readFile(cert.caPath) : undefined,
       },
     });

--- a/src/renderer/components/shared/settings/TlsTab/CertificateEditor.test.tsx
+++ b/src/renderer/components/shared/settings/TlsTab/CertificateEditor.test.tsx
@@ -74,7 +74,7 @@ describe('CertificateEditor', () => {
 
     await user.click(screen.getByRole('button', { name: /add certificate/i }));
 
-    expect(onChangeMock).toHaveBeenCalledWith({ certPath: '', keyPath: '', caPath: undefined });
+    expect(onChangeMock).toHaveBeenCalledWith({ certPath: '' });
   });
 
   it('shows clear buttons only for fields that have a value', () => {
@@ -108,7 +108,7 @@ describe('CertificateEditor', () => {
     const clearButtons = screen.getAllByRole('button', { name: /clear/i });
     await user.click(clearButtons[1]); // second Clear = keyPath
 
-    expect(onChangeMock).toHaveBeenCalledWith({ ...CERT, keyPath: '' });
+    expect(onChangeMock).toHaveBeenCalledWith({ ...CERT, keyPath: undefined });
   });
 
   it('clears caPath when its Clear button is clicked', async () => {

--- a/src/renderer/components/shared/settings/TlsTab/CertificateEditor.tsx
+++ b/src/renderer/components/shared/settings/TlsTab/CertificateEditor.tsx
@@ -21,7 +21,7 @@ export const CertificateEditor = ({ certificate, onCertificateChange }: Certific
   const handleBrowse = async (field: keyof ClientCertificate) => {
     const path = await pickFile();
     if (path == null) return;
-    onCertificateChange({ ...(certificate ?? { certPath: '', keyPath: '' }), [field]: path });
+    onCertificateChange({ ...(certificate ?? { certPath: '' }), [field]: path });
   };
 
   if (certificate == null) {
@@ -31,7 +31,7 @@ export const CertificateEditor = ({ certificate, onCertificateChange }: Certific
           className="h-fit gap-1 pl-0 hover:bg-transparent"
           size="sm"
           variant="ghost"
-          onClick={() => onCertificateChange({ certPath: '', keyPath: '', caPath: undefined })}
+          onClick={() => onCertificateChange({ certPath: '' })}
         >
           <AddIcon /> Add Certificate
         </Button>
@@ -72,10 +72,10 @@ export const CertificateEditor = ({ certificate, onCertificateChange }: Certific
           onBrowse={() => handleBrowse('certPath')}
         />
         <CertField
-          label="Private Key"
-          value={certificate.keyPath}
+          label="Private Key (optional)"
+          value={certificate.keyPath ?? ''}
           placeholder="Path to private key (.pem / .key)"
-          onChange={(v) => onCertificateChange({ ...certificate, keyPath: v })}
+          onChange={(v) => onCertificateChange({ ...certificate, keyPath: v || undefined })}
           onBrowse={() => handleBrowse('keyPath')}
         />
         <CertField

--- a/src/shim/objects/collection.ts
+++ b/src/shim/objects/collection.ts
@@ -8,7 +8,7 @@ import z from 'zod';
 /** File paths for a client certificate used in mutual TLS (mTLS). */
 export const ClientCertificate = z.object({
   certPath: z.string(),
-  keyPath: z.string(),
+  keyPath: z.string().optional(),
   caPath: z.string().optional(),
 });
 export type ClientCertificate = z.infer<typeof ClientCertificate>;


### PR DESCRIPTION
## Changes

- make key for mTLS optional (in settings UI and backend)

## Testing

<img width="1012" height="466" alt="image" src="https://github.com/user-attachments/assets/d895723e-3c89-4da3-8ccf-bd576b4f5c9b" />

- Manually tested
- Adjusted automated tests

## Checklist

- [ ] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
