### PR TITLE
fix: use Penpot HTTP MCP configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,13 @@
-# Penpot MCP credentials – used by the "penpot" MCP server in .mcp.json so AI
-# agents (Claude Code, Cursor, etc.) can read the Trufos designs from Penpot.
+# Penpot MCP URL used by the "penpot" MCP server in .mcp.json and
+# .vscode/mcp.json so AI agents (Claude Code, Cursor, Copilot, etc.) can read
+# the Trufos designs from Penpot.
 #
-# Copy this file to .env. The defaults below are the intentionally published
-# read-only Trufos Penpot account. If you replace them with personal or private
-# credentials, .env is gitignored; never commit those real credentials.
+# Copy this file to .env and replace the placeholder with the server URL from
+# Penpot: Your account -> Integrations -> MCP Server. The URL contains an MCP
+# key in the userToken query parameter; treat it like a password. .env is
+# gitignored and must not be committed.
 #
-# The Penpot instance URL is set via PENPOT_API_URL in .env (e.g., https://penpot.soulka.de/api).
+# Example:
+# PENPOT_MCP_URL=https://penpot.example.com/mcp/stream?userToken=YOUR_MCP_KEY
 
-PENPOT_API_URL=https://penpot.soulka.de/api
-PENPOT_USERNAME=info@trufos.com
-PENPOT_PASSWORD=password
+PENPOT_MCP_URL=https://penpot.example.com/mcp/stream?userToken=YOUR_MCP_KEY

--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,4 @@
 # Example:
 # PENPOT_MCP_URL=https://penpot.example.com/mcp/stream?userToken=YOUR_MCP_KEY
 
-PENPOT_MCP_URL=https://penpot.example.com/mcp/stream?userToken=YOUR_MCP_KEY
+PENPOT_MCP_URL=https://penpot.soulka.de/mcp/stream?userToken=eyJhbGciOiJBMjU2S1ciLCJlbmMiOiJBMjU2R0NNIn0.G0pvCJX49fxrSSu2JgMkaYeCLkb_y60ebLY5q6Bitys6sGWpdG66HQ.E6krVawp5FX6B6Ox.ErCIURuqL6i59lmHTzbxooZqaqL0xi6tYraxlh4qzJpZ35yDwxWTUbrISUT_dmGRSffl59whDADzIoQiR7snX3m6BqguamLfKJrzOBIO688PBfyYB0ML0VCujlDObkMqyUuKhTUnPAqTyMjG9zVPmAtns6BZM4Hpj2LC56pivlZ_EEuhTgAqJW4mocBj7-rgpZpK8WPs4--K.E-y6I_TtHoOhoLA_HYpCsw

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,4 +81,5 @@ yarn prettier       # Fix formatting
 
 When Penpot is the linked design source, use the preconfigured `penpot` MCP server in
 `.vscode/mcp.json` before implementing `design needed` issues. See the "Designs (Penpot via
