### PR TITLE
fix: clarify AI review provider config in workflow

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -25,18 +25,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          # === Active provider: Claude Sonnet 4.6 via Exxeta LiteLLM proxy ===
-          # ai.exxeta.info is an OpenAI-compatible LiteLLM proxy that fronts
-          # Bedrock internally, so PR-Agent talks to it like OpenAI. The openai/
-          # prefix forces LiteLLM to honor OPENAI__API_BASE; the model name after
-          # it is the proxy's registered model id (see ai.exxeta.info model list).
-          # OPENAI_API_BASE_URL secret points at the proxy (e.g. https://ai.exxeta.info/v1);
-          # OPENAI_KEY is a proxy virtual key.
+          # === Active provider: Exxeta LiteLLM proxy (OpenAI-compatible) ===
+          # ai.exxeta.info is an OpenAI-compatible LiteLLM proxy fronting Bedrock.
+          # The openai/ prefix forces LiteLLM to honor OPENAI__API_BASE. The OPENAI_KEY
+          # virtual key can only address the "all-team-models" access group (the only
+          # entry returned by /v1/models for this key) — individual model ids like
+          # anthropic.claude-sonnet-4-6 are rejected. The proxy routes the group to its
+          # configured deployment.
+          # OPENAI_API_BASE_URL points at the proxy (e.g. https://ai.exxeta.info/v1).
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           OPENAI__API_BASE: ${{ secrets.OPENAI_API_BASE_URL }}
-          config.model: "openai/anthropic.claude-sonnet-4-6"
-          # PR-Agent v0.34 does not know every model's token window; declare it
-          # explicitly so large diffs are not truncated (Sonnet 4.6 input = 1M).
+          config.model: "openai/all-team-models"
+          # Disable PR-Agent's default fallback (o4-mini), which is not addressable
+          # by this key and would also 400.
+          config.fallback_models: "[]"
+          # PR-Agent v0.34 does not know this model's token window; declare it
+          # explicitly so large diffs are not truncated.
           config.custom_model_max_tokens: "1000000"
 
           # === Alternative: Google AI Studio (Gemini) via LiteLLM ===

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -25,28 +25,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          # === Active provider: Claude Sonnet 4.6 on Amazon Bedrock ===
-          # PR-Agent routes through LiteLLM. The bedrock/converse/ prefix selects
-          # the Bedrock Converse API; the eu. prefix is the EU cross-region
-          # inference profile. Requires AWS credentials with Bedrock access in an
-          # EU region, plus model access enabled for the inference profile.
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION_NAME: eu-central-1
-          config.model: "bedrock/converse/eu.anthropic.claude-sonnet-4-6"
+          # === Active provider: Claude Sonnet 4.6 via Exxeta LiteLLM proxy ===
+          # ai.exxeta.info is an OpenAI-compatible LiteLLM proxy that fronts
+          # Bedrock internally, so PR-Agent talks to it like OpenAI. The openai/
+          # prefix forces LiteLLM to honor OPENAI__API_BASE; the model name after
+          # it is the proxy's registered model id (see ai.exxeta.info model list).
+          # OPENAI_API_BASE_URL secret points at the proxy (e.g. https://ai.exxeta.info/v1);
+          # OPENAI_KEY is a proxy virtual key.
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          OPENAI__API_BASE: ${{ secrets.OPENAI_API_BASE_URL }}
+          config.model: "openai/anthropic.claude-sonnet-4-6"
           # PR-Agent v0.34 does not know every model's token window; declare it
           # explicitly so large diffs are not truncated (Sonnet 4.6 input = 1M).
           config.custom_model_max_tokens: "1000000"
 
-          # === Alternative: Claude via OpenAI-compatible gateway ===
-          # Comment out the AWS_* block above and uncomment the lines below.
-          # The openai/ prefix forces LiteLLM to honor OPENAI__API_BASE.
-          # OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
-          # OPENAI__API_BASE: ${{ secrets.OPENAI_API_BASE_URL }}
-          # config.model: "openai/claude-sonnet-4-6"
-
           # === Alternative: Google AI Studio (Gemini) via LiteLLM ===
-          # Comment out the AWS_* block above and uncomment the lines below.
+          # Comment out the OPENAI_* block above and uncomment the lines below.
           # Requires the GEMINI_API_KEY repository secret. Flash models are
           # available on the Gemini free tier (no billing required).
           # GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -54,7 +48,7 @@ jobs:
           # config.fallback_models: '["gemini/gemini-2.0-flash"]'
 
           # === Alternative: Anthropic Claude (native API) ===
