### PR TITLE
fix(879): MonacoEditor test

### DIFF
--- a/src/renderer/lib/monaco/MonacoEditor.test.tsx
+++ b/src/renderer/lib/monaco/MonacoEditor.test.tsx
@@ -56,7 +56,10 @@ vi.mock('@monaco-editor/loader', () => ({
   },
 }));
 
-vi.mock('@/contexts/ThemeContext', () => ({ useTheme: () => ({ theme: 'light' }) }));
+vi.mock('@/contexts/ThemeContext', () => ({
+  TrufosTheme: { Light: 'light', Dark: 'dark' },
+  useTheme: () => ({ theme: 'light' }),
+}));
 vi.mock('monaco-editor', () => ({ editor: {} }));
 
 // Use the real @monaco-editor/react, wrapping <Editor> only to capture the


### PR DESCRIPTION
### **User description**
## Changes
- fix `MonacoEditor` test

## Testing

If relevant, mention your manual testing here. If possible, include screenshots.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [ ] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person


___

### **PR Type**
Tests, Bug fix


___

### **Description**
- Fix MonacoEditor test by exporting TrufosTheme mock

- Ensure ThemeContext mock includes required theme constants

- Prevent crashes when switching between editors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ThemeContext Mock"] -->|"Add TrufosTheme export"| B["MonacoEditor Test"]
  B -->|"Prevents unmount crash"| C["Editor Switching"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MonacoEditor.test.tsx</strong><dd><code>Add TrufosTheme export to ThemeContext mock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/lib/monaco/MonacoEditor.test.tsx

<ul><li>Updated <code>@/contexts/ThemeContext</code> mock to export <code>TrufosTheme</code> object with <br>Light and Dark theme constants<br> <li> Maintains existing <code>useTheme</code> hook mock functionality<br> <li> Fixes test failures related to missing theme constant exports</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/906/files#diff-1dbda6702a027b1f83221a2f1a7526bf0856f5525c7b076b6f4ebf62888fa6c7">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

