### PR TITLE
GraphQL support

### DIFF
--- a/src/main/event/main-event-service.test.ts
+++ b/src/main/event/main-event-service.test.ts
@@ -4,9 +4,8 @@ import { fs } from 'memfs';
 import { vi, describe, it, beforeEach, expect } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { Collection } from 'shim/objects/collection';
-import { TrufosRequest } from 'shim/objects/request';
+import { TrufosRequest , RequestBodyType } from 'shim/objects/request';
 import { RequestMethod } from 'shim/objects/request-method';
-import { RequestBodyType } from 'shim/objects/request';
 import { Folder } from 'shim/objects/folder';
 
 vi.mock('electron', () => ({

--- a/src/main/event/main-event-service.test.ts
+++ b/src/main/event/main-event-service.test.ts
@@ -4,7 +4,7 @@ import { fs } from 'memfs';
 import { vi, describe, it, beforeEach, expect } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { Collection } from 'shim/objects/collection';
-import { TrufosRequest , RequestBodyType } from 'shim/objects/request';
+import { TrufosRequest, RequestBodyType } from 'shim/objects/request';
 import { RequestMethod } from 'shim/objects/request-method';
 import { Folder } from 'shim/objects/folder';
 

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -11,12 +11,14 @@ import type {
   ScriptType,
   IEventService,
   ImportStrategy,
+  TrufosHeader,
 } from 'shim';
 import type { ClientCertificate } from 'shim/objects/collection';
 import { PersistenceService } from '../persistence/service/persistence-service';
 import { ImportService } from 'main/import/service/import-service';
 import { ScriptingService } from 'main/scripting/scripting-service';
 import { updateElectronApp } from 'update-electron-app';
+import undici from 'undici';
 
 // register stream events
 import './stream-events';
@@ -230,5 +232,89 @@ export class MainEventService implements IEventService {
       },
       updateInterval: '1 hour',
     });
+  }
+
+  async introspectSchema(url: string, headers: TrufosHeader[]): Promise<any> {
+    logger.info('Introspecting GraphQL schema at URL:', url);
+    const undiciHeaders: Record<string, string> = {
+      'content-type': 'application/json',
+    };
+    for (const h of headers) {
+      if (h.isActive) {
+        undiciHeaders[h.key.toLowerCase()] = h.value;
+      }
+    }
+
+    const introspectionQuery = `
+      query IntrospectionQuery {
+        __schema {
+          queryType { name }
+          mutationType { name }
+          subscriptionType { name }
+          types {
+            kind
+            name
+            description
+            fields(includeDeprecated: true) {
+              name
+              description
+              args {
+                name
+                description
+                type {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                    ofType {
+                      kind
+                      name
+                      ofType {
+                        kind
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+              type {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                    ofType {
+                      kind
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    const payload = JSON.stringify({
+      query: introspectionQuery,
+    });
+
+    const response = await undici.request(url, {
+      method: 'POST',
+      headers: undiciHeaders,
+      body: payload,
+    });
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw new Error(`Introspection failed with status code ${response.statusCode}`);
+    }
+
+    const responseBody = await response.body.json();
+    return responseBody;
   }
 }

--- a/src/main/logging/logger.ts
+++ b/src/main/logging/logger.ts
@@ -13,7 +13,6 @@ console.info('Saving logs at', app.getPath('logs'));
 type TransformableInfoExtended = TransformableInfo & LogEntry;
 
 declare global {
-   
   var logger: winston.Logger & {
     secret: {
       info: (message: string, ...meta: unknown[]) => void;

--- a/src/main/logging/logger.ts
+++ b/src/main/logging/logger.ts
@@ -13,7 +13,7 @@ console.info('Saving logs at', app.getPath('logs'));
 type TransformableInfoExtended = TransformableInfo & LogEntry;
 
 declare global {
-  // eslint-disable-next-line no-var
+   
   var logger: winston.Logger & {
     secret: {
       info: (message: string, ...meta: unknown[]) => void;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2,14 +2,13 @@ import './logging/logger';
 
 import { app, BrowserWindow, dialog, ipcMain, safeStorage, shell } from 'electron';
 import { EnvironmentService } from 'main/environment/service/environment-service';
-import 'main/event/main-event-service';
+import { MainEventService } from 'main/event/main-event-service';
 import path from 'node:path';
 import quit from 'electron-squirrel-startup';
 import { SettingsService } from './persistence/service/settings-service';
 import { once } from 'node:events';
 import process from 'node:process';
 import { ResponseBodyService } from 'main/network/service/response-body-service';
-import { MainEventService } from 'main/event/main-event-service';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;

--- a/src/main/network/authentication/auth-strategy-factory.test.ts
+++ b/src/main/network/authentication/auth-strategy-factory.test.ts
@@ -8,7 +8,9 @@ import {
   BasicAuthorizationInformation,
   BearerAuthorizationInformation,
   OAuth2ClientAuthenticationMethod,
- OAuth2ClientCrentialsAuthorizationInformation, OAuth2Method } from 'shim/objects';
+  OAuth2ClientCrentialsAuthorizationInformation,
+  OAuth2Method,
+} from 'shim/objects';
 import ClientCredentialsAuthorizationStrategy from './oauth2/client-credentials';
 
 describe('createAuthStrategy()', () => {

--- a/src/main/network/authentication/auth-strategy-factory.test.ts
+++ b/src/main/network/authentication/auth-strategy-factory.test.ts
@@ -8,8 +8,7 @@ import {
   BasicAuthorizationInformation,
   BearerAuthorizationInformation,
   OAuth2ClientAuthenticationMethod,
-} from 'shim/objects';
-import { OAuth2ClientCrentialsAuthorizationInformation, OAuth2Method } from 'shim/objects';
+ OAuth2ClientCrentialsAuthorizationInformation, OAuth2Method } from 'shim/objects';
 import ClientCredentialsAuthorizationStrategy from './oauth2/client-credentials';
 
 describe('createAuthStrategy()', () => {

--- a/src/main/network/authentication/oauth2/auth-code-flow.ts
+++ b/src/main/network/authentication/oauth2/auth-code-flow.ts
@@ -17,16 +17,14 @@ import { RequestMethod } from 'shim/objects/request-method';
 
 function isPKCEConfig(
   auth:
-    | OAuth2ClientAuthorizationCodeFlowInformation
-    | OAuth2ClientAuthorizationCodeFlowPKCEInformation
+    OAuth2ClientAuthorizationCodeFlowInformation | OAuth2ClientAuthorizationCodeFlowPKCEInformation
 ): auth is OAuth2ClientAuthorizationCodeFlowPKCEInformation {
   return auth.method === OAuth2Method.AUTHORIZATION_CODE_PKCE;
 }
 
 export default class AuthCodeFlowAuthorizationStrategy<
   T extends
-    | OAuth2ClientAuthorizationCodeFlowInformation
-    | OAuth2ClientAuthorizationCodeFlowPKCEInformation,
+    OAuth2ClientAuthorizationCodeFlowInformation | OAuth2ClientAuthorizationCodeFlowPKCEInformation,
 > extends OAuth2AuthStrategy<T> {
   private async getCurrentUrl(authorizationUrl: URL, callbackUrl: string) {
     let redirectUrl: URL | undefined;

--- a/src/main/network/authentication/oauth2/client-credentials.test.ts
+++ b/src/main/network/authentication/oauth2/client-credentials.test.ts
@@ -1,5 +1,4 @@
-import { AuthorizationType } from 'shim/objects';
-import {
+import { AuthorizationType ,
   OAuth2ClientAuthenticationMethod,
   OAuth2ClientCrentialsAuthorizationInformation,
   OAuth2Method,

--- a/src/main/network/authentication/oauth2/client-credentials.test.ts
+++ b/src/main/network/authentication/oauth2/client-credentials.test.ts
@@ -1,4 +1,5 @@
-import { AuthorizationType ,
+import {
+  AuthorizationType,
   OAuth2ClientAuthenticationMethod,
   OAuth2ClientCrentialsAuthorizationInformation,
   OAuth2Method,

--- a/src/main/network/service/http-service.test.ts
+++ b/src/main/network/service/http-service.test.ts
@@ -475,12 +475,43 @@ describe('HttpService', () => {
     expect(executeSpy.mock.calls[0]?.[0]).toEqual(preScript);
     expect(executeSpy.mock.calls[1]?.[0]).toEqual(postScript);
   });
+
+  it('fetchAsync() should correctly format and serialize a GraphQL request', async () => {
+    // Arrange
+    const responseBodyMock = { data: { hello: 'world' } };
+    const url = new URL('https://example.com/graphql');
+    const httpService = setupMockHttpService(url, responseBodyMock, undefined, 'POST');
+    const request: TrufosRequest = {
+      id: randomUUID(),
+      parentId: randomUUID(),
+      type: 'request',
+      title: 'GraphQL Request',
+      url: parseUrl(url.toString()),
+      method: RequestMethod.GRAPHQL,
+      headers: [],
+      body: {
+        type: RequestBodyType.GRAPHQL,
+        query: 'query { hello }',
+        variables: '{"someVar": "val"}',
+      },
+    };
+
+    // Act
+    const result = await httpService.fetchAsync(request);
+
+    // Assert
+    expect(result.metaInfo.status).toEqual(200);
+    const filePath = responseBodyService.getFilePath(result.id);
+    const responseBody = JSON.parse(fs.readFileSync(filePath!, 'utf8'));
+    expect(responseBody).toEqual(responseBodyMock);
+  });
 });
 
 function setupMockHttpService(
   url: URL,
   body: object | string | null,
-  headers?: IncomingHttpHeaders
+  headers?: IncomingHttpHeaders,
+  method = 'GET'
 ) {
   let bodyString;
   switch (typeof body) {
@@ -496,7 +527,7 @@ function setupMockHttpService(
 
   const mockClient = mockAgent.get(url.origin);
   mockClient
-    .intercept({ path: url.pathname })
+    .intercept({ path: url.pathname, method })
     .reply(200, bodyString ?? undefined, { headers: headers });
   return new HttpService(() => Promise.resolve(mockAgent));
 }

--- a/src/main/network/service/http-service.ts
+++ b/src/main/network/service/http-service.ts
@@ -6,7 +6,8 @@ import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import { Readable } from 'stream';
 import { EnvironmentService } from 'main/environment/service/environment-service';
-import { RequestBody, RequestBodyType, TrufosRequest } from 'shim/objects/request';
+import { RequestBody, RequestBodyType, TrufosRequest, GraphQLBody } from 'shim/objects/request';
+import { RequestMethod } from 'shim/objects/request-method';
 import { buildUrl } from 'shim/objects/url';
 import { TrufosResponse } from 'shim/objects/response';
 import { PersistenceService } from 'main/persistence/service/persistence-service';
@@ -86,11 +87,13 @@ export class HttpService {
 
     const [body, size] = await this.readBody(request);
 
+    const method = request.method === RequestMethod.GRAPHQL ? 'POST' : request.method;
+
     // measure duration of the request
     const now = getSteadyTimestamp();
     const responseData = await undici.request(url, {
       dispatcher: await this._dispatcherProvider(),
-      method: request.method,
+      method,
       headers: {
         ['content-type']: this.getContentType(request.body),
         ['authorization']: authorization,
@@ -153,6 +156,27 @@ export class HttpService {
       }
       case RequestBodyType.FILE:
         return this.readFileBody(request.body.filePath);
+      case RequestBodyType.GRAPHQL: {
+        const gqlBody = request.body as GraphQLBody;
+        const resolvedQuery = await environmentService.setVariablesInString(gqlBody.query ?? '');
+        const resolvedVariablesStr = await environmentService.setVariablesInString(
+          gqlBody.variables ?? '{}'
+        );
+        let parsedVariables = {};
+        if (resolvedVariablesStr.trim()) {
+          try {
+            parsedVariables = JSON.parse(resolvedVariablesStr);
+          } catch (e) {
+            // Keep variables as empty object if not valid JSON
+          }
+        }
+        const payload = JSON.stringify({
+          query: resolvedQuery,
+          variables: parsedVariables,
+          operationName: null,
+        });
+        return [Readable.from(payload), Buffer.byteLength(payload)];
+      }
       case RequestBodyType.FORM_DATA:
         const form = new FormData();
         for (const field of request.body.fields) {
@@ -198,6 +222,8 @@ export class HttpService {
           return body.mimeType ?? 'text/plain';
         case RequestBodyType.FILE:
           return body.mimeType ?? 'application/octet-stream';
+        case RequestBodyType.GRAPHQL:
+          return 'application/json';
       }
     }
   }

--- a/src/main/persistence/service/info-files/v1-3-0.ts
+++ b/src/main/persistence/service/info-files/v1-3-0.ts
@@ -5,8 +5,7 @@ import { RequestMethod } from 'shim/objects/request-method';
 import { TrufosHeader } from 'shim/objects/headers';
 import { SemVer } from 'main/util/semver';
 import { AbstractInfoFileMigrator } from './migrator';
-import { TrufosObjectType } from 'shim/objects';
-import { AuthorizationInformation, InheritAuthorizationInformation } from 'shim/objects';
+import { TrufosObjectType , AuthorizationInformation, InheritAuthorizationInformation } from 'shim/objects';
 
 import { InfoFile as OldInfoFile, VERSION as OLD_VERSION } from './v1-2-0';
 

--- a/src/main/persistence/service/info-files/v1-3-0.ts
+++ b/src/main/persistence/service/info-files/v1-3-0.ts
@@ -5,7 +5,11 @@ import { RequestMethod } from 'shim/objects/request-method';
 import { TrufosHeader } from 'shim/objects/headers';
 import { SemVer } from 'main/util/semver';
 import { AbstractInfoFileMigrator } from './migrator';
-import { TrufosObjectType , AuthorizationInformation, InheritAuthorizationInformation } from 'shim/objects';
+import {
+  TrufosObjectType,
+  AuthorizationInformation,
+  InheritAuthorizationInformation,
+} from 'shim/objects';
 
 import { InfoFile as OldInfoFile, VERSION as OLD_VERSION } from './v1-2-0';
 

--- a/src/main/persistence/service/info-files/v1-4-0.ts
+++ b/src/main/persistence/service/info-files/v1-4-0.ts
@@ -5,8 +5,7 @@ import { RequestMethod } from 'shim/objects/request-method';
 import { TrufosHeader } from 'shim/objects/headers';
 import { SemVer } from 'main/util/semver';
 import { AbstractInfoFileMigrator } from './migrator';
-import { TrufosObjectType } from 'shim/objects';
-import { AuthorizationInformation, InheritAuthorizationInformation } from 'shim/objects';
+import { TrufosObjectType , AuthorizationInformation, InheritAuthorizationInformation } from 'shim/objects';
 
 import { InfoFile as OldInfoFile, VERSION as OLD_VERSION } from './v1-3-0';
 

--- a/src/main/persistence/service/info-files/v1-4-0.ts
+++ b/src/main/persistence/service/info-files/v1-4-0.ts
@@ -5,7 +5,11 @@ import { RequestMethod } from 'shim/objects/request-method';
 import { TrufosHeader } from 'shim/objects/headers';
 import { SemVer } from 'main/util/semver';
 import { AbstractInfoFileMigrator } from './migrator';
-import { TrufosObjectType , AuthorizationInformation, InheritAuthorizationInformation } from 'shim/objects';
+import {
+  TrufosObjectType,
+  AuthorizationInformation,
+  InheritAuthorizationInformation,
+} from 'shim/objects';
 
 import { InfoFile as OldInfoFile, VERSION as OLD_VERSION } from './v1-3-0';
 

--- a/src/main/persistence/service/info-files/v2-0-0.ts
+++ b/src/main/persistence/service/info-files/v2-0-0.ts
@@ -5,8 +5,7 @@ import { RequestMethod } from 'shim/objects/request-method';
 import { TrufosHeader } from 'shim/objects/headers';
 import { SemVer } from 'main/util/semver';
 import { AbstractInfoFileMigrator } from './migrator';
-import { TrufosObjectType } from 'shim/objects';
-import { AuthorizationInformation, InheritAuthorizationInformation } from 'shim/objects';
+import { TrufosObjectType , AuthorizationInformation, InheritAuthorizationInformation } from 'shim/objects';
 
 import { InfoFile as OldInfoFile, VERSION as OLD_VERSION } from './v1-4-0';
 import { DRAFT_DIR_NAME, SECRETS_FILE_NAME } from 'main/persistence/constants';

--- a/src/main/persistence/service/info-files/v2-0-0.ts
+++ b/src/main/persistence/service/info-files/v2-0-0.ts
@@ -5,7 +5,11 @@ import { RequestMethod } from 'shim/objects/request-method';
 import { TrufosHeader } from 'shim/objects/headers';
 import { SemVer } from 'main/util/semver';
 import { AbstractInfoFileMigrator } from './migrator';
-import { TrufosObjectType , AuthorizationInformation, InheritAuthorizationInformation } from 'shim/objects';
+import {
+  TrufosObjectType,
+  AuthorizationInformation,
+  InheritAuthorizationInformation,
+} from 'shim/objects';
 
 import { InfoFile as OldInfoFile, VERSION as OLD_VERSION } from './v1-4-0';
 import { DRAFT_DIR_NAME, SECRETS_FILE_NAME } from 'main/persistence/constants';

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/InputTabs.test.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/InputTabs.test.tsx
@@ -6,7 +6,7 @@ import { TrufosQueryParam } from 'shim/objects/query-param';
 import { InputTabs } from './InputTabs';
 
 let mockHeaders: TrufosHeader[] = [];
-let mockQueryParams: TrufosQueryParam[] = [];
+const mockQueryParams: TrufosQueryParam[] = [];
 
 // Mock child components to avoid their store dependencies
 vi.mock('@/components/mainWindow/bodyTabs/InputTabs/tabs/HeaderTab/HeaderTab', () => ({

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTab.tsx
@@ -12,6 +12,7 @@ import { selectRequest, useCollectionActions, useCollectionStore } from '@/state
 import BodyTabFileInput from './BodyTabFileInput';
 import BodyTabTextInput from './BodyTabTextInput';
 import { FormDataTab } from './FormDataTab';
+import { GraphQLBodyEditor } from './GraphQLBodyEditor';
 import { Button } from '@/components/ui/button';
 import { WandSparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -23,8 +24,8 @@ export const BodyTab = () => {
 
   const requestBody = useCollectionStore((state) => selectRequest(state)!.body);
   const mimeType = 'mimeType' in requestBody ? requestBody.mimeType : undefined;
-  const language = mimeTypeToLanguage(mimeType!);
-  const canFormatRequestBody = isFormattableLanguage(language);
+  const language = mimeType ? mimeTypeToLanguage(mimeType) : undefined;
+  const canFormatRequestBody = language ? isFormattableLanguage(language) : false;
 
   const changeBodyType = useCallback(
     (type: RequestBodyType) => {
@@ -37,6 +38,9 @@ export const BodyTab = () => {
           break;
         case RequestBodyType.FORM_DATA:
           setRequestBody({ type, fields: [] });
+          break;
+        case RequestBodyType.GRAPHQL:
+          setRequestBody({ type, query: '', variables: '{}' });
           break;
       }
     },
@@ -59,9 +63,10 @@ export const BodyTab = () => {
                 [RequestBodyType.TEXT, 'Text'],
                 [RequestBodyType.FILE, 'File'],
                 [RequestBodyType.FORM_DATA, 'Form Data'],
+                [RequestBodyType.GRAPHQL, 'GraphQL'],
               ]}
             />
-            {requestBody.type === RequestBodyType.TEXT && (
+            {requestBody.type === RequestBodyType.TEXT && language && (
               <SimpleSelect<Language>
                 value={language}
                 onValueChange={(language) => setRequestBodyMimeType(languageToMimeType(language))}
@@ -93,10 +98,12 @@ export const BodyTab = () => {
         <FormDataTab />
       ) : requestBody.type === RequestBodyType.FILE ? (
         <BodyTabFileInput className="px-4 pb-2" />
+      ) : requestBody.type === RequestBodyType.GRAPHQL ? (
+        <GraphQLBodyEditor />
       ) : (
         <BodyTabTextInput
           className="pr-4"
-          language={language}
+          language={language!}
           onMount={(editorInstance) => {
             editorRef.current = editorInstance;
           }}

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/GraphQLBodyEditor.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/GraphQLBodyEditor.tsx
@@ -1,0 +1,146 @@
+import { FC, useEffect, useRef, useState, useCallback } from 'react';
+import MonacoEditor from '@/lib/monaco/MonacoEditor';
+import { getBodyModel, getVariablesModel } from '@/lib/monaco/models';
+import { selectRequest, useCollectionActions, useCollectionStore } from '@/state/collectionStore';
+import { REQUEST_EDITOR_OPTIONS } from '@/components/shared/settings/monaco-settings';
+import { ResizablePanel, ResizablePanelGroup, ResizableHandle } from '@/components/ui/resizable';
+import { editor } from 'monaco-editor';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { WandSparkles, RefreshCw } from 'lucide-react';
+import { introspectGraphQLSchema } from '@/lib/monaco/graphql-autocomplete';
+import { buildUrl } from 'shim/objects/url';
+
+export const GraphQLBodyEditor: FC = () => {
+  const { setDraftFlag } = useCollectionActions();
+  const selectedRequestId = useCollectionStore((state) => state.selectedRequestId);
+  const request = useCollectionStore(selectRequest)!;
+
+  const [isIntrospecting, setIsIntrospecting] = useState(false);
+
+  const queryEditorRef = useRef<editor.ICodeEditor | undefined>(undefined);
+  const varsEditorRef = useRef<editor.ICodeEditor | undefined>(undefined);
+
+  // Listen for changes on query/variables models to set draft flag
+  useEffect(() => {
+    if (selectedRequestId == null) return;
+    const model = getBodyModel(selectedRequestId);
+    const varModel = getVariablesModel(selectedRequestId);
+
+    // Explicitly set the language of the models when this editor handles them
+    editor.setModelLanguage(model, 'graphql');
+    if (varModel) {
+      editor.setModelLanguage(varModel, 'json');
+    }
+
+    const disposables = [
+      model.onDidChangeContent((e) => {
+        if (e.isFlush) return;
+        setDraftFlag();
+      }),
+    ];
+
+    if (varModel) {
+      disposables.push(
+        varModel.onDidChangeContent((e) => {
+          if (e.isFlush) return;
+          setDraftFlag();
+        })
+      );
+    }
+
+    return () => disposables.forEach((d) => d.dispose());
+  }, [selectedRequestId]);
+
+  const handleFormat = useCallback(async () => {
+    await queryEditorRef.current?.getAction('editor.action.formatDocument')?.run();
+    await varsEditorRef.current?.getAction('editor.action.formatDocument')?.run();
+  }, []);
+
+  const handleIntrospect = async () => {
+    if (!request) return;
+    setIsIntrospecting(true);
+    try {
+      const urlStr = buildUrl(request.url);
+      await introspectGraphQLSchema(request.id, urlStr, request.headers);
+    } finally {
+      setIsIntrospecting(false);
+    }
+  };
+
+  if (selectedRequestId == null) return null;
+
+  return (
+    <div className="flex h-full flex-col gap-2">
+      <div className="flex items-center justify-between px-4 pb-2">
+        <span className="text-text-secondary text-xs font-semibold tracking-wider uppercase">
+          GraphQL Editor
+        </span>
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 gap-1.5 text-xs"
+            onClick={handleIntrospect}
+            disabled={isIntrospecting}
+          >
+            <RefreshCw size={14} className={cn({ 'animate-spin': isIntrospecting })} />
+            Introspect Schema
+          </Button>
+          <Button size="sm" variant="ghost" className="h-7 gap-1.5 text-xs" onClick={handleFormat}>
+            <WandSparkles size={14} />
+            Format
+          </Button>
+        </div>
+      </div>
+
+      <div className="relative min-h-0 flex-1">
+        <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
+          <ResizablePanel defaultSize={60} minSize={30} className="relative h-full">
+            <div className="absolute inset-0 flex flex-col">
+              <div className="text-text-disabled px-4 py-1 text-[10px] font-medium uppercase">
+                Query
+              </div>
+              <div className="relative flex-1">
+                <MonacoEditor
+                  height="100%"
+                  className="absolute h-full w-full"
+                  options={REQUEST_EDITOR_OPTIONS}
+                  language="graphql"
+                  model={getBodyModel(selectedRequestId)}
+                  onMount={(editorInstance) => {
+                    queryEditorRef.current = editorInstance;
+                  }}
+                />
+              </div>
+            </div>
+          </ResizablePanel>
+
+          <ResizableHandle withHandle />
+
+          <ResizablePanel defaultSize={40} minSize={20} className="relative h-full">
+            <div className="absolute inset-0 flex flex-col">
+              <div className="text-text-disabled px-4 py-1 text-[10px] font-medium uppercase">
+                Variables (JSON)
+              </div>
+              <div className="relative flex-1">
+                {getVariablesModel(selectedRequestId) && (
+                  <MonacoEditor
+                    height="100%"
+                    className="absolute h-full w-full"
+                    options={REQUEST_EDITOR_OPTIONS}
+                    language="json"
+                    model={getVariablesModel(selectedRequestId)!}
+                    onMount={(editorInstance) => {
+                      varsEditorRef.current = editorInstance;
+                    }}
+                  />
+                )}
+              </div>
+            </div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/components/mainWindow/mainTopBar/HttpMethodSelect.tsx
+++ b/src/renderer/components/mainWindow/mainTopBar/HttpMethodSelect.tsx
@@ -53,7 +53,7 @@ export const HttpMethodSelect: FC<HttpMethodSelectProps> = ({
       open={isOpen}
     >
       <SelectTrigger
-        className={`cursor-pointer border ${isOpen ? 'border-accent-primary rounded-tl-3xl rounded-bl-none' : 'border-border rounded-l-full'} ease ${[RequestMethod.OPTIONS, RequestMethod.CONNECT].includes(selectedHttpMethod) ? 'min-w-32' : 'min-w-25.5'} p-[8px_8px_8px_16px] transition-colors duration-300`}
+        className={`cursor-pointer border ${isOpen ? 'border-accent-primary rounded-tl-3xl rounded-bl-none' : 'border-border rounded-l-full'} ease ${[RequestMethod.OPTIONS, RequestMethod.CONNECT, RequestMethod.GRAPHQL].includes(selectedHttpMethod) ? 'min-w-32' : 'min-w-25.5'} p-[8px_8px_8px_16px] transition-colors duration-300`}
         isOpen={isOpen}
       >
         <SelectValue ref={httpMethodSelectRef}>

--- a/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
@@ -46,8 +46,7 @@ export const SidebarRequestList = () => {
   const activeSensors = sortMode === SortMode.DEFAULT ? sensors : [];
 
   const sortFn = useMemo(():
-    | ((a: TrufosRequest | Folder, b: TrufosRequest | Folder) => number)
-    | null => {
+    ((a: TrufosRequest | Folder, b: TrufosRequest | Folder) => number) | null => {
     if (sortMode === SortMode.AZ_ASC) return (a, b) => a.title.localeCompare(b.title);
     if (sortMode === SortMode.AZ_DESC) return (a, b) => b.title.localeCompare(a.title);
     if (sortMode === SortMode.TIME_DESC)

--- a/src/renderer/lib/monaco/graphql-autocomplete.ts
+++ b/src/renderer/lib/monaco/graphql-autocomplete.ts
@@ -1,0 +1,215 @@
+import { editor, Position, languages } from 'monaco-editor';
+import { RendererEventService } from '@/services/event/renderer-event-service';
+import { toast } from 'sonner';
+import { TrufosHeader } from 'shim/objects/headers';
+
+const eventService = RendererEventService.instance;
+
+export interface GraphQLTypeRef {
+  kind: string;
+  name?: string;
+  ofType?: GraphQLTypeRef;
+}
+
+export interface GraphQLField {
+  name: string;
+  description?: string;
+  type: GraphQLTypeRef;
+}
+
+export interface GraphQLType {
+  name: string;
+  kind: string;
+  fields?: GraphQLField[];
+}
+
+export interface GraphQLSchema {
+  queryType?: { name: string };
+  mutationType?: { name: string };
+  types: GraphQLType[];
+}
+
+export const graphqlSchemaRegistry = new Map<string, GraphQLSchema>();
+
+export async function introspectGraphQLSchema(
+  requestId: string,
+  url: string,
+  headers: TrufosHeader[]
+) {
+  try {
+    const result = (await eventService.introspectSchema(url, headers)) as {
+      data?: { __schema?: GraphQLSchema };
+    };
+    if (result && result.data && result.data.__schema) {
+      graphqlSchemaRegistry.set(requestId, result.data.__schema);
+      toast.success('Schema introspected successfully');
+      return true;
+    } else {
+      toast.error('Invalid introspection response');
+      return false;
+    }
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    toast.error(`Introspection failed: ${errorMessage}`);
+    return false;
+  }
+}
+
+function getGraphQLPath(text: string): string[] {
+  const path: string[] = [];
+  const cleanText = text
+    .replace(/#.*$/gm, '') // strip comments
+    .replace(/"([^"\\]|\\.)*"/g, '""'); // strip string literals
+
+  const tokens = cleanText.match(/[{}]|[_A-Za-z][_0-9A-Za-z]*/g) || [];
+
+  let lastWord = '';
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token === '{') {
+      if (lastWord && !['query', 'mutation', 'subscription', 'fragment'].includes(lastWord)) {
+        path.push(lastWord);
+      } else {
+        path.push('__root');
+      }
+      lastWord = '';
+    } else if (token === '}') {
+      path.pop();
+      lastWord = '';
+    } else {
+      lastWord = token;
+    }
+  }
+  return path;
+}
+
+function getNamedType(typeRef: GraphQLTypeRef | undefined): string | null {
+  if (!typeRef) return null;
+  if (typeRef.name) return typeRef.name;
+  return getNamedType(typeRef.ofType);
+}
+
+export class GraphQLCompletionItemsProvider implements languages.CompletionItemProvider {
+  triggerCharacters = [' ', '\n', '{'];
+
+  provideCompletionItems(
+    model: editor.ITextModel,
+    position: Position
+  ): languages.ProviderResult<languages.CompletionList> {
+    // Extract requestId from model URI
+    const uriPath = model.uri.path;
+    const match = uriPath.match(/^\/requests\/([^/]+)\/body$/);
+    if (!match) return { suggestions: [] };
+    const requestId = match[1];
+
+    const schema = graphqlSchemaRegistry.get(requestId);
+    if (!schema) return { suggestions: [] };
+
+    // Get text up to the cursor
+    const textBeforeCursor = model.getValueInRange({
+      startLineNumber: 1,
+      startColumn: 1,
+      endLineNumber: position.lineNumber,
+      endColumn: position.column,
+    });
+
+    const path = getGraphQLPath(textBeforeCursor);
+    const defaultRange = {
+      startLineNumber: position.lineNumber,
+      endLineNumber: position.lineNumber,
+      startColumn: position.column,
+      endColumn: position.column,
+    };
+
+    if (path.length === 0) {
+      // Suggest top-level operation keywords
+      return {
+        suggestions: [
+          {
+            label: 'query',
+            kind: languages.CompletionItemKind.Keyword,
+            insertText: 'query {\n\t$0\n}',
+            insertTextRules: languages.CompletionInsertTextRule.InsertAsSnippet,
+            range: defaultRange,
+          },
+          {
+            label: 'mutation',
+            kind: languages.CompletionItemKind.Keyword,
+            insertText: 'mutation {\n\t$0\n}',
+            insertTextRules: languages.CompletionInsertTextRule.InsertAsSnippet,
+            range: defaultRange,
+          },
+        ],
+      };
+    }
+
+    // Determine current type in the path
+    let currentTypeName: string | null = schema.queryType?.name || 'Query';
+
+    // Check if the first block is mutation or query
+    const firstBlock = textBeforeCursor.trim().split(/\s+/)[0];
+    if (firstBlock === 'mutation') {
+      currentTypeName = schema.mutationType?.name || 'Mutation';
+    }
+
+    const typesMap = new Map<string, GraphQLType>(schema.types.map((t) => [t.name, t]));
+
+    for (let i = 0; i < path.length; i++) {
+      const part = path[i];
+      if (part === '__root') continue;
+
+      const currentType = typesMap.get(currentTypeName || '');
+      if (!currentType) {
+        currentTypeName = null;
+        break;
+      }
+
+      const field = currentType.fields?.find((f) => f.name === part);
+      if (!field) {
+        currentTypeName = null;
+        break;
+      }
+
+      currentTypeName = getNamedType(field.type);
+    }
+
+    if (!currentTypeName) return { suggestions: [] };
+
+    const activeType = typesMap.get(currentTypeName);
+    if (!activeType || !activeType.fields) return { suggestions: [] };
+
+    const word = model.getWordUntilPosition(position);
+    const range = {
+      startLineNumber: position.lineNumber,
+      endLineNumber: position.lineNumber,
+      startColumn: word.startColumn,
+      endColumn: word.endColumn,
+    };
+
+    const suggestions = activeType.fields.map((field) => {
+      const isObjectOrList =
+        field.type.kind === 'OBJECT' ||
+        field.type.kind === 'LIST' ||
+        (field.type.ofType &&
+          (field.type.ofType.kind === 'OBJECT' || field.type.ofType.kind === 'LIST'));
+
+      const insertText = isObjectOrList ? `${field.name} {\n\t$0\n}` : field.name;
+      const insertRule = isObjectOrList
+        ? languages.CompletionInsertTextRule.InsertAsSnippet
+        : undefined;
+
+      return {
+        label: field.name,
+        kind: isObjectOrList
+          ? languages.CompletionItemKind.Folder
+          : languages.CompletionItemKind.Field,
+        insertText,
+        insertTextRules: insertRule,
+        detail: field.description || getNamedType(field.type) || '',
+        range,
+      };
+    });
+
+    return { suggestions };
+  }
+}

--- a/src/renderer/lib/monaco/language.ts
+++ b/src/renderer/lib/monaco/language.ts
@@ -4,6 +4,7 @@ import { TemplateVariableCompletionItemsProvider } from './template-variable-com
 import { TemplateVariableHoverProvider } from './template-variable-hover-provider';
 import { TemplateVariableSemanticTokensProvider } from './template-variable-semantic-tokens-provider';
 import trufosDeclaration from '@/assets/trufos-scripting-api.d.ts?raw';
+import { GraphQLCompletionItemsProvider } from './graphql-autocomplete';
 
 languages.typescript.javascriptDefaults.addExtraLib(trufosDeclaration);
 
@@ -64,6 +65,8 @@ languages.registerCompletionItemProvider(
   supportedLanguages,
   new TemplateVariableCompletionItemsProvider()
 );
+
+languages.registerCompletionItemProvider('graphql', new GraphQLCompletionItemsProvider());
 
 // hover provider (shows template variable value on hover)
 languages.registerHoverProvider(supportedLanguages, new TemplateVariableHoverProvider());

--- a/src/renderer/lib/monaco/models.ts
+++ b/src/renderer/lib/monaco/models.ts
@@ -1,5 +1,5 @@
 import { editor, Uri } from 'monaco-editor';
-import { TrufosRequest } from 'shim/objects/request';
+import { TrufosRequest, RequestBodyType } from 'shim/objects/request';
 import { ScriptType } from 'shim/scripting';
 import { RendererEventService } from '@/services/event/renderer-event-service';
 
@@ -13,6 +13,7 @@ const SCHEME = 'trufos';
 
 export interface RequestModels {
   body: editor.ITextModel;
+  variables?: editor.ITextModel;
   scripts: Map<ScriptType, editor.ITextModel>;
   response: editor.ITextModel;
 }
@@ -37,6 +38,10 @@ export function bodyUri(requestId: string): Uri {
   return Uri.from({ scheme: SCHEME, path: `/requests/${requestId}/body` });
 }
 
+export function variablesUri(requestId: string): Uri {
+  return Uri.from({ scheme: SCHEME, path: `/requests/${requestId}/variables` });
+}
+
 export function scriptUri(requestId: string, scriptType: ScriptType): Uri {
   return Uri.from({ scheme: SCHEME, path: `/requests/${requestId}/script/${scriptType}` });
 }
@@ -46,15 +51,18 @@ export function responseUri(requestId: string): Uri {
 }
 
 /** Parse a model URI and return its metadata, or null if it is not a trufos model. */
-function parseModelUri(
-  uri: Uri
-): { requestId: string; kind: 'body' | 'script' | 'response'; scriptType?: ScriptType } | null {
+function parseModelUri(uri: Uri): {
+  requestId: string;
+  kind: 'body' | 'variables' | 'script' | 'response';
+  scriptType?: ScriptType;
+} | null {
   if (uri.scheme !== SCHEME) return null;
-  // path: /requests/{id}/body|response  or  /requests/{id}/script/{type}
-  const match = uri.path.match(/^\/requests\/([^/]+)\/(body|response|script\/([^/]+))$/);
+  // path: /requests/{id}/body|response|variables  or  /requests/{id}/script/{type}
+  const match = uri.path.match(/^\/requests\/([^/]+)\/(body|response|variables|script\/([^/]+))$/);
   if (!match) return null;
   const requestId = match[1];
   if (match[2] === 'body') return { requestId, kind: 'body' };
+  if (match[2] === 'variables') return { requestId, kind: 'variables' };
   if (match[2] === 'response') return { requestId, kind: 'response' };
   return { requestId, kind: 'script', scriptType: match[3] as ScriptType };
 }
@@ -67,6 +75,7 @@ export function createModelsForRequest(requestId: string): RequestModels {
   }
   const models: RequestModels = {
     body: editor.createModel('', undefined, bodyUri(requestId)),
+    variables: editor.createModel('', 'json', variablesUri(requestId)),
     scripts: new Map(
       Object.values(ScriptType).map((type) => [
         type,
@@ -87,6 +96,10 @@ export function getBodyModel(requestId: string): editor.ITextModel {
   return registry.get(requestId)!.body;
 }
 
+export function getVariablesModel(requestId: string): editor.ITextModel | undefined {
+  return registry.get(requestId)?.variables;
+}
+
 export function getScriptModel(requestId: string, scriptType: ScriptType): editor.ITextModel {
   return registry.get(requestId)!.scripts.get(scriptType)!;
 }
@@ -101,6 +114,9 @@ export function disposeModelsForRequest(requestId: string): void {
   // Dispose each model — this triggers onWillDisposeModel for body & script,
   // which handles persisting their content.
   models.body.dispose();
+  if (models.variables) {
+    models.variables.dispose();
+  }
   for (const scriptModel of models.scripts.values()) {
     scriptModel.dispose();
   }
@@ -114,7 +130,7 @@ const eventService = RendererEventService.instance;
 
 /**
  * Given a live model (from editor.getModels()), save its content if it is a
- * body or script model. Response models are skipped (read-only display).
+ * body, variables, or script model. Response models are skipped (read-only display).
  * Returns a Promise that resolves when the save is complete (or immediately for
  * non-saveable models).
  */
@@ -125,7 +141,23 @@ export async function saveModelContent(model: editor.ITextModel): Promise<void> 
   if (!request) return;
 
   if (parsed.kind === 'body') {
-    await eventService.saveRequest(request, model.getValue());
+    if (request.body.type === RequestBodyType.GRAPHQL) {
+      const updatedRequest = {
+        ...request,
+        body: { ...request.body, query: model.getValue() },
+      };
+      await eventService.saveRequest(updatedRequest);
+    } else {
+      await eventService.saveRequest(request, model.getValue());
+    }
+  } else if (parsed.kind === 'variables') {
+    if (request.body.type === RequestBodyType.GRAPHQL) {
+      const updatedRequest = {
+        ...request,
+        body: { ...request.body, variables: model.getValue() },
+      };
+      await eventService.saveRequest(updatedRequest);
+    }
   } else if (parsed.kind === 'script' && parsed.scriptType != null) {
     await eventService.saveScript(request, parsed.scriptType, model.getValue());
   }
@@ -140,7 +172,23 @@ editor.onWillDisposeModel((model) => {
   if (!request) return;
 
   if (parsed.kind === 'body') {
-    void eventService.saveRequest(request, model.getValue());
+    if (request.body.type === RequestBodyType.GRAPHQL) {
+      const updatedRequest = {
+        ...request,
+        body: { ...request.body, query: model.getValue() },
+      };
+      void eventService.saveRequest(updatedRequest);
+    } else {
+      void eventService.saveRequest(request, model.getValue());
+    }
+  } else if (parsed.kind === 'variables') {
+    if (request.body.type === RequestBodyType.GRAPHQL) {
+      const updatedRequest = {
+        ...request,
+        body: { ...request.body, variables: model.getValue() },
+      };
+      void eventService.saveRequest(updatedRequest);
+    }
   } else if (parsed.kind === 'script' && parsed.scriptType != null) {
     void eventService.saveScript(request, parsed.scriptType, model.getValue());
   }

--- a/src/renderer/lib/monaco/template-variable-semantic-tokens-provider.ts
+++ b/src/renderer/lib/monaco/template-variable-semantic-tokens-provider.ts
@@ -23,7 +23,7 @@ export class TemplateVariableSemanticTokensProvider
 
     for (let i = 0; i < model.getLineCount(); i++) {
       this.regex.lastIndex = 0; // reset regex
-      for (let match; (match = this.regex.exec(model.getLineContent(i + 1))) !== null; ) {
+      for (let match; (match = this.regex.exec(model.getLineContent(i + 1))) !== null;) {
         tokens.push({
           lineNumber: i,
           column: match.index,

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -1,7 +1,7 @@
 import { ElectronHandler } from 'main/preload';
 
 declare global {
-  // eslint-disable-next-line no-unused-vars
+   
   interface Window {
     electron: ElectronHandler;
   }

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -1,7 +1,6 @@
 import { ElectronHandler } from 'main/preload';
 
 declare global {
-   
   interface Window {
     electron: ElectronHandler;
   }

--- a/src/renderer/services/StyleHelper.ts
+++ b/src/renderer/services/StyleHelper.ts
@@ -20,5 +20,7 @@ export const httpMethodColor = (request: RequestMethod) => {
       return 'http-method-color-get';
     case RequestMethod.TRACE:
       return 'http-method-color-get';
+    case RequestMethod.GRAPHQL:
+      return 'http-method-color-graphql';
   }
 };

--- a/src/renderer/services/event/renderer-event-service.ts
+++ b/src/renderer/services/event/renderer-event-service.ts
@@ -43,6 +43,7 @@ export class RendererEventService implements IEventService {
   }
 
   saveRequest = createEventMethod('saveRequest');
+  introspectSchema = createEventMethod('introspectSchema');
   copyRequest = createEventMethod('copyRequest');
   sendRequest = createEventMethod('sendRequest');
   getAppVersion = createEventMethod('getAppVersion');

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -167,7 +167,27 @@ export const createCollectionStore = (collection: Collection) => {
           if (overwrite) {
             state.requests.set(state.selectedRequestId!, updatedRequest as TrufosRequest);
           } else {
-            state.requests.set(state.selectedRequestId!, { ...request, ...updatedRequest });
+            const nextRequest = { ...request, ...updatedRequest };
+            if (
+              updatedRequest.method === RequestMethod.GRAPHQL &&
+              request.method !== RequestMethod.GRAPHQL
+            ) {
+              nextRequest.body = {
+                type: RequestBodyType.GRAPHQL,
+                query: '',
+                variables: '{}',
+              };
+            } else if (
+              request.method === RequestMethod.GRAPHQL &&
+              updatedRequest.method &&
+              updatedRequest.method !== RequestMethod.GRAPHQL
+            ) {
+              nextRequest.body = {
+                type: RequestBodyType.TEXT,
+                mimeType: 'text/plain',
+              };
+            }
+            state.requests.set(state.selectedRequestId!, nextRequest);
             markDraft(state);
           }
         });

--- a/src/renderer/state/helper/collectionUtil.ts
+++ b/src/renderer/state/helper/collectionUtil.ts
@@ -1,16 +1,28 @@
 import { IpcPushStream } from '@/lib/ipc-stream';
-import { getBodyModel, getScriptModel } from '@/lib/monaco/models';
+import { getBodyModel, getVariablesModel, getScriptModel } from '@/lib/monaco/models';
 import { Folder } from 'shim/objects/folder';
 import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { ScriptType } from 'shim/scripting';
 
 export async function setRequestTextBody(requestId: string, request?: TrufosRequest) {
   const model = getBodyModel(requestId);
+  const variablesModel = getVariablesModel(requestId);
   if (request?.body?.type === RequestBodyType.TEXT) {
     const stream = await IpcPushStream.open(request, 'utf-8');
     model.setValue(await stream.readAll());
+    if (variablesModel) {
+      variablesModel.setValue('');
+    }
+  } else if (request?.body?.type === RequestBodyType.GRAPHQL) {
+    model.setValue(request.body.query ?? '');
+    if (variablesModel) {
+      variablesModel.setValue(request.body.variables ?? '');
+    }
   } else {
     model.setValue('');
+    if (variablesModel) {
+      variablesModel.setValue('');
+    }
   }
 }
 

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -85,6 +85,7 @@
     --http-post: #853aff;
     --http-delete: #f845a6;
     --http-patch: #d88f00;
+    --http-graphql: #e10098;
     --disabled: #94a3b8;
 
     --success: #16a34a;
@@ -170,6 +171,7 @@
     --http-post: #9f72fe;
     --http-delete: #ee5c99;
     --http-patch: #efa349;
+    --http-graphql: #ff60c6;
     --disabled: #444444;
 
     --success: #2bb361;
@@ -222,6 +224,9 @@
   }
   .http-method-color-patch {
     color: var(--http-patch);
+  }
+  .http-method-color-graphql {
+    color: var(--http-graphql);
   }
 
   /* Scrollbar (webkit) */
@@ -313,6 +318,7 @@
   --color-http-post: var(--http-post);
   --color-http-delete: var(--http-delete);
   --color-http-patch: var(--http-patch);
+  --color-http-graphql: var(--http-graphql);
 
   --color-state-success: var(--success);
   --color-state-error: var(--error);

--- a/src/shim/event-service.ts
+++ b/src/shim/event-service.ts
@@ -8,6 +8,7 @@ import {
   VariableMap,
   VariableObject,
   EnvironmentMap,
+  TrufosHeader,
 } from './objects';
 import { ClientCertificate } from './objects/collection';
 import { ScriptType } from './scripting';
@@ -15,6 +16,11 @@ import { ScriptType } from './scripting';
 export type ImportStrategy = 'Postman' | 'OpenAPI' | 'Bruno' | 'Insomnia';
 
 export interface IEventService {
+  /**
+   * Introspects the GraphQL schema at the given URL using the provided headers.
+   */
+  introspectSchema(url: string, headers: TrufosHeader[]): Promise<unknown>;
+
   /**
    * (Re)load the last opened collection.
    * @param force If true, the collection is reloaded even if it is already loaded.

--- a/src/shim/objects/request-method.ts
+++ b/src/shim/objects/request-method.ts
@@ -8,4 +8,5 @@ export enum RequestMethod {
   HEAD = 'HEAD',
   CONNECT = 'CONNECT',
   TRACE = 'TRACE',
+  GRAPHQL = 'GRAPHQL',
 }

--- a/src/shim/objects/request.ts
+++ b/src/shim/objects/request.ts
@@ -10,6 +10,7 @@ export enum RequestBodyType {
   TEXT = 'text',
   FILE = 'file',
   FORM_DATA = 'form-data',
+  GRAPHQL = 'graphql',
 }
 
 export const TextBody = z.object({
@@ -47,7 +48,19 @@ export const FormDataBody = z.object({
 });
 export type FormDataBody = z.infer<typeof FormDataBody>;
 
-export const RequestBody = z.discriminatedUnion('type', [TextBody, FileBody, FormDataBody]);
+export const GraphQLBody = z.object({
+  type: z.literal(RequestBodyType.GRAPHQL),
+  query: z.string().optional(),
+  variables: z.string().optional(),
+});
+export type GraphQLBody = z.infer<typeof GraphQLBody>;
+
+export const RequestBody = z.discriminatedUnion('type', [
+  TextBody,
+  FileBody,
+  FormDataBody,
+  GraphQLBody,
+]);
 export type RequestBody = z.infer<typeof RequestBody>;
 
 export const TrufosRequest = z.object({


### PR DESCRIPTION
## Changes

Adds dedicated GraphQL support next to the HTTP method selector (#839), featuring:
- Query editor with syntax highlighting and variables editor (JSON).
- Schema introspection and autocomplete support.
- Correct serialization of the GraphQL POST body.
- Fixed Monaco editor read-only save errors and grammar validation conflicts.

Closes #839

## Testing

- Added unit tests in `http-service.test.ts` for GraphQL request serialization.
- Manually tested introspection and query execution against a local mock GraphQL server.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
