### PR TITLE
feat: enable inline AI code review suggestions

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -37,8 +37,13 @@ jobs:
           github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'
           # Automatically generate a PR description when none is provided
           github_action_config.auto_describe: "true"
-          # Suggest improvements but do not auto-approve
-          github_action_config.auto_improve: "false"
+          # Walk the diff and post concrete code suggestions (does not auto-approve/merge)
+          github_action_config.auto_improve: "true"
+          # Post suggestions as inline committable comments on the changed files
+          # instead of a single summary table
+          pr_code_suggestions.commitable_code_suggestions: "true"
+          # Mark each automated review with the "Review effort x/5" labels
+          pr_reviewer.enable_review_labels_effort: "true"
 
           # Review focus tailored to Trufos project conventions
           pr_reviewer.extra_instructions: |


### PR DESCRIPTION
## Changes

Closes #875.

The automated AI review (PR-Agent, `.github/workflows/ai-review.yml`) previously only posted a summary report. This enables it to walk the diff and leave concrete, inline suggestions on the changed files, and marks the output as an automated review.

- `github_action_config.auto_improve: "true"` — runs PR-Agent's `improve` tool automatically on every non-draft, non-dependabot PR (previously `"false"`).
- `pr_code_suggestions.commitable_code_suggestions: "true"` — posts suggestions as inline committable comments on the files instead of one summary table.
- `pr_reviewer.enable_review_labels_effort: "true"` — applies the existing "Review effort x/5" labels so each automated review is clearly marked.

Does not auto-approve or auto-merge.

## Testing

- Parsed the workflow with `js-yaml` and asserted the three new env keys resolve (`auto_improve=true`, `commitable=true`, `effort_labels=true`).
- Behaviour can only be fully verified once a PR triggers the workflow with the AI provider secret configured.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [ ] Manual testing has been performed
- [x] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
