### PR TITLE
fix: keep selected environment valid

### DIFF
--- a/src/main/environment/service/environment-service.test.ts
+++ b/src/main/environment/service/environment-service.test.ts
@@ -70,6 +70,40 @@ describe('EnvironmentService', () => {
     expect(environmentService.currentCollection.variables).toEqual(newVariables);
   });
 
+  it('setEnvironmentVariables() should keep the selected environment valid', () => {
+    // Arrange
+    environmentService.currentEnvironmentKey = 'missing';
+    const newEnvironments = {
+      dev: { variables: { host: { value: 'localhost' } } },
+    };
+
+    // Act
+    environmentService.setEnvironmentVariables(newEnvironments);
+
+    // Assert
+    expect(environmentService.currentCollection.environments).toEqual(newEnvironments);
+    expect(environmentService.currentEnvironmentKey).toBe('dev');
+  });
+
+  it('changeCollection() should replace a stale selected environment', async () => {
+    // Arrange
+    environmentService.currentEnvironmentKey = 'missing';
+    const newCollection: Partial<Collection> = {
+      id: randomUUID(),
+      dirPath: '/some/path',
+      variables: {},
+      environments: {
+        dev: { variables: { host: { value: 'localhost' } } },
+      },
+    };
+
+    // Act
+    await environmentService.changeCollection(newCollection as Collection);
+
+    // Assert
+    expect(environmentService.currentEnvironmentKey).toBe('dev');
+  });
+
   it('changeCollection() should load the new collection from PersistenceService', async () => {
     // Arrange
     const newCollection: Partial<Collection> = { id: randomUUID(), dirPath: '/some/path' };

--- a/src/main/environment/service/environment-service.ts
+++ b/src/main/environment/service/environment-service.ts
@@ -32,7 +32,7 @@ export class EnvironmentService implements Initializable {
   /** The currently selected environment in the current collection. */
   public get currentEnvironment() {
     if (this.currentEnvironmentKey == null) return;
-    return this.currentCollection.environments[this.currentEnvironmentKey];
+    return this.currentCollection.environments?.[this.currentEnvironmentKey];
   }
 
   private _currentCollection!: Collection;
@@ -87,6 +87,7 @@ export class EnvironmentService implements Initializable {
   public setEnvironmentVariables(environmentVariables: EnvironmentMap) {
     logger.secret?.debug('Setting environment variables:', environmentVariables);
     this.currentCollection.environments = environmentVariables;
+    this.ensureSelectedEnvironmentExists();
   }
 
   public setClientCertificate(clientCertificate: ClientCertificate | null) {
@@ -104,6 +105,7 @@ export class EnvironmentService implements Initializable {
       typeof collection === 'string'
         ? await persistenceService.loadCollection(collection)
         : collection;
+    this.ensureSelectedEnvironmentExists();
 
     // add collection to the list of open collections if it is not already there
     const path = this.currentCollection.dirPath;
@@ -201,6 +203,11 @@ export class EnvironmentService implements Initializable {
 
   private getVariableValue(key: string) {
     return this.getVariable(key)?.value;
+  }
+
+  private ensureSelectedEnvironmentExists() {
+    if (this.currentEnvironmentKey != null && this.currentEnvironment != null) return;
+    this.currentEnvironmentKey = Object.keys(this.currentCollection.environments ?? {})[0];
   }
 
   /**

--- a/src/renderer/state/CollectionStoreProvider.test.tsx
+++ b/src/renderer/state/CollectionStoreProvider.test.tsx
@@ -13,6 +13,7 @@ vi.mock('@/services/event/renderer-event-service', () => ({
         listeners[event] = listener;
       }),
       emit: vi.fn(),
+      selectEnvironment: vi.fn().mockResolvedValue(undefined),
       loadCollection: vi.fn().mockResolvedValue({
         id: 'col-1',
         type: 'collection',

--- a/src/renderer/state/environmentStore.test.ts
+++ b/src/renderer/state/environmentStore.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEnvironmentStore } from './environmentStore';
+
+const { selectEnvironmentMock, setEnvironmentVariablesMock } = vi.hoisted(() => ({
+  selectEnvironmentMock: vi.fn(),
+  setEnvironmentVariablesMock: vi.fn(),
+}));
+
+vi.mock('@/services/event/renderer-event-service', () => ({
+  RendererEventService: {
+    instance: {
+      selectEnvironment: selectEnvironmentMock,
+      setEnvironmentVariables: setEnvironmentVariablesMock,
+    },
+  },
+}));
+
+describe('environmentStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectEnvironmentMock.mockResolvedValue(undefined);
+    setEnvironmentVariablesMock.mockResolvedValue(undefined);
+    useEnvironmentStore.setState({ environments: {}, selectedEnvironment: undefined });
+  });
+
+  it('selects the first environment when no environment is selected', () => {
+    useEnvironmentStore.getState().initialize({
+      dev: { variables: { host: { value: 'localhost' } } },
+      prod: { variables: { host: { value: 'example.com' } } },
+    });
+
+    expect(useEnvironmentStore.getState().selectedEnvironment).toBe('dev');
+    expect(selectEnvironmentMock).toHaveBeenCalledWith('dev');
+  });
+
+  it('replaces a stale selected environment when environments change', () => {
+    useEnvironmentStore.getState().initialize({
+      dev: { variables: { host: { value: 'localhost' } } },
+    });
+
+    useEnvironmentStore.getState().initialize({
+      prod: { variables: { host: { value: 'example.com' } } },
+    });
+
+    expect(useEnvironmentStore.getState().selectedEnvironment).toBe('prod');
+    expect(selectEnvironmentMock).toHaveBeenLastCalledWith('prod');
+  });
+
+  it('keeps the selected environment valid after saving environments', async () => {
+    useEnvironmentStore.getState().initialize({
+      dev: { variables: {} },
+    });
+
+    await useEnvironmentStore.getState().setEnvironments({
+      prod: { variables: {} },
+    });
+
+    expect(setEnvironmentVariablesMock).toHaveBeenCalledWith({
+      prod: { variables: {} },
+    });
+    expect(useEnvironmentStore.getState().selectedEnvironment).toBe('prod');
+    expect(selectEnvironmentMock).toHaveBeenLastCalledWith('prod');
+  });
+
+  it('clears the selection when no environments remain', async () => {
+    useEnvironmentStore.getState().initialize({
+      dev: { variables: {} },
+    });
+
+    await useEnvironmentStore.getState().setEnvironments({});
+
+    expect(useEnvironmentStore.getState().selectedEnvironment).toBeUndefined();
+    expect(selectEnvironmentMock).toHaveBeenLastCalledWith(undefined);
+  });
+});

--- a/src/renderer/state/environmentStore.ts
+++ b/src/renderer/state/environmentStore.ts
@@ -6,6 +6,19 @@ import { RendererEventService } from '@/services/event/renderer-event-service';
 
 const eventService = RendererEventService.instance;
 
+const getFirstEnvironmentKey = (environments: EnvironmentMap) => Object.keys(environments)[0];
+
+const getValidEnvironmentKey = (environments: EnvironmentMap, environmentKey?: string) =>
+  environmentKey != null && environments[environmentKey] != null
+    ? environmentKey
+    : getFirstEnvironmentKey(environments);
+
+const syncSelectedEnvironment = (environmentKey?: string) => {
+  void eventService.selectEnvironment(environmentKey).catch((error) => {
+    console.error('Failed to select environment', error);
+  });
+};
+
 interface EnvironmentState {
   /** The environments of the current collection */
   environments: EnvironmentMap;
@@ -22,30 +35,36 @@ interface EnvironmentActions {
 }
 
 export const useEnvironmentStore = create<EnvironmentState & EnvironmentActions>()(
-  immer((set) => ({
+  immer((set, get) => ({
     environments: {},
     selectedEnvironment: undefined,
 
     initialize(environments: EnvironmentMap) {
+      let selectedEnvironment: string | undefined;
       set((state) => {
+        selectedEnvironment = getValidEnvironmentKey(environments, state.selectedEnvironment);
         state.environments = environments;
-        if (Object.keys(environments).length > 0 && !state.selectedEnvironment) {
-          state.selectedEnvironment = Object.keys(environments)[0];
-        }
+        state.selectedEnvironment = selectedEnvironment;
       });
+      syncSelectedEnvironment(selectedEnvironment);
     },
 
     setEnvironments: async (environments) => {
       await eventService.setEnvironmentVariables(environments);
+      let selectedEnvironment: string | undefined;
       set((state) => {
+        selectedEnvironment = getValidEnvironmentKey(environments, state.selectedEnvironment);
         state.environments = environments;
+        state.selectedEnvironment = selectedEnvironment;
       });
+      await eventService.selectEnvironment(selectedEnvironment);
     },
 
     selectEnvironment: async (environmentKey?: string) => {
-      await eventService.selectEnvironment(environmentKey);
+      const selectedEnvironment = getValidEnvironmentKey(get().environments, environmentKey);
+      await eventService.selectEnvironment(selectedEnvironment);
       set((state) => {
-        state.selectedEnvironment = environmentKey;
+        state.selectedEnvironment = selectedEnvironment;
       });
     },
 


### PR DESCRIPTION
### **User description**
## Changes

Fixes #661.

Reproduced as stale environment selection:
- select/open a collection with environment `dev`
- switch/update to environments that no longer contain `dev`
- the selected environment key remains stale, so no valid environment variables are selected

This PR keeps the selected environment valid in both renderer and main process:
- the renderer environment store replaces stale selected environment keys with the first available environment (or `undefined` if none exist)
- the renderer syncs automatic environment selection back to the main process
- the main environment service validates the selected environment after collection changes and environment updates
- missing environment maps are handled defensively

## Testing

- `yarn test` (332 passed, 1 skipped)
- `yarn eslint` on the changed files

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [ ] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person


___

### **PR Type**
Bug fix


___

### **Description**
- Prevents stale environment selection when environments change

- Validates selected environment in main process after collection/environment updates

- Syncs automatic environment selection from renderer to main process

- Handles missing environment maps defensively with optional chaining


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Environment Changes"] --> B["Renderer Store"]
  B --> C["Validate Selection"]
  C --> D["Sync to Main Process"]
  D --> E["Main Service Validates"]
  E --> F["Valid Environment Selected"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>environment-service.ts</strong><dd><code>Main process environment validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/environment/service/environment-service.ts

<ul><li>Added optional chaining to <code>currentEnvironment</code> getter to handle missing <br>environment maps<br> <li> Introduced <code>ensureSelectedEnvironmentExists()</code> method to validate and <br>replace stale environment keys<br> <li> Called validation method in <code>setEnvironmentVariables()</code> and <br><code>changeCollection()</code> to maintain valid selection</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/836/files#diff-84c0ccda9cecc7e151816dc85f87a8b80cead8e9827259a6430b8e7cedfe0ca3">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>environmentStore.ts</strong><dd><code>Renderer environment store validation and sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/state/environmentStore.ts

<ul><li>Added helper functions to validate and get first available environment <br>key<br> <li> Added <code>syncSelectedEnvironment()</code> to sync selection back to main process<br> <li> Enhanced <code>initialize()</code> to validate environment selection and sync to <br>main process<br> <li> Enhanced <code>setEnvironments()</code> to validate selection after environment <br>updates and sync changes<br> <li> Enhanced <code>selectEnvironment()</code> to validate requested environment before <br>selection</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/836/files#diff-d18d7951e0c0b8e8ab5b58716aa20a920d9ee9288df531629d4ee92ebaabcaaf">+25/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>environment-service.test.ts</strong><dd><code>Main process environment validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/environment/service/environment-service.test.ts

<ul><li>Added test for <code>setEnvironmentVariables()</code> to verify stale environment <br>replacement<br> <li> Added test for <code>changeCollection()</code> to verify stale environment handling <br>during collection changes</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/836/files#diff-d6c7005552a5340289d81132f3fad084676b1252bf8cbc08d00968534dccc9bf">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>environmentStore.test.ts</strong><dd><code>Renderer environment store validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/state/environmentStore.test.ts

<ul><li>Added comprehensive test suite for environment store validation logic<br> <li> Tests cover: selecting first environment on initialization, replacing <br>stale selections, keeping selection valid after saves, and clearing <br>selection when no environments exist</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/836/files#diff-9ab9a6026e18316b9062afefe546f88350964583b2b52cffe1a51664a238a6da">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CollectionStoreProvider.test.tsx</strong><dd><code>Collection store provider test mock update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/state/CollectionStoreProvider.test.tsx

<ul><li>Added mock for <code>selectEnvironment</code> method in RendererEventService mock</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/836/files#diff-76a8050b5cab0c020ead6cf69fa2bad75f211a11af95d4c98b6d7096ff6f5b86">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