-          # Comment out the AWS_* block above and uncomment the lines below.
+          # Comment out the OPENAI_* block above and uncomment the lines below.
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # config.model: "anthropic/claude-sonnet-4-6"
 

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -25,18 +25,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          # === Active provider: Claude via OpenAI-compatible gateway ===
-          # Routes PR-Agent through an OpenAI-compatible base URL that serves a
-          # Claude model. Requires the OPENAI_KEY and OPENAI_API_BASE_URL secrets.
-          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
-          OPENAI__API_BASE: ${{ secrets.OPENAI_API_BASE_URL }}
-          config.model: "claude-sonnet-4.6"
+          # === Active provider: Claude Sonnet 4.6 on Amazon Bedrock ===
+          # PR-Agent routes through LiteLLM. The bedrock/converse/ prefix selects
+          # the Bedrock Converse API; the eu. prefix is the EU cross-region
+          # inference profile. Requires AWS credentials with Bedrock access in an
+          # EU region, plus model access enabled for the inference profile.
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION_NAME: eu-central-1
+          config.model: "bedrock/converse/eu.anthropic.claude-sonnet-4-6"
           # PR-Agent v0.34 does not know every model's token window; declare it
-          # explicitly so large diffs are not truncated.
-          config.custom_model_max_tokens: "1048576"
+          # explicitly so large diffs are not truncated (Sonnet 4.6 input = 1M).
+          config.custom_model_max_tokens: "1000000"
+
+          # === Alternative: Claude via OpenAI-compatible gateway ===
+          # Comment out the AWS_* block above and uncomment the lines below.
+          # The openai/ prefix forces LiteLLM to honor OPENAI__API_BASE.
+          # OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          # OPENAI__API_BASE: ${{ secrets.OPENAI_API_BASE_URL }}
+          # config.model: "openai/claude-sonnet-4-6"
 
           # === Alternative: Google AI Studio (Gemini) via LiteLLM ===
-          # Comment out the OPENAI_* block above and uncomment the lines below.
+          # Comment out the AWS_* block above and uncomment the lines below.
           # Requires the GEMINI_API_KEY repository secret. Flash models are
           # available on the Gemini free tier (no billing required).
           # GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -44,9 +54,9 @@ jobs:
           # config.fallback_models: '["gemini/gemini-2.0-flash"]'
 
           # === Alternative: Anthropic Claude (native API) ===
-          # Comment out the OPENAI_* block above and uncomment the lines below.
+          # Comment out the AWS_* block above and uncomment the lines below.
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          # config.model: "anthropic/claude-sonnet-4-5"
+          # config.model: "anthropic/claude-sonnet-4-6"
 
           # Automatically review every new / updated PR
           github_action_config.auto_review: "true"

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -25,20 +25,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          # === Active provider: Exxeta LiteLLM proxy (OpenAI-compatible) ===
+          # === Active provider: Claude Sonnet 4.6 via Exxeta LiteLLM proxy ===
           # ai.exxeta.info is an OpenAI-compatible LiteLLM proxy fronting Bedrock.
