### PR TITLE
fix(196): broken build with brunodependency

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -10,6 +10,7 @@ import { FuseV1Options, FuseVersion } from '@electron/fuses';
 import ts from 'typescript';
 import { resolve } from 'node:path';
 import { writeFile } from 'node:fs/promises';
+import { name as packageName } from './package.json';
 
 let osxNotarize: ForgePackagerOptions['osxNotarize'];
 let osxSign: ForgePackagerOptions['osxSign'];
@@ -56,7 +57,7 @@ const config: ForgeConfig = {
   },
   packagerConfig: {
     asar: true,
-    executableName: 'trufos',
+    executableName: process.platform === 'linux' ? packageName : undefined,
     icon:
       process.platform === 'darwin'
         ? ['./images/macos/icon.icns', './images/macos/icon.icon']

--- a/src/main/vite.config.ts
+++ b/src/main/vite.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     alias: {
       main: __dirname,
       shim: path.resolve(__dirname, '..', 'shim'),
+      // Force CJS entry: ohm-js ESM bundle only exports { default, extras },
+      // so require('ohm-js').grammar is undefined without this alias.
+      'ohm-js': path.resolve(__dirname, '..', '..', 'node_modules', 'ohm-js', 'index.js'),
     },
   },
   server: {
@@ -23,8 +26,5 @@ export default defineConfig({
   build: {
     sourcemap: isProduction ? true : 'inline',
     minify: false,
-    rollupOptions: {
-      external: ['@usebruno/lang'],
-    },
   },
 });


### PR DESCRIPTION
## Changes
- The app build was failing during app start due to the new bruno lang dependency from #196. Needed a workaround for vite
- Fix app name being lowercase

## Testing

If relevant, mention your manual testing here. If possible, include screenshots.

## Checklist

- [ ] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person
