### PR TITLE
Feature/#869 - Download response as file

### DIFF
--- a/src/main/__mocks__/test-behavior.ts
+++ b/src/main/__mocks__/test-behavior.ts
@@ -1,0 +1,8 @@
+import { app, safeStorage, dialog, BrowserWindow, ipcMain } from 'electron';
+
+const result = safeStorage.encryptString('test');
+console.log('encryptString result:', JSON.stringify(result));
+console.log('encryptString typeof:', typeof result);
+
+const path = app.getPath('userData');
+console.log('getPath result:', JSON.stringify(path));

--- a/src/main/__mocks__/test-behavior.ts
+++ b/src/main/__mocks__/test-behavior.ts
@@ -1,8 +1,0 @@
-import { app, safeStorage, dialog, BrowserWindow, ipcMain } from 'electron';
-
-const result = safeStorage.encryptString('test');
-console.log('encryptString result:', JSON.stringify(result));
-console.log('encryptString typeof:', typeof result);
-
-const path = app.getPath('userData');
-console.log('getPath result:', JSON.stringify(path));

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -1,4 +1,4 @@
-import { app, dialog, ipcMain, WebContents } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, WebContents } from 'electron';
 import { EnvironmentService } from 'main/environment/service/environment-service';
 import { HttpService } from 'main/network/service/http-service';
 import type {
@@ -16,6 +16,9 @@ import type { ClientCertificate } from 'shim/objects/collection';
 import { PersistenceService } from '../persistence/service/persistence-service';
 import { ImportService } from 'main/import/service/import-service';
 import { ScriptingService } from 'main/scripting/scripting-service';
+import { ResponseBodyService } from 'main/network/service/response-body-service';
+import { getSuggestedFilename } from 'main/network/response-filename';
+import fs from 'node:fs/promises';
 import { updateElectronApp } from 'update-electron-app';
 
 // register stream events
@@ -217,6 +220,31 @@ export class MainEventService implements IEventService {
 
   async rename(object: TrufosObject, newTitle: string): Promise<void> {
     await persistenceService.rename(object, newTitle);
+  }
+
+  async downloadResponse(responseId: string): Promise<string | null> {
+    const entry = ResponseBodyService.instance.getEntry(responseId);
+    if (!entry) {
+      logger.warn(`Response body not found for ID: ${responseId}`);
+      return null;
+    }
+
+    const defaultPath = getSuggestedFilename(entry.headers);
+    const parentWindow = this.webContents
+      ? BrowserWindow.fromWebContents(this.webContents) ?? undefined
+      : undefined;
+
+    const { canceled, filePath: chosenPath } = parentWindow
+      ? await dialog.showSaveDialog(parentWindow, { defaultPath })
+      : await dialog.showSaveDialog({ defaultPath });
+
+    if (canceled || !chosenPath) {
+      return null;
+    }
+
+    await fs.copyFile(entry.filePath, chosenPath);
+    logger.info(`Response body saved to ${chosenPath}`);
+    return chosenPath;
   }
 
   updateApp() {

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -18,7 +18,6 @@ import { ImportService } from 'main/import/service/import-service';
 import { ScriptingService } from 'main/scripting/scripting-service';
 import { ResponseBodyService } from 'main/network/service/response-body-service';
 import { getSuggestedFilename } from 'main/network/response-filename';
-import fs from 'node:fs/promises';
 import { updateElectronApp } from 'update-electron-app';
 
 // register stream events
@@ -230,21 +229,16 @@ export class MainEventService implements IEventService {
     }
 
     const defaultPath = getSuggestedFilename(entry.headers);
-    const parentWindow = this.webContents
-      ? BrowserWindow.fromWebContents(this.webContents) ?? undefined
-      : undefined;
-
-    const { canceled, filePath: chosenPath } = parentWindow
-      ? await dialog.showSaveDialog(parentWindow, { defaultPath })
-      : await dialog.showSaveDialog({ defaultPath });
+    const { canceled, filePath: chosenPath } = await dialog.showSaveDialog(
+      BrowserWindow.fromWebContents(this.webContents!)!,
+      { defaultPath }
+    );
 
     if (canceled || !chosenPath) {
       return null;
     }
 
-    await fs.copyFile(entry.filePath, chosenPath);
-    logger.info(`Response body saved to ${chosenPath}`);
-    return chosenPath;
+    return await ResponseBodyService.instance.downloadResponse(responseId, chosenPath);
   }
 
   updateApp() {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2,7 +2,7 @@ import './logging/logger';
 
 import { app, BrowserWindow, dialog, ipcMain, safeStorage, shell } from 'electron';
 import { EnvironmentService } from 'main/environment/service/environment-service';
-import 'main/event/main-event-service';
+import { MainEventService } from 'main/event/main-event-service';
 import path from 'node:path';
 import quit from 'electron-squirrel-startup';
 import { SettingsService } from './persistence/service/settings-service';

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9,7 +9,6 @@ import { SettingsService } from './persistence/service/settings-service';
 import { once } from 'node:events';
 import process from 'node:process';
 import { ResponseBodyService } from 'main/network/service/response-body-service';
-import { MainEventService } from 'main/event/main-event-service';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;

--- a/src/main/network/authentication/oauth2/auth-code-flow.ts
+++ b/src/main/network/authentication/oauth2/auth-code-flow.ts
@@ -17,16 +17,14 @@ import { RequestMethod } from 'shim/objects/request-method';
 
 function isPKCEConfig(
   auth:
-    | OAuth2ClientAuthorizationCodeFlowInformation
-    | OAuth2ClientAuthorizationCodeFlowPKCEInformation
+    OAuth2ClientAuthorizationCodeFlowInformation | OAuth2ClientAuthorizationCodeFlowPKCEInformation
 ): auth is OAuth2ClientAuthorizationCodeFlowPKCEInformation {
   return auth.method === OAuth2Method.AUTHORIZATION_CODE_PKCE;
 }
 
 export default class AuthCodeFlowAuthorizationStrategy<
   T extends
-    | OAuth2ClientAuthorizationCodeFlowInformation
-    | OAuth2ClientAuthorizationCodeFlowPKCEInformation,
+    OAuth2ClientAuthorizationCodeFlowInformation | OAuth2ClientAuthorizationCodeFlowPKCEInformation,
 > extends OAuth2AuthStrategy<T> {
   private async getCurrentUrl(authorizationUrl: URL, callbackUrl: string) {
     let redirectUrl: URL | undefined;

--- a/src/main/network/response-filename.ts
+++ b/src/main/network/response-filename.ts
@@ -1,0 +1,88 @@
+const MIME_EXTENSIONS: Record<string, string> = {
+  'application/json': '.json',
+  'application/vnd.api+json': '.json',
+  'text/html': '.html',
+  'text/plain': '.txt',
+  'text/css': '.css',
+  'text/javascript': '.js',
+  'application/javascript': '.js',
+  'text/xml': '.xml',
+  'application/xml': '.xml',
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/gif': '.gif',
+  'image/svg+xml': '.svg',
+  'image/webp': '.webp',
+  'image/bmp': '.bmp',
+  'application/pdf': '.pdf',
+  'application/zip': '.zip',
+  'application/gzip': '.gz',
+  'application/x-tar': '.tar',
+  'application/x-bzip2': '.bz2',
+  'application/x-www-form-urlencoded': '.txt',
+  'application/octet-stream': '.bin',
+  'multipart/form-data': '.txt',
+};
+
+type HeadersInput = Record<string, string | string[] | undefined>;
+
+function getHeaderValue(headers: HeadersInput, key: string): string | undefined {
+  const actualKey = Object.keys(headers).find((k) => k.toLowerCase() === key.toLowerCase());
+  if (!actualKey) return undefined;
+  const value = headers[actualKey];
+  if (value === undefined) return undefined;
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function sanitizeFilename(name: string): string {
+  let sanitized = name.replace(/[/\\?%*:|"<>]/g, '_');
+  sanitized = sanitized.replace(/\0/g, '');
+  sanitized = sanitized.replace(/_+/g, '_');
+  sanitized = sanitized.replace(/^[. ]+|[. ]+$/g, '');
+  return sanitized || '_';
+}
+
+export function parseContentDispositionFilename(disposition: string): string | undefined {
+  const parts = disposition.split(';').map((s) => s.trim());
+
+  for (const part of parts) {
+    if (part.startsWith('filename*=')) {
+      const value = part.slice('filename*='.length);
+      const match = value.match(/^(?:UTF-8|ISO-8859-1)''(.+)$/i);
+      if (match) {
+        try {
+          return sanitizeFilename(decodeURIComponent(match[1]));
+        } catch {
+          return undefined;
+        }
+      }
+    }
+  }
+
+  for (const part of parts) {
+    if (part.startsWith('filename=')) {
+      const value = part.slice('filename='.length);
+      const name = value.replace(/^["']|["']$/g, '').trim();
+      if (name) return sanitizeFilename(name);
+    }
+  }
+
+  return undefined;
+}
+
+export function getSuggestedFilename(headers: HeadersInput): string {
+  const disposition = getHeaderValue(headers, 'content-disposition');
+  if (disposition) {
+    const parsed = parseContentDispositionFilename(disposition);
+    if (parsed) return parsed;
+  }
+
+  const contentType = getHeaderValue(headers, 'content-type');
+  if (contentType) {
+    const mime = contentType.split(';')[0].trim();
+    const ext = MIME_EXTENSIONS[mime] ?? '.bin';
+    return `response${ext}`;
+  }
+
+  return 'response.bin';
+}

--- a/src/main/network/response-filename.ts
+++ b/src/main/network/response-filename.ts
@@ -1,36 +1,9 @@
-const MIME_EXTENSIONS: Record<string, string> = {
-  'application/json': '.json',
-  'application/vnd.api+json': '.json',
-  'text/html': '.html',
-  'text/plain': '.txt',
-  'text/css': '.css',
-  'text/javascript': '.js',
-  'application/javascript': '.js',
-  'text/xml': '.xml',
-  'application/xml': '.xml',
-  'image/png': '.png',
-  'image/jpeg': '.jpg',
-  'image/gif': '.gif',
-  'image/svg+xml': '.svg',
-  'image/webp': '.webp',
-  'image/bmp': '.bmp',
-  'application/pdf': '.pdf',
-  'application/zip': '.zip',
-  'application/gzip': '.gz',
-  'application/x-tar': '.tar',
-  'application/x-bzip2': '.bz2',
-  'application/x-www-form-urlencoded': '.txt',
-  'application/octet-stream': '.bin',
-  'multipart/form-data': '.txt',
-};
+import mime from 'mime-types';
 
-type HeadersInput = Record<string, string | string[] | undefined>;
+import type { HttpHeaders } from 'shim/headers';
 
-function getHeaderValue(headers: HeadersInput, key: string): string | undefined {
-  const actualKey = Object.keys(headers).find((k) => k.toLowerCase() === key.toLowerCase());
-  if (!actualKey) return undefined;
-  const value = headers[actualKey];
-  if (value === undefined) return undefined;
+function getHeaderValue(headers: HttpHeaders, key: string): string | undefined {
+  const value = headers[key.toLowerCase()];
   return Array.isArray(value) ? value[0] : value;
 }
 
@@ -43,34 +16,23 @@ export function sanitizeFilename(name: string): string {
 }
 
 export function parseContentDispositionFilename(disposition: string): string | undefined {
-  const parts = disposition.split(';').map((s) => s.trim());
-
-  for (const part of parts) {
-    if (part.startsWith('filename*=')) {
-      const value = part.slice('filename*='.length);
-      const match = value.match(/^(?:UTF-8|ISO-8859-1)''(.+)$/i);
-      if (match) {
-        try {
-          return sanitizeFilename(decodeURIComponent(match[1]));
-        } catch {
-          return undefined;
-        }
-      }
+  const starMatch = disposition.match(/filename\*=(?:UTF-8|ISO-8859-1)''([^;]+)/i);
+  if (starMatch) {
+    try {
+      return sanitizeFilename(decodeURIComponent(starMatch[1]));
+    } catch {
+      return undefined;
     }
   }
 
-  for (const part of parts) {
-    if (part.startsWith('filename=')) {
-      const value = part.slice('filename='.length);
-      const name = value.replace(/^["']|["']$/g, '').trim();
-      if (name) return sanitizeFilename(name);
-    }
+  const plainMatch = disposition.match(/filename=["']?([^"';\r\n]+)["']?/i);
+  if (plainMatch) {
+    const name = plainMatch[1].trim();
+    if (name) return sanitizeFilename(name);
   }
-
-  return undefined;
 }
 
-export function getSuggestedFilename(headers: HeadersInput): string {
+export function getSuggestedFilename(headers: HttpHeaders): string {
   const disposition = getHeaderValue(headers, 'content-disposition');
   if (disposition) {
     const parsed = parseContentDispositionFilename(disposition);
@@ -79,9 +41,8 @@ export function getSuggestedFilename(headers: HeadersInput): string {
 
   const contentType = getHeaderValue(headers, 'content-type');
   if (contentType) {
-    const mime = contentType.split(';')[0].trim();
-    const ext = MIME_EXTENSIONS[mime] ?? '.bin';
-    return `response${ext}`;
+    const ext = mime.extension(contentType);
+    if (ext) return `response.${ext}`;
   }
 
   return 'response.bin';

--- a/src/main/network/service/http-service.ts
+++ b/src/main/network/service/http-service.ts
@@ -128,7 +128,7 @@ export class HttpService {
       },
       headers: Object.freeze(responseData.headers),
       id: (responseData.body != null
-        ? responseBodyService.register(bodyFile.name!)
+        ? responseBodyService.register(bodyFile.name!, responseData.headers)
         : undefined) as string,
     };
 

--- a/src/main/network/service/response-body-service.ts
+++ b/src/main/network/service/response-body-service.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
+import { copyFile } from 'node:fs/promises';
 import type { HttpHeaders } from 'shim/headers';
 
 export interface ResponseBodyEntry {
@@ -27,6 +28,18 @@ export class ResponseBodyService {
 
   public getEntry(responseId: string): ResponseBodyEntry | undefined {
     return this.responseBodyMap.get(responseId);
+  }
+
+  public async downloadResponse(responseId: string, chosenPath: string): Promise<string | null> {
+    const entry = this.getEntry(responseId);
+    if (!entry) {
+      logger.warn(`Response body not found for ID: ${responseId}`);
+      return null;
+    }
+
+    await copyFile(entry.filePath, chosenPath);
+    logger.info(`Response body saved to ${chosenPath}`);
+    return chosenPath;
   }
 
   public remove(responseId: string): void {

--- a/src/main/network/service/response-body-service.ts
+++ b/src/main/network/service/response-body-service.ts
@@ -1,36 +1,46 @@
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
+import type { HttpHeaders } from 'shim/headers';
+
+export interface ResponseBodyEntry {
+  filePath: string;
+  headers: HttpHeaders;
+}
 
 export class ResponseBodyService {
   public static readonly instance = new ResponseBodyService();
 
-  private readonly responseBodyMap = new Map<string, string>();
+  private readonly responseBodyMap = new Map<string, ResponseBodyEntry>();
 
   private constructor() {}
 
-  public register(filePath: string): string {
+  public register(filePath: string, headers: HttpHeaders = {}): string {
     const responseId = randomUUID();
-    this.responseBodyMap.set(responseId, filePath);
+    this.responseBodyMap.set(responseId, { filePath, headers });
     logger.debug(`Registered response body: ${responseId} -> ${filePath}`);
     return responseId;
   }
 
   public getFilePath(responseId: string): string | undefined {
+    return this.responseBodyMap.get(responseId)?.filePath;
+  }
+
+  public getEntry(responseId: string): ResponseBodyEntry | undefined {
     return this.responseBodyMap.get(responseId);
   }
 
   public remove(responseId: string): void {
-    const filePath = this.responseBodyMap.get(responseId);
-    if (filePath) {
-      this.deleteFileIfExists(filePath);
+    const entry = this.responseBodyMap.get(responseId);
+    if (entry) {
+      this.deleteFileIfExists(entry.filePath);
       this.responseBodyMap.delete(responseId);
       logger.debug(`Removed response body: ${responseId}`);
     }
   }
 
   public clear(): void {
-    this.responseBodyMap.forEach((filePath) => {
-      this.deleteFileIfExists(filePath);
+    this.responseBodyMap.forEach((entry) => {
+      this.deleteFileIfExists(entry.filePath);
     });
     this.responseBodyMap.clear();
     logger.debug('Cleared all response bodies');

--- a/src/main/persistence/service/secret-service.ts
+++ b/src/main/persistence/service/secret-service.ts
@@ -4,6 +4,10 @@ import { Buffer } from 'node:buffer';
 export class SecretService {
   public static readonly instance = new SecretService();
 
+  /**
+   * Encrypts a string using the SafeStorage API.
+   * @param plain The string to encrypt.
+   */
   public encrypt(plain: string): Buffer {
     try {
       return safeStorage.encryptString(plain);
@@ -12,6 +16,10 @@ export class SecretService {
     }
   }
 
+  /**
+   * Decrypts a string using the SafeStorage API.
+   * @param encrypted The encrypted bytes to decrypt.
+   */
   public decrypt(encrypted: Buffer): string {
     try {
       return safeStorage.decryptString(encrypted);

--- a/src/main/persistence/service/secret-service.ts
+++ b/src/main/persistence/service/secret-service.ts
@@ -1,21 +1,22 @@
 import { safeStorage } from 'electron';
+import { Buffer } from 'node:buffer';
 
 export class SecretService {
   public static readonly instance = new SecretService();
 
-  /**
-   * Encrypts a string using the SafeStorage API.
-   * @param plain The string to encrypt.
-   */
   public encrypt(plain: string): Buffer {
-    return safeStorage.encryptString(plain);
+    try {
+      return safeStorage.encryptString(plain);
+    } catch {
+      return Buffer.from(plain, 'utf-8');
+    }
   }
 
-  /**
-   * Decrypts a string using the SafeStorage API.
-   * @param encrypted The encrypted bytes to decrypt.
-   */
   public decrypt(encrypted: Buffer): string {
-    return safeStorage.decryptString(encrypted);
+    try {
+      return safeStorage.decryptString(encrypted);
+    } catch {
+      return encrypted.toString('utf-8');
+    }
   }
 }

--- a/src/main/persistence/service/secret-service.ts
+++ b/src/main/persistence/service/secret-service.ts
@@ -9,11 +9,7 @@ export class SecretService {
    * @param plain The string to encrypt.
    */
   public encrypt(plain: string): Buffer {
-    try {
-      return safeStorage.encryptString(plain);
-    } catch {
-      return Buffer.from(plain, 'utf-8');
-    }
+    return safeStorage.encryptString(plain);
   }
 
   /**
@@ -21,10 +17,6 @@ export class SecretService {
    * @param encrypted The encrypted bytes to decrypt.
    */
   public decrypt(encrypted: Buffer): string {
-    try {
-      return safeStorage.decryptString(encrypted);
-    } catch {
-      return encrypted.toString('utf-8');
-    }
+    return safeStorage.decryptString(encrypted);
   }
 }

--- a/src/renderer/components/mainWindow/bodyTabs/OutputTabs/BodyTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/OutputTabs/BodyTab.tsx
@@ -10,6 +10,9 @@ import { TextualPrettyRenderer } from './TextualPrettyRenderer';
 import { DefaultRenderer } from './DefaultRenderer';
 import { useStateDerived } from '@/util/react-util';
 import { Button } from '@/components/ui/button';
+import { Download } from 'lucide-react';
+import { IconButton } from '@/components/ui/icon-button';
+import { RendererEventService } from '@/services/event/renderer-event-service';
 
 enum OutputType {
   RAW = 'Raw',
@@ -69,6 +72,13 @@ export const BodyTab = () => {
             onValueChange={setOutputType}
             items={outputTypes}
           />
+          <IconButton
+            disabled={!response?.id}
+            onClick={() => RendererEventService.instance.downloadResponse(response!.id)}
+            title="Save response body"
+          >
+            <Download className="h-4 w-4" />
+          </IconButton>
         </div>
         <Divider />
       </div>

--- a/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
@@ -46,8 +46,7 @@ export const SidebarRequestList = () => {
   const activeSensors = sortMode === SortMode.DEFAULT ? sensors : [];
 
   const sortFn = useMemo(():
-    | ((a: TrufosRequest | Folder, b: TrufosRequest | Folder) => number)
-    | null => {
+    ((a: TrufosRequest | Folder, b: TrufosRequest | Folder) => number) | null => {
     if (sortMode === SortMode.AZ_ASC) return (a, b) => a.title.localeCompare(b.title);
     if (sortMode === SortMode.AZ_DESC) return (a, b) => b.title.localeCompare(a.title);
     if (sortMode === SortMode.TIME_DESC)

--- a/src/renderer/lib/monaco/template-variable-semantic-tokens-provider.ts
+++ b/src/renderer/lib/monaco/template-variable-semantic-tokens-provider.ts
@@ -23,7 +23,7 @@ export class TemplateVariableSemanticTokensProvider
 
     for (let i = 0; i < model.getLineCount(); i++) {
       this.regex.lastIndex = 0; // reset regex
-      for (let match; (match = this.regex.exec(model.getLineContent(i + 1))) !== null; ) {
+      for (let match; (match = this.regex.exec(model.getLineContent(i + 1))) !== null;) {
         tokens.push({
           lineNumber: i,
           column: match.index,

--- a/src/renderer/services/event/renderer-event-service.ts
+++ b/src/renderer/services/event/renderer-event-service.ts
@@ -69,5 +69,6 @@ export class RendererEventService implements IEventService {
   reorderItem = createEventMethod('reorderItem');
   updateApp = createEventMethod('updateApp');
   saveScript = createEventMethod('saveScript');
+  downloadResponse = createEventMethod('downloadResponse');
   setClientCertificate = createEventMethod('setClientCertificate');
 }

--- a/src/shim/event-service.ts
+++ b/src/shim/event-service.ts
@@ -215,4 +215,15 @@ export interface IEventService {
    * @param script The script content to save.
    */
   saveScript(request: TrufosRequest, type: ScriptType, script: string): Promise<void>;
+
+  /**
+   * Save a response body to disk. Opens a native save dialog with a suggested filename
+   * derived from the Content-Disposition or Content-Type header, then copies the
+   * response body temp file to the chosen path. The response body never enters the
+   * renderer process.
+   *
+   * @param responseId The ID of the response body to save.
+   * @returns The saved file path, or null if the user cancelled or the body is unavailable.
+   */
+  downloadResponse(responseId: string): Promise<string | null>;
 }


### PR DESCRIPTION
## Changes

For #869. Implemented the Download button in the renderer, that stays disabled, when no response to download. Along with this, created a small logic that derives filename from the headers and if not available, goes to a fallback. Also, the safeStorage.decryptString was throwing an error which led to crash on startup, so just wrapped them in a try-catch block.

## Testing

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/440ac4de-a681-4077-96d2-02bdbd6ebb9b" />
Have added a simple icon to download the response as files.  

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/dc54585e-f4fe-470c-80bd-0268a81a1650" />

The file gets downloaded to user's machine.
Have tested this on Linux.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person