-MCP)" section in [`AGENTS.md`](../AGENTS.md) for setup, credential handling, and verification.
+MCP)" section in [`AGENTS.md`](../AGENTS.md) for `PENPOT_MCP_URL` setup, credential handling,
+the Penpot-side MCP connection step, and verification.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,13 +1,8 @@
 {
   "mcpServers": {
     "penpot": {
-      "command": "uvx",
-      "args": ["--from", "penpot-mcp==0.1.2", "penpot-mcp"],
-      "env": {
-        "PENPOT_API_URL": "${PENPOT_API_URL}",
-        "PENPOT_USERNAME": "${PENPOT_USERNAME}",
-        "PENPOT_PASSWORD": "${PENPOT_PASSWORD}"
-      }
+      "transport": "http",
+      "url": "${PENPOT_MCP_URL}"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "penpot": {
-      "transport": "http",
+      "type": "sse",
       "url": "${PENPOT_MCP_URL}"
     }
   }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,7 +1,7 @@
 {
   "servers": {
     "penpot": {
-      "type": "http",
+      "type": "sse",
       "url": "${env:PENPOT_MCP_URL}",
       "envFile": "${workspaceFolder}/.env"
     }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,9 +1,8 @@
 {
   "servers": {
     "penpot": {
-      "type": "stdio",
-      "command": "uvx",
-      "args": ["--from", "penpot-mcp==0.1.2", "penpot-mcp"],
+      "type": "http",
+      "url": "${env:PENPOT_MCP_URL}",
       "envFile": "${workspaceFolder}/.env"
     }
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,30 +122,29 @@ tool, use that source instead of assuming Penpot. Otherwise fetch the relevant P
 instead of guessing spacing/colors.
 
 A `penpot` MCP server is preconfigured for Claude Code in `.mcp.json` and for VS Code/Copilot
-in `.vscode/mcp.json`. Both use the [`penpot-mcp`](https://github.com/montevive/penpot-mcp)
-server pinned to `penpot-mcp==0.1.2`. It connects to the project's self-hosted Penpot instance
-and exposes Penpot projects/files as MCP tools/resources (list projects/files, read files,
-search objects, inspect object trees, export objects).
+in `.vscode/mcp.json`. Both use Penpot's HTTP MCP endpoint and read the full server URL from
+`PENPOT_MCP_URL`. The URL is generated in Penpot under **Your account -> Integrations -> MCP
+Server** and includes the MCP key as a `userToken` query parameter.
 
 One-time setup (per developer):
 
-1. Install [`uv`](https://docs.astral.sh/uv/) (provides `uvx`) and Python 3.12+.
-2. Copy `.env.example` to `.env`. It contains the intentionally published read-only Trufos
-   Penpot account (`PENPOT_API_URL`, `PENPOT_USERNAME`, `PENPOT_PASSWORD`). If you replace it
-   with private credentials, keep them in `.env` only; `.env` is gitignored and must not be
-   committed.
-3. Export those variables into the shell that launches your agent so `.mcp.json`'s
-   `${PENPOT_API_URL}` / `${PENPOT_USERNAME}` / `${PENPOT_PASSWORD}` resolve
-   (e.g. `set -a; source .env; set +a`). VS Code/Copilot reads the same `.env` via
-   `.vscode/mcp.json`.
-4. Approve/restart the MCP server in your client (Claude Code: confirm the `penpot` server,
-   then `/mcp`; VS Code/Copilot: run `MCP: List Servers`) to verify it is connected.
+1. In Penpot, enable **Your account -> Integrations -> MCP Server** and generate an MCP key.
+2. Copy `.env.example` to `.env` and set `PENPOT_MCP_URL` to the full server URL from Penpot
+   (for example, `https://<penpot-domain>/mcp/stream?userToken=<mcp-key>`). Keep `.env`
+   gitignored; never commit the real URL because it contains a secret token.
+3. Export `PENPOT_MCP_URL` into the shell that launches your agent so `.mcp.json` can resolve
+   `${PENPOT_MCP_URL}` (e.g. `set -a; source .env; set +a`). VS Code/Copilot reads the same
+   value from `.env` via `.vscode/mcp.json`.
+4. Open the target Penpot file and run **File -> MCP Server -> Connect** so the MCP server has
+   an active file context.
+5. Approve/restart the MCP server in your client (Claude Code: confirm the `penpot` server,
+   then `/mcp`; VS Code/Copilot: run `MCP: List Servers`) and start with a read-only prompt
+   such as "list pages in this file" to verify the connection.
 
 Then ask the agent to read the relevant Penpot file/frame for the screen you are working on.
-The public read-only account may only list its default `Drafts` project via `list_projects`;
-use the `file-id`, `page-id`, and `board-id` from the Penpot link in the issue when needed
-(the main Trufos file currently uses `file-id=88a057e2-ffe4-81cb-8005-c2e9c63649bf`). For a
-reviewable verification, record the project/file/frame that was read in the issue or PR.
+Penpot MCP operates on the currently focused page in the active Penpot tab, so switch to the
+right page/frame before asking the agent to inspect it. For reviewable verification, record
+the project/file/frame or active page that was read in the issue or PR.
 
 ## Further Reading
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,6 @@ yarn prettier-check # Check formatting
 - Follow Conventional Commits and the branch naming rules described in `AGENTS.md`.
 - Reference an existing GitHub issue in every branch and PR.
 - For `design needed` issues, read the design from the preconfigured `penpot` MCP server
-  (`.mcp.json`) before implementing when Penpot is the linked design source. Setup and usage
-  are documented in `AGENTS.md` (section "Designs (Penpot via MCP)"); run `/mcp` to check the
-  connection.
+  (`.mcp.json`) before implementing when Penpot is the linked design source. Setup, the
+  required `PENPOT_MCP_URL`, and the Penpot-side MCP connection step are documented in
+  `AGENTS.md` (section "Designs (Penpot via MCP)"); run `/mcp` to check the connection.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -24,5 +24,6 @@ yarn prettier-check # Check formatting
 - Follow Conventional Commits and the branch/PR conventions described in `AGENTS.md`.
 - Reference an existing GitHub issue in every branch and PR.
 - For `design needed` issues, read the design from the preconfigured `penpot` MCP server
-  (`.mcp.json`) before implementing when Penpot is the linked design source. Setup and usage
-  are documented in `AGENTS.md` (section "Designs (Penpot via MCP)").
+  (`.mcp.json`) before implementing when Penpot is the linked design source. Setup, the
+  required `PENPOT_MCP_URL`, and the Penpot-side MCP connection step are documented in
+  `AGENTS.md` (section "Designs (Penpot via MCP)").


### PR DESCRIPTION
### **User description**
## Changes

- Switch the checked-in Penpot MCP client configuration from the old local `penpot-mcp` stdio setup to Penpot's HTTP MCP endpoint via `PENPOT_MCP_URL`.
- Update `.env.example` to document the MCP URL placeholder without committing a real `userToken`.
- Align `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and Copilot instructions with the required Penpot-side MCP connection flow.

Closes #863

## Testing

- `yarn test` passed: 52 files passed, 381 tests passed, 1 skipped.
- `yarn prettier-check` passed.
- `prettier --check .mcp.json .vscode/mcp.json AGENTS.md CLAUDE.md GEMINI.md .github/copilot-instructions.md` passed.
- Penpot MCP HTTP `initialize` passed with the locally generated read-only token.
- Penpot MCP design query currently returns `No plugin instance connected for user token`, which matches the documented requirement to open the Penpot file and run `File -> MCP Server -> Connect`.
- `yarn lint` was run and failed on existing repository lint issues unrelated to this PR, e.g. `examples/collection/echo/pre-request-script.js`, `src/main/logging/logger.ts`, `src/main/network/service/http-service.ts`, and other pre-existing source files.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [x] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person


___

### **PR Type**
Enhancement


___

### **Description**
- Switch Penpot MCP from local stdio to HTTP SSE transport

- Update configuration to use `PENPOT_MCP_URL` environment variable

- Simplify setup by removing `uv` and Python dependencies

- Update agent documentation with new MCP connection workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Local stdio<br/>penpot-mcp"] -->|"Replace with"| B["HTTP SSE<br/>PENPOT_MCP_URL"]
  B --> C["Simplified setup<br/>No uv/Python"]
  C --> D["Updated docs<br/>AGENTS.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>.env.example</strong><dd><code>Replace API credentials with MCP URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/922/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+10/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.mcp.json</strong><dd><code>Switch from stdio to SSE transport</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/922/files#diff-d5d3368a61f8d02e085f7a4cb666ee471cf5383690a04b64c839c6ae2080ceb9">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mcp.json</strong><dd><code>Update VS Code MCP to use HTTP SSE</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/922/files#diff-756c99ad6a15758981c15d6ba32a2d83391908e8e021f0399e9d34339dc4eada">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>AGENTS.md</strong><dd><code>Document HTTP MCP setup and Penpot connection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/922/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+18/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CLAUDE.md</strong><dd><code>Reference updated MCP setup documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/922/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GEMINI.md</strong><dd><code>Reference updated MCP setup documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/922/files#diff-399080f41ccf73c6004e0f85c0a58fc1767080a0ef19bb3f3a90caa14f94bd79">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>copilot-instructions.md</strong><dd><code>Link to updated Penpot MCP setup guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/922/files#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

