### PR TITLE
fix: use valid Gemini Flash model IDs for AI review

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -27,13 +27,13 @@ jobs:
           # Provider: Google AI Studio (Gemini) via LiteLLM.
           # Requires the GEMINI_API_KEY repository secret to be set.
           GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          # Pro requires the Gemini API paid tier (free-tier quota is 0); the
-          # consumer "Google AI Pro" plan does not enable API billing. Flash is
-          # the free-tier fallback.
-          config.model: "gemini/gemini-3.1-pro"
-          config.fallback_models: '["gemini/gemini-3.5-flash"]'
+          # Flash models are available on the Gemini API free tier (no billing
+          # required). The previously configured gemini-3.x IDs do not exist and
+          # returned 404 (NOT_FOUND).
+          config.model: "gemini/gemini-2.5-flash"
+          config.fallback_models: '["gemini/gemini-2.0-flash"]'
           # PR-Agent v0.34 does not know these models' token window; declare it
-          # explicitly (Gemini input window = 1,048,576 tokens).
+          # explicitly (Gemini Flash input window = 1,048,576 tokens).
           config.custom_model_max_tokens: "1048576"
           # To use OpenAI instead, uncomment:
           # OPENAI_KEY: ${{ secrets.OPENAI_KEY }}


### PR DESCRIPTION
### **User description**
## Summary

The `ai-review` workflow used non-existent Gemini model IDs (`gemini-3.1-pro`, fallback `gemini-3.5-flash`), causing every run to fail with:

```
GeminiException 404: models/gemini-3.1-pro is not found for API version v1alpha
```

The job still exited 0, so failures were silent (no review posted).

## Changes

- `config.model`: `gemini/gemini-2.5-flash`
- `config.fallback_models`: `["gemini/gemini-2.0-flash"]`
- Both are Gemini API **free-tier** models — no billing required, uses the existing `GEMINI_API_KEY` secret.

## Testing

Verified via a real `pull_request` run on the branch (CI uses the `GEMINI_API_KEY` secret): the 404 is gone and the review is generated.

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Update Gemini model IDs.

- Use free-tier Flash models.

- Resolve 404 errors.

- Enable AI review generation.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AI Review Workflow"] --> B["PR-Agent Action"]
  B -- "Uses primary model" --> C["gemini/gemini-2.5-flash"]
  B -- "Uses fallback model" --> D["gemini/gemini-2.0-flash"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ai-review.yml</strong><dd><code>Update Gemini AI review model configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ai-review.yml

<ul><li>Updated <code>config.model</code> from <code>gemini/gemini-3.1-pro</code> to <br><code>gemini/gemini-2.5-flash</code>.<br> <li> Changed <code>config.fallback_models</code> from <code>gemini/gemini-3.5-flash</code> to <br><code>gemini/gemini-2.0-flash</code>.<br> <li> Updated comments to reflect the use of free-tier Flash models and the <br>previous 404 errors.<br> <li> Clarified the <code>config.custom_model_max_tokens</code> comment for Gemini Flash <br>models.</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/884/files#diff-105e0011bdd1445d561435b79b1c776c324c9ea99ac6c3649f8bf4895399fa41">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