-          # The openai/ prefix forces LiteLLM to honor OPENAI__API_BASE. The OPENAI_KEY
-          # virtual key can only address the "all-team-models" access group (the only
-          # entry returned by /v1/models for this key) — individual model ids like
-          # anthropic.claude-sonnet-4-6 are rejected. The proxy routes the group to its
-          # configured deployment.
-          # OPENAI_API_BASE_URL points at the proxy (e.g. https://ai.exxeta.info/v1).
+          # The openai/ prefix forces LiteLLM to honor OPENAI__API_BASE; the model
+          # name after it is the proxy's public id from /v1/models (note the dot:
+          # "claude-sonnet-4.6", not "claude-sonnet-4-6").
+          # OPENAI_API_BASE_URL points at the proxy (e.g. https://ai.exxeta.info/v1);
+          # OPENAI_KEY is a proxy virtual key.
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           OPENAI__API_BASE: ${{ secrets.OPENAI_API_BASE_URL }}
-          config.model: "openai/all-team-models"
-          # Disable PR-Agent's default fallback (o4-mini), which is not addressable
-          # by this key and would also 400.
-          config.fallback_models: "[]"
+          config.model: "openai/claude-sonnet-4.6"
+          # Override PR-Agent's default fallback (o4-mini, not on this proxy) with
+          # a model the proxy actually serves.
+          config.fallback_models: '["openai/claude-haiku-4.5"]'
           # PR-Agent v0.34 does not know this model's token window; declare it
           # explicitly so large diffs are not truncated.
           config.custom_model_max_tokens: "1000000"

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -24,22 +24,27 @@ jobs:
         uses: Codium-ai/pr-agent@v0.34
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Provider: Google AI Studio (Gemini) via LiteLLM.
-          # Requires the GEMINI_API_KEY repository secret to be set.
-#          GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          # Flash models are available on the Gemini API free tier (no billing
-          # required). The previously configured gemini-3.x IDs do not exist and
-          # returned 404 (NOT_FOUND).
-#          config.model: "gemini/gemini-2.5-flash"
-#          config.fallback_models: '["gemini/gemini-2.0-flash"]'
-          # PR-Agent v0.34 does not know these models' token window; declare it
-          # explicitly (Gemini Flash input window = 1,048,576 tokens).
-          config.custom_model_max_tokens: "1048576"
-          # To use OpenAI instead, uncomment:
+
+          # === Active provider: Claude via OpenAI-compatible gateway ===
+          # Routes PR-Agent through an OpenAI-compatible base URL that serves a
+          # Claude model. Requires the OPENAI_KEY and OPENAI_API_BASE_URL secrets.
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           OPENAI__API_BASE: ${{ secrets.OPENAI_API_BASE_URL }}
           config.model: "claude-sonnet-4.6"
-          # To use Anthropic Claude instead, uncomment:
+          # PR-Agent v0.34 does not know every model's token window; declare it
+          # explicitly so large diffs are not truncated.
+          config.custom_model_max_tokens: "1048576"
+
+          # === Alternative: Google AI Studio (Gemini) via LiteLLM ===
+          # Comment out the OPENAI_* block above and uncomment the lines below.
+          # Requires the GEMINI_API_KEY repository secret. Flash models are
+          # available on the Gemini free tier (no billing required).
+          # GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # config.model: "gemini/gemini-2.5-flash"
+          # config.fallback_models: '["gemini/gemini-2.0-flash"]'
+
+          # === Alternative: Anthropic Claude (native API) ===
+          # Comment out the OPENAI_* block above and uncomment the lines below.
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # config.model: "anthropic/claude-sonnet-4-5"
 


### PR DESCRIPTION
### **User description**
## Summary

Follow-up to commit 4cc5f6e. Restructures the PR-Agent `env` block in `.github/workflows/ai-review.yml` so the configuration is internally consistent.

Previously `config.model: "claude-sonnet-4.6"` sat under the `OPENAI_KEY` block while the comment above still read `# To use OpenAI instead, uncomment:`, and the disabled Gemini block kept comments that read as if active.

## Changes

- Active provider block (Claude via OpenAI-compatible gateway) clearly labeled.
- Gemini and native Anthropic options marked as commented-out alternatives with consistent comments.
- No functional change to the active gateway values.

Closes #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Restructures AI review workflow provider configuration for clarity

- Active Claude provider block now clearly labeled with detailed comments

- Gemini and Anthropic alternatives marked as commented-out options

- Updates model IDs and configuration to match Exxeta LiteLLM proxy setup

- Adds fallback models and explicit token window declarations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Gemini/Anthropic<br/>Commented Out"] -->|Alternative| B["Active Config<br/>Claude via Proxy"]
  C["Clear Section<br/>Headers"] -->|Organize| B
  D["Updated Model IDs<br/>& Comments"] -->|Improve| B
  E["Fallback Models<br/>& Token Window"] -->|Configure| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ai-review.yml</strong><dd><code>Restructure provider config with clear active/alternative sections</code></dd></summary>
<hr>

.github/workflows/ai-review.yml

<ul><li>Reorganizes environment variables with clear section headers for <br>active provider and alternatives<br> <li> Updates active provider from bare <code>claude-sonnet-4.6</code> to <br><code>openai/claude-sonnet-4.6</code> with detailed proxy documentation<br> <li> Adds <code>config.fallback_models</code> pointing to <code>openai/claude-haiku-4.5</code> and <br>increases <code>config.custom_model_max_tokens</code> to 1000000<br> <li> Restructures Gemini and Anthropic blocks as clearly marked <br>commented-out alternatives with consistent explanatory comments</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/895/files#diff-105e0011bdd1445d561435b79b1c776c324c9ea99ac6c3649f8bf4895399fa41">+27/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

