### PR TITLE
Add GraphQL request body support

### DIFF
--- a/src/main/network/service/http-service.test.ts
+++ b/src/main/network/service/http-service.test.ts
@@ -15,6 +15,7 @@ import { FileSystemService } from 'main/filesystem/filesystem-service';
 import { PersistenceService } from 'main/persistence/service/persistence-service';
 import { ScriptingService } from 'main/scripting/scripting-service';
 import { Readable } from 'node:stream';
+import { text } from 'node:stream/consumers';
 
 const mockAgent = new MockAgent({ connections: 1 });
 const environmentService = EnvironmentService.instance;
@@ -342,8 +343,9 @@ describe('HttpService', () => {
     const httpService = new HttpService(() => Promise.resolve(mockAgent));
 
     const fileContent = 'test file content';
-    const { Readable } = require('node:stream');
-    vi.spyOn(fileSystemService, 'readFile').mockResolvedValue(Readable.from([fileContent]));
+    vi.spyOn(fileSystemService, 'readFile').mockResolvedValue(
+      Readable.from([fileContent]) as fs.ReadStream
+    );
     vi.spyOn(fs, 'statSync').mockReturnValue({ size: fileContent.length } as fs.Stats);
 
     const request: TrufosRequest = {
@@ -475,12 +477,193 @@ describe('HttpService', () => {
     expect(executeSpy.mock.calls[0]?.[0]).toEqual(preScript);
     expect(executeSpy.mock.calls[1]?.[0]).toEqual(postScript);
   });
+
+  it('fetchAsync() should serialize GraphQL POST requests', async () => {
+    const url = new URL('https://example.com/graphql');
+    const httpService = setupMockHttpService(url, { data: { hello: 'world' } }, undefined, 'POST');
+    const request: TrufosRequest = {
+      id: randomUUID(),
+      parentId: randomUUID(),
+      type: 'request',
+      lastModified: Date.now(),
+      title: 'GraphQL POST',
+      url: parseUrl(url.toString()),
+      method: RequestMethod.POST,
+      headers: [],
+      body: {
+        type: RequestBodyType.GRAPHQL,
+        query: 'query Hello($name: String!) { hello(name: $name) }',
+        variables: '{"name":"Ada"}',
+        operationName: 'Hello',
+      },
+    };
+
+    await httpService.fetchAsync(request);
+
+    const lastCall = mockAgent.getCallHistory()?.lastCall();
+    expect(lastCall).toBeDefined();
+    expect(lastCall?.method).toEqual('POST');
+    // @ts-expect-error lastCall may be undefined, expect() asserts it is defined
+    expect(lastCall.headers['content-type']).toEqual('application/json');
+    expect(JSON.parse(await text(lastCall?.body as unknown as Readable))).toEqual({
+      query: 'query Hello($name: String!) { hello(name: $name) }',
+      variables: { name: 'Ada' },
+      operationName: 'Hello',
+    });
+  });
+
+  it('fetchAsync() should accept pasted GraphQL JSON bodies', async () => {
+    const url = new URL('https://example.com/graphql');
+    const httpService = setupMockHttpService(url, { data: { getAllTcps: [] } }, undefined, 'POST');
+    const query =
+      'query { getAllTcps(where: { treasuryCompassSC: { tcId: { eq: 19 } } }) { id status } }';
+    const request: TrufosRequest = {
+      id: randomUUID(),
+      parentId: randomUUID(),
+      type: 'request',
+      lastModified: Date.now(),
+      title: 'GraphQL pasted JSON',
+      url: parseUrl(url.toString()),
+      method: RequestMethod.POST,
+      headers: [],
+      body: {
+        type: RequestBodyType.GRAPHQL,
+        query: JSON.stringify({ query }),
+        variables: '{}',
+      },
+    };
+
+    await httpService.fetchAsync(request);
+
+    const lastCall = mockAgent.getCallHistory()?.lastCall();
+    expect(lastCall).toBeDefined();
+    expect(JSON.parse(await text(lastCall?.body as unknown as Readable))).toEqual({
+      query,
+      variables: {},
+    });
+  });
+
+  it('fetchAsync() should serialize GraphQL query requests over GET', async () => {
+    const url = new URL('https://example.com/graphql');
+    const query = 'query Hello { hello }';
+    const path = `/graphql?${new URLSearchParams({
+      query,
+      variables: '{}',
+      operationName: 'Hello',
+    }).toString()}`;
+    const httpService = setupMockHttpService(
+      url,
+      { data: { hello: 'world' } },
+      undefined,
+      'GET',
+      path
+    );
+    const request: TrufosRequest = {
+      id: randomUUID(),
+      parentId: randomUUID(),
+      type: 'request',
+      lastModified: Date.now(),
+      title: 'GraphQL GET',
+      url: parseUrl(url.toString()),
+      method: RequestMethod.GET,
+      headers: [],
+      body: {
+        type: RequestBodyType.GRAPHQL,
+        query,
+        variables: '{}',
+        operationName: 'Hello',
+      },
+    };
+
+    await httpService.fetchAsync(request);
+
+    const lastCall = mockAgent.getCallHistory()?.lastCall();
+    expect(lastCall).toBeDefined();
+    expect(lastCall?.method).toEqual('GET');
+    expect(lastCall?.body).toBeUndefined();
+  });
+
+  it('fetchAsync() should reject GraphQL mutations over GET', async () => {
+    const url = new URL('https://example.com/graphql');
+    const httpService = new HttpService(() => Promise.resolve(mockAgent));
+    const request: TrufosRequest = {
+      id: randomUUID(),
+      parentId: randomUUID(),
+      type: 'request',
+      lastModified: Date.now(),
+      title: 'GraphQL GET Mutation',
+      url: parseUrl(url.toString()),
+      method: RequestMethod.GET,
+      headers: [],
+      body: {
+        type: RequestBodyType.GRAPHQL,
+        query: 'mutation Save { saveThing }',
+        variables: '{}',
+      },
+    };
+
+    await expect(httpService.fetchAsync(request)).rejects.toThrow(
+      'GraphQL mutations cannot be sent over GET'
+    );
+  });
+
+  it('fetchAsync() should reject invalid GraphQL variables JSON', async () => {
+    const url = new URL('https://example.com/graphql');
+    const httpService = new HttpService(() => Promise.resolve(mockAgent));
+    const request: TrufosRequest = {
+      id: randomUUID(),
+      parentId: randomUUID(),
+      type: 'request',
+      lastModified: Date.now(),
+      title: 'GraphQL Invalid Variables',
+      url: parseUrl(url.toString()),
+      method: RequestMethod.POST,
+      headers: [],
+      body: {
+        type: RequestBodyType.GRAPHQL,
+        query: 'query Hello { hello }',
+        variables: '{',
+      },
+    };
+
+    await expect(httpService.fetchAsync(request)).rejects.toThrow(
+      'GraphQL variables must be valid JSON'
+    );
+  });
+
+  it('fetchAsync() should expose GraphQL errors returned with HTTP 200', async () => {
+    const responseBody = { data: null, errors: [{ message: 'Nope' }, { message: 'Still nope' }] };
+    const url = new URL('https://example.com/graphql');
+    const httpService = setupMockHttpService(url, responseBody, undefined, 'POST');
+    const request: TrufosRequest = {
+      id: randomUUID(),
+      parentId: randomUUID(),
+      type: 'request',
+      lastModified: Date.now(),
+      title: 'GraphQL Errors',
+      url: parseUrl(url.toString()),
+      method: RequestMethod.POST,
+      headers: [],
+      body: {
+        type: RequestBodyType.GRAPHQL,
+        query: 'query Hello { hello }',
+        variables: '{}',
+      },
+    };
+
+    const response = await httpService.fetchAsync(request);
+
+    expect(response.metaInfo.status).toEqual(200);
+    expect(response.metaInfo.graphqlErrors).toEqual(2);
+  });
 });
 
 function setupMockHttpService(
   url: URL,
   body: object | string | null,
-  headers?: IncomingHttpHeaders
+  headers?: IncomingHttpHeaders,
+  method = 'GET',
+  path = url.pathname
 ) {
   let bodyString;
   switch (typeof body) {
@@ -495,8 +678,6 @@ function setupMockHttpService(
   }
 
   const mockClient = mockAgent.get(url.origin);
-  mockClient
-    .intercept({ path: url.pathname })
-    .reply(200, bodyString ?? undefined, { headers: headers });
+  mockClient.intercept({ path, method }).reply(200, bodyString ?? undefined, { headers: headers });
   return new HttpService(() => Promise.resolve(mockAgent));
 }

--- a/src/main/network/service/http-service.ts
+++ b/src/main/network/service/http-service.ts
@@ -6,7 +6,7 @@ import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import { Readable } from 'stream';
 import { EnvironmentService } from 'main/environment/service/environment-service';
-import { RequestBody, RequestBodyType, TrufosRequest } from 'shim/objects/request';
+import { GraphQLBody, RequestBody, RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { buildUrl } from 'shim/objects/url';
 import { TrufosResponse } from 'shim/objects/response';
 import { PersistenceService } from 'main/persistence/service/persistence-service';
@@ -77,7 +77,7 @@ export class HttpService {
         });
       } catch (e) {
         logger.error('Failed to generate authentication header:', e);
-        throw new Error('Please check your authentication settings and try again');
+        throw new Error('Please check your authentication settings and try again', { cause: e });
       }
     }
 
@@ -88,11 +88,11 @@ export class HttpService {
     // execute pre-request script if it exists
     await this.executeScript(request, ScriptType.PRE_REQUEST);
 
-    const [body, size] = await this.readBody(request);
+    const [body, size, requestUrl] = await this.readBody(request, url);
 
     // measure duration of the request
     const now = getSteadyTimestamp();
-    const responseData = await undici.request(url, {
+    const responseData = await undici.request(requestUrl ?? url, {
       dispatcher: await this._dispatcherProvider(),
       method: request.method,
       headers: {
@@ -119,6 +119,8 @@ export class HttpService {
       logger.debug('Successfully written response body');
     }
 
+    const graphqlErrors = await this.countGraphQLErrors(request, bodyFile.name);
+
     // return a new Response instance
     const response: TrufosResponse = {
       type: 'response',
@@ -129,6 +131,7 @@ export class HttpService {
           responseData.headers,
           responseData.body != null ? (bodyFile.name ?? undefined) : undefined
         ),
+        graphqlErrors,
       },
       headers: Object.freeze(responseData.headers),
       id: (responseData.body != null
@@ -145,7 +148,10 @@ export class HttpService {
    * @param request request object
    * @returns request body as stream or null if there is no body
    */
-  private async readBody(request: TrufosRequest): Promise<[(Readable | FormData)?, number?]> {
+  private async readBody(
+    request: TrufosRequest,
+    url: string
+  ): Promise<[(Readable | FormData)?, number?, string?]> {
     if (request.body == null) {
       return [];
     }
@@ -157,7 +163,9 @@ export class HttpService {
       }
       case RequestBodyType.FILE:
         return this.readFileBody(request.body.filePath);
-      case RequestBodyType.FORM_DATA:
+      case RequestBodyType.GRAPHQL:
+        return this.readGraphQLBody(request.body, request.method, url);
+      case RequestBodyType.FORM_DATA: {
         const form = new FormData();
         for (const field of request.body.fields) {
           switch (field.value.type) {
@@ -167,7 +175,7 @@ export class HttpService {
                 await environmentService.setVariablesInString(field.value.text ?? '')
               );
               break;
-            case RequestBodyType.FILE:
+            case RequestBodyType.FILE: {
               const [body] = await this.readFileBody(field.value.filePath);
               if (body != null) {
                 const fileName = field.value.fileName ?? 'file';
@@ -176,13 +184,93 @@ export class HttpService {
                 form.append(field.key, value);
               }
               break;
+            }
             default:
               throw new Error('Unknown form data field value type');
           }
         }
         return [form];
+      }
       default:
         throw new Error('Unknown body type');
+    }
+  }
+
+  private async readGraphQLBody(
+    body: GraphQLBody,
+    method: string,
+    requestUrl: string
+  ): Promise<[Readable?, number?, string?]> {
+    const { query, variables, operationName } = await this.resolveGraphQLBody(body);
+
+    if (method === 'GET') {
+      if (/^\s*mutation\b/i.test(query)) {
+        throw new Error('GraphQL mutations cannot be sent over GET');
+      }
+      const url = new URL(requestUrl);
+      url.searchParams.set('query', query);
+      if (body.variables?.trim()) url.searchParams.set('variables', JSON.stringify(variables));
+      if (operationName != null) url.searchParams.set('operationName', operationName);
+      return [undefined, undefined, url.toString()];
+    }
+
+    const payload = JSON.stringify({ query, variables, operationName });
+    return [Readable.from(payload), Buffer.byteLength(payload)];
+  }
+
+  private async resolveGraphQLBody(body: GraphQLBody) {
+    const queryInput = await environmentService.setVariablesInString(body.query ?? '');
+    const pastedPayload = this.parseGraphQLJsonPayload(queryInput);
+    const hasVariablesOverride =
+      body.variables != null && body.variables.trim() !== '' && body.variables.trim() !== '{}';
+    const variablesText = hasVariablesOverride
+      ? await environmentService.setVariablesInString(body.variables ?? '{}')
+      : JSON.stringify(pastedPayload?.variables ?? {});
+
+    return {
+      query: pastedPayload?.query ?? queryInput,
+      variables: this.parseGraphQLVariables(variablesText),
+      operationName: body.operationName?.trim() || pastedPayload?.operationName,
+    };
+  }
+
+  private parseGraphQLJsonPayload(input: string) {
+    try {
+      const parsed = JSON.parse(input) as {
+        query?: unknown;
+        variables?: unknown;
+        operationName?: unknown;
+      };
+      if (typeof parsed.query !== 'string') return undefined;
+      return {
+        query: parsed.query,
+        variables: parsed.variables,
+        operationName: typeof parsed.operationName === 'string' ? parsed.operationName : undefined,
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  private parseGraphQLVariables(resolvedVariables: string) {
+    if (!resolvedVariables.trim()) return {};
+    try {
+      return JSON.parse(resolvedVariables) as Record<string, unknown>;
+    } catch (error) {
+      throw new Error('GraphQL variables must be valid JSON', { cause: error });
+    }
+  }
+
+  private async countGraphQLErrors(request: TrufosRequest, responseBodyPath?: string) {
+    if (request.body?.type !== RequestBodyType.GRAPHQL || responseBodyPath == null)
+      return undefined;
+    try {
+      const responseBody = JSON.parse(await fsp.readFile(responseBodyPath, 'utf8')) as {
+        errors?: unknown[];
+      };
+      return Array.isArray(responseBody.errors) ? responseBody.errors.length : undefined;
+    } catch {
+      return undefined;
     }
   }
 
@@ -202,6 +290,8 @@ export class HttpService {
           return body.mimeType ?? 'text/plain';
         case RequestBodyType.FILE:
           return body.mimeType ?? 'application/octet-stream';
+        case RequestBodyType.GRAPHQL:
+          return 'application/json';
       }
     }
   }

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTab.tsx
@@ -12,6 +12,7 @@ import { selectRequest, useCollectionActions, useCollectionStore } from '@/state
 import BodyTabFileInput from './BodyTabFileInput';
 import BodyTabTextInput from './BodyTabTextInput';
 import { FormDataTab } from './FormDataTab';
+import { GraphQLBodyEditor } from './GraphQLBodyEditor';
 import { Button } from '@/components/ui/button';
 import { WandSparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -23,7 +24,7 @@ export const BodyTab = () => {
 
   const requestBody = useCollectionStore((state) => selectRequest(state)!.body);
   const mimeType = 'mimeType' in requestBody ? requestBody.mimeType : undefined;
-  const language = mimeTypeToLanguage(mimeType!);
+  const language = mimeType != null ? mimeTypeToLanguage(mimeType) : undefined;
   const canFormatRequestBody = isFormattableLanguage(language);
 
   const changeBodyType = useCallback(
@@ -37,6 +38,9 @@ export const BodyTab = () => {
           break;
         case RequestBodyType.FORM_DATA:
           setRequestBody({ type, fields: [] });
+          break;
+        case RequestBodyType.GRAPHQL:
+          setRequestBody({ type, query: '', variables: '{}', operationName: undefined });
           break;
       }
     },
@@ -59,9 +63,10 @@ export const BodyTab = () => {
                 [RequestBodyType.TEXT, 'Text'],
                 [RequestBodyType.FILE, 'File'],
                 [RequestBodyType.FORM_DATA, 'Form Data'],
+                [RequestBodyType.GRAPHQL, 'GraphQL'],
               ]}
             />
-            {requestBody.type === RequestBodyType.TEXT && (
+            {requestBody.type === RequestBodyType.TEXT && language != null && (
               <SimpleSelect<Language>
                 value={language}
                 onValueChange={(language) => setRequestBodyMimeType(languageToMimeType(language))}
@@ -93,10 +98,12 @@ export const BodyTab = () => {
         <FormDataTab />
       ) : requestBody.type === RequestBodyType.FILE ? (
         <BodyTabFileInput className="px-4 pb-2" />
+      ) : requestBody.type === RequestBodyType.GRAPHQL ? (
+        <GraphQLBodyEditor />
       ) : (
         <BodyTabTextInput
           className="pr-4"
-          language={language}
+          language={language ?? Language.TEXT}
           onMount={(editorInstance) => {
             editorRef.current = editorInstance;
           }}

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/GraphQLBodyEditor.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/GraphQLBodyEditor.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import MonacoEditor from '@/lib/monaco/MonacoEditor';
+import { getBodyModel, getVariablesModel } from '@/lib/monaco/models';
+import { REQUEST_EDITOR_OPTIONS } from '@/components/shared/settings/monaco-settings';
+import { Language } from '@/lib/monaco/language';
+import {
+  getGraphQLOperationNames,
+  introspectGraphQLSchema,
+  parseGraphQLJsonPayload,
+} from '@/lib/graphql';
+import { Button } from '@/components/ui/button';
+import { showError } from '@/error/errorHandler';
+import { selectRequest, useCollectionActions, useCollectionStore } from '@/state/collectionStore';
+import { languages } from 'monaco-editor';
+
+export function GraphQLBodyEditor() {
+  const [isIntrospecting, setIsIntrospecting] = useState(false);
+  const [queryText, setQueryText] = useState('');
+  const { setDraftFlag, setRequestBody } = useCollectionActions();
+  const request = useCollectionStore(selectRequest)!;
+  const selectedRequestId = useCollectionStore((state) => state.selectedRequestId);
+
+  const operationNames = useMemo(() => getGraphQLOperationNames(queryText), [queryText]);
+
+  useEffect(() => {
+    if (selectedRequestId == null) return;
+    const bodyModel = getBodyModel(selectedRequestId);
+    setQueryText(bodyModel.getValue());
+    const bodyDisposable = bodyModel.onDidChangeContent((event) => {
+      if (!event.isFlush) setDraftFlag();
+      setQueryText(bodyModel.getValue());
+    });
+    const variablesDisposable = getVariablesModel(selectedRequestId).onDidChangeContent((event) => {
+      if (!event.isFlush) setDraftFlag();
+    });
+    return () => {
+      bodyDisposable.dispose();
+      variablesDisposable.dispose();
+    };
+  }, [selectedRequestId, setDraftFlag]);
+
+  useEffect(() => {
+    if (request.body.type !== 'graphql') return;
+    const fields = getSchemaFieldNames(request.body.schema ?? '');
+    if (fields.length === 0) return;
+    const disposable = languages.registerCompletionItemProvider(Language.GRAPHQL, {
+      provideCompletionItems: (model, position) => {
+        const word = model.getWordUntilPosition(position);
+        const range = {
+          startLineNumber: position.lineNumber,
+          endLineNumber: position.lineNumber,
+          startColumn: word.startColumn,
+          endColumn: word.endColumn,
+        };
+        return {
+          suggestions: fields.map((field) => ({
+            label: field,
+            kind: languages.CompletionItemKind.Field,
+            insertText: field,
+            range,
+          })),
+        };
+      },
+    });
+    return () => disposable.dispose();
+  }, [request.body]);
+
+  const updateGraphQLBody = useCallback(
+    (updates: { operationName?: string; schema?: string }) => {
+      if (request.body.type !== 'graphql') return;
+      setRequestBody({ ...request.body, ...updates });
+    },
+    [request.body, setRequestBody]
+  );
+
+  const introspect = useCallback(async () => {
+    if (request.body.type !== 'graphql') return;
+    try {
+      setIsIntrospecting(true);
+      const schema = await introspectGraphQLSchema(request);
+      updateGraphQLBody({ schema });
+    } catch (error) {
+      showError(error);
+    } finally {
+      setIsIntrospecting(false);
+    }
+  }, [request, updateGraphQLBody]);
+
+  const extractJsonBody = useCallback(() => {
+    if (selectedRequestId == null) return;
+    const payload = parseGraphQLJsonPayload(getBodyModel(selectedRequestId).getValue());
+    if (payload == null) return;
+    getBodyModel(selectedRequestId).setValue(payload.query);
+    getVariablesModel(selectedRequestId).setValue(payload.variables ?? '{}');
+    updateGraphQLBody({ operationName: payload.operationName });
+    setDraftFlag();
+  }, [selectedRequestId, setDraftFlag, updateGraphQLBody]);
+
+  if (selectedRequestId == null || request.body.type !== 'graphql') return null;
+
+  return (
+    <div className="grid h-full grid-rows-[auto_minmax(0,1fr)] gap-3 px-4 pb-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground text-sm">GraphQL body</span>
+          <Button className="h-8" size="sm" variant="ghost" onClick={extractJsonBody}>
+            Extract JSON body
+          </Button>
+        </div>
+        <select
+          className="bg-background border-border h-8 rounded border px-2 text-sm"
+          value={request.body.operationName ?? ''}
+          onChange={(event) =>
+            updateGraphQLBody({ operationName: event.target.value || undefined })
+          }
+        >
+          <option value="">operationName</option>
+          {operationNames.map((operationName) => (
+            <option key={operationName} value={operationName}>
+              {operationName}
+            </option>
+          ))}
+        </select>
+        <Button
+          className="h-8"
+          size="sm"
+          variant="ghost"
+          onClick={introspect}
+          disabled={isIntrospecting}
+        >
+          {isIntrospecting ? 'Introspecting...' : 'Introspect'}
+        </Button>
+      </div>
+
+      <div className="grid min-h-0 grid-cols-[minmax(0,2fr)_minmax(280px,1fr)] gap-3">
+        <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-1">
+          <span className="text-muted-foreground text-xs">Query</span>
+          <MonacoEditor
+            className="min-h-0"
+            height="100%"
+            language={Language.GRAPHQL}
+            model={getBodyModel(selectedRequestId)}
+            options={REQUEST_EDITOR_OPTIONS}
+          />
+        </div>
+        <div className="grid min-h-0 grid-rows-[minmax(0,1fr)_minmax(0,1fr)] gap-3">
+          <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-1">
+            <span className="text-muted-foreground text-xs">Variables JSON</span>
+            <MonacoEditor
+              className="min-h-0"
+              height="100%"
+              language={Language.JSON}
+              model={getVariablesModel(selectedRequestId)}
+              options={REQUEST_EDITOR_OPTIONS}
+            />
+          </div>
+          <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-1">
+            <span className="text-muted-foreground text-xs">Schema fallback</span>
+            <textarea
+              className="bg-background border-border min-h-0 resize-none rounded border p-2 font-mono text-sm"
+              placeholder="Paste introspection JSON or SDL"
+              value={request.body.schema ?? ''}
+              onChange={(event) => updateGraphQLBody({ schema: event.target.value })}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getSchemaFieldNames(schema: string): string[] {
+  if (!schema.trim()) return [];
+  try {
+    const parsed = JSON.parse(schema) as {
+      types?: { name?: string; fields?: { name?: string }[] }[];
+      queryType?: { name?: string };
+      mutationType?: { name?: string };
+    };
+    const rootNames = new Set([parsed.queryType?.name, parsed.mutationType?.name].filter(Boolean));
+    return Array.from(
+      new Set(
+        (parsed.types ?? [])
+          .filter((type) => rootNames.has(type.name))
+          .flatMap((type) => type.fields ?? [])
+          .map((field) => field.name)
+          .filter((field): field is string => field != null)
+      )
+    );
+  } catch {
+    const matches = schema.matchAll(/\b(?:type|extend\s+type)\s+(?:Query|Mutation)\s*{([^}]*)}/gms);
+    return Array.from(
+      new Set(
+        Array.from(matches)
+          .flatMap((match) => match[1].split('\n'))
+          .map((line) => line.trim().match(/^([_A-Za-z][_0-9A-Za-z]*)/)?.[1])
+          .filter((field): field is string => field != null)
+      )
+    );
+  }
+}

--- a/src/renderer/components/mainWindow/responseStatus/ResponseStatus.tsx
+++ b/src/renderer/components/mainWindow/responseStatus/ResponseStatus.tsx
@@ -25,6 +25,9 @@ export function ResponseStatus() {
   return (
     <span className="response-status truncate text-nowrap">
       <span className={'text-sm ' + statusColorClass}>{statusText}</span>
+      {metaInfo.graphqlErrors != null && metaInfo.graphqlErrors > 0 && (
+        <span className="text-error ml-2 text-sm">GraphQL errors: {metaInfo.graphqlErrors}</span>
+      )}
       <span className="ml-2 text-sm">{durationText}</span>
       <Tooltip>
         <TooltipTrigger asChild>

--- a/src/renderer/lib/graphql.ts
+++ b/src/renderer/lib/graphql.ts
@@ -1,0 +1,84 @@
+import { IpcPushStream } from '@/lib/ipc-stream';
+import { RendererEventService } from '@/services/event/renderer-event-service';
+import { TrufosRequest } from 'shim/objects/request';
+
+export const GRAPHQL_INTROSPECTION_QUERY = `
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    types {
+      kind
+      name
+      fields(includeDeprecated: true) {
+        name
+        type {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`.trim();
+
+export function getGraphQLOperationNames(query: string): string[] {
+  return Array.from(query.matchAll(/\b(?:query|mutation)\s+([_A-Za-z][_0-9A-Za-z]*)/g)).map(
+    (match) => match[1]
+  );
+}
+
+export function parseGraphQLJsonPayload(input: string) {
+  try {
+    const parsed = JSON.parse(input) as {
+      query?: unknown;
+      variables?: unknown;
+      operationName?: unknown;
+    };
+    if (typeof parsed.query !== 'string') return undefined;
+    return {
+      query: parsed.query,
+      variables:
+        parsed.variables == null
+          ? undefined
+          : typeof parsed.variables === 'string'
+            ? parsed.variables
+            : JSON.stringify(parsed.variables, null, 2),
+      operationName: typeof parsed.operationName === 'string' ? parsed.operationName : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export async function introspectGraphQLSchema(request: TrufosRequest): Promise<string> {
+  if (request.body.type !== 'graphql') return '';
+  const response = await RendererEventService.instance.sendRequest({
+    ...request,
+    body: {
+      ...request.body,
+      query: GRAPHQL_INTROSPECTION_QUERY,
+      variables: '{}',
+      operationName: 'IntrospectionQuery',
+    },
+  });
+  const body = await (await IpcPushStream.open(response, 'utf-8')).readAll();
+  const parsed = JSON.parse(body) as { data?: { __schema?: unknown }; errors?: unknown[] };
+
+  if (parsed.errors?.length) {
+    throw new Error('GraphQL introspection returned errors. Paste schema SDL manually instead.');
+  }
+  if (parsed.data?.__schema == null) {
+    throw new Error('GraphQL introspection response did not include __schema.');
+  }
+
+  return JSON.stringify(parsed.data.__schema, null, 2);
+}

--- a/src/renderer/lib/monaco/language.ts
+++ b/src/renderer/lib/monaco/language.ts
@@ -5,16 +5,19 @@ import { TemplateVariableHoverProvider } from './template-variable-hover-provide
 import { TemplateVariableSemanticTokensProvider } from './template-variable-semantic-tokens-provider';
 import trufosDeclaration from '@/assets/trufos-scripting-api.d.ts?raw';
 
+// @ts-expect-error Monaco exposes TypeScript defaults at runtime, but its barrel type is narrow.
 languages.typescript.javascriptDefaults.addExtraLib(trufosDeclaration);
 
 export enum Language {
   JSON = 'json',
+  GRAPHQL = 'graphql',
   XML = 'xml',
   TEXT = 'plaintext',
 }
 
 const LANGUAGE_TO_MIME_TYPE_MAP: Record<Language, string> = {
   [Language.JSON]: 'application/json',
+  [Language.GRAPHQL]: 'application/graphql',
   [Language.XML]: 'application/xml',
   [Language.TEXT]: 'text/plain',
 };
@@ -43,13 +46,33 @@ export function mimeTypeToLanguage(mimeType: string): Language {
   return MIME_TYPE_TO_LANGUAGE_MAP[mimeType];
 }
 
-const supportedLanguages = [Language.JSON, Language.XML, Language.TEXT];
+const supportedLanguages = [Language.JSON, Language.GRAPHQL, Language.XML, Language.TEXT];
 const formattableLanguages = new Set([Language.JSON, Language.XML]);
 
 // plaintext using fast syntax highlighting
 languages.setMonarchTokensProvider(Language.TEXT, {
   tokenizer: {
     root: [[/\{\{\s*(\$?\w+)\s*}}/, 'variable.template']],
+  },
+});
+
+languages.setMonarchTokensProvider(Language.GRAPHQL, {
+  tokenizer: {
+    root: [
+      [/#.*$/, 'comment'],
+      [/\b(query|mutation|fragment|on|schema|type|input|enum|interface|union|scalar)\b/, 'keyword'],
+      [/\$[A-Za-z_][\w]*/, 'variable'],
+      [/[A-Za-z_][\w]*(?=\s*:)/, 'attribute.name'],
+      [/[A-Za-z_][\w]*/, 'identifier'],
+      [/[{}()[\]:=!|&]/, 'delimiter'],
+      [/"([^"\\]|\\.)*$/, 'string.invalid'],
+      [/"/, { token: 'string.quote', bracket: '@open', next: '@string' }],
+    ],
+    string: [
+      [/[^\\"]+/, 'string'],
+      [/\\./, 'string.escape'],
+      [/"/, { token: 'string.quote', bracket: '@close', next: '@pop' }],
+    ],
   },
 });
 

--- a/src/renderer/lib/monaco/models.ts
+++ b/src/renderer/lib/monaco/models.ts
@@ -1,5 +1,5 @@
 import { editor, Uri } from 'monaco-editor';
-import { TrufosRequest } from 'shim/objects/request';
+import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { ScriptType } from 'shim/scripting';
 import { RendererEventService } from '@/services/event/renderer-event-service';
 
@@ -13,6 +13,7 @@ const SCHEME = 'trufos';
 
 export interface RequestModels {
   body: editor.ITextModel;
+  variables: editor.ITextModel;
   scripts: Map<ScriptType, editor.ITextModel>;
   response: editor.ITextModel;
 }
@@ -37,6 +38,10 @@ export function bodyUri(requestId: string): Uri {
   return Uri.from({ scheme: SCHEME, path: `/requests/${requestId}/body` });
 }
 
+export function variablesUri(requestId: string): Uri {
+  return Uri.from({ scheme: SCHEME, path: `/requests/${requestId}/variables` });
+}
+
 export function scriptUri(requestId: string, scriptType: ScriptType): Uri {
   return Uri.from({ scheme: SCHEME, path: `/requests/${requestId}/script/${scriptType}` });
 }
@@ -46,15 +51,18 @@ export function responseUri(requestId: string): Uri {
 }
 
 /** Parse a model URI and return its metadata, or null if it is not a trufos model. */
-function parseModelUri(
-  uri: Uri
-): { requestId: string; kind: 'body' | 'script' | 'response'; scriptType?: ScriptType } | null {
+function parseModelUri(uri: Uri): {
+  requestId: string;
+  kind: 'body' | 'variables' | 'script' | 'response';
+  scriptType?: ScriptType;
+} | null {
   if (uri.scheme !== SCHEME) return null;
-  // path: /requests/{id}/body|response  or  /requests/{id}/script/{type}
-  const match = uri.path.match(/^\/requests\/([^/]+)\/(body|response|script\/([^/]+))$/);
+  // path: /requests/{id}/body|variables|response  or  /requests/{id}/script/{type}
+  const match = uri.path.match(/^\/requests\/([^/]+)\/(body|variables|response|script\/([^/]+))$/);
   if (!match) return null;
   const requestId = match[1];
   if (match[2] === 'body') return { requestId, kind: 'body' };
+  if (match[2] === 'variables') return { requestId, kind: 'variables' };
   if (match[2] === 'response') return { requestId, kind: 'response' };
   return { requestId, kind: 'script', scriptType: match[3] as ScriptType };
 }
@@ -67,6 +75,7 @@ export function createModelsForRequest(requestId: string): RequestModels {
   }
   const models: RequestModels = {
     body: editor.createModel('', undefined, bodyUri(requestId)),
+    variables: editor.createModel('', 'json', variablesUri(requestId)),
     scripts: new Map(
       Object.values(ScriptType).map((type) => [
         type,
@@ -87,6 +96,10 @@ export function getBodyModel(requestId: string): editor.ITextModel {
   return registry.get(requestId)!.body;
 }
 
+export function getVariablesModel(requestId: string): editor.ITextModel {
+  return registry.get(requestId)!.variables;
+}
+
 export function getScriptModel(requestId: string, scriptType: ScriptType): editor.ITextModel {
   return registry.get(requestId)!.scripts.get(scriptType)!;
 }
@@ -101,6 +114,7 @@ export function disposeModelsForRequest(requestId: string): void {
   // Dispose each model — this triggers onWillDisposeModel for body & script,
   // which handles persisting their content.
   models.body.dispose();
+  models.variables.dispose();
   for (const scriptModel of models.scripts.values()) {
     scriptModel.dispose();
   }
@@ -124,8 +138,12 @@ export async function saveModelContent(model: editor.ITextModel): Promise<void> 
   const request = getRequest(parsed.requestId);
   if (!request) return;
 
-  if (parsed.kind === 'body') {
-    await eventService.saveRequest(request, model.getValue());
+  if (parsed.kind === 'body' || parsed.kind === 'variables') {
+    if (request.body.type === RequestBodyType.GRAPHQL) {
+      await eventService.saveRequest(requestWithGraphQLModelValues(request));
+    } else if (parsed.kind === 'body') {
+      await eventService.saveRequest(request, model.getValue());
+    }
   } else if (parsed.kind === 'script' && parsed.scriptType != null) {
     await eventService.saveScript(request, parsed.scriptType, model.getValue());
   }
@@ -139,9 +157,26 @@ editor.onWillDisposeModel((model) => {
   const request = getRequest(parsed.requestId);
   if (!request) return;
 
-  if (parsed.kind === 'body') {
-    void eventService.saveRequest(request, model.getValue());
+  if (parsed.kind === 'body' || parsed.kind === 'variables') {
+    if (request.body.type === RequestBodyType.GRAPHQL) {
+      void eventService.saveRequest(requestWithGraphQLModelValues(request));
+    } else if (parsed.kind === 'body') {
+      void eventService.saveRequest(request, model.getValue());
+    }
   } else if (parsed.kind === 'script' && parsed.scriptType != null) {
     void eventService.saveScript(request, parsed.scriptType, model.getValue());
   }
 });
+
+function requestWithGraphQLModelValues(request: TrufosRequest): TrufosRequest {
+  if (request.body.type !== RequestBodyType.GRAPHQL) return request;
+  const models = registry.get(request.id);
+  return {
+    ...request,
+    body: {
+      ...request.body,
+      query: models?.body.getValue() ?? request.body.query,
+      variables: models?.variables.getValue() ?? request.body.variables,
+    },
+  };
+}

--- a/src/renderer/state/helper/collectionUtil.ts
+++ b/src/renderer/state/helper/collectionUtil.ts
@@ -1,16 +1,22 @@
 import { IpcPushStream } from '@/lib/ipc-stream';
-import { getBodyModel, getScriptModel } from '@/lib/monaco/models';
+import { getBodyModel, getScriptModel, getVariablesModel } from '@/lib/monaco/models';
 import { Folder } from 'shim/objects/folder';
 import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { ScriptType } from 'shim/scripting';
 
 export async function setRequestTextBody(requestId: string, request?: TrufosRequest) {
   const model = getBodyModel(requestId);
+  const variablesModel = getVariablesModel(requestId);
   if (request?.body?.type === RequestBodyType.TEXT) {
     const stream = await IpcPushStream.open(request, 'utf-8');
     model.setValue(await stream.readAll());
+    variablesModel.setValue('');
+  } else if (request?.body?.type === RequestBodyType.GRAPHQL) {
+    model.setValue(request.body.query ?? '');
+    variablesModel.setValue(request.body.variables ?? '{}');
   } else {
     model.setValue('');
+    variablesModel.setValue('');
   }
 }
 

--- a/src/shim/objects/request.ts
+++ b/src/shim/objects/request.ts
@@ -10,6 +10,7 @@ export enum RequestBodyType {
   TEXT = 'text',
   FILE = 'file',
   FORM_DATA = 'form-data',
+  GRAPHQL = 'graphql',
 }
 
 export const TextBody = z.object({
@@ -47,7 +48,21 @@ export const FormDataBody = z.object({
 });
 export type FormDataBody = z.infer<typeof FormDataBody>;
 
-export const RequestBody = z.discriminatedUnion('type', [TextBody, FileBody, FormDataBody]);
+export const GraphQLBody = z.object({
+  type: z.literal(RequestBodyType.GRAPHQL),
+  query: z.string().optional(),
+  variables: z.string().optional(),
+  operationName: z.string().optional(),
+  schema: z.string().optional(),
+});
+export type GraphQLBody = z.infer<typeof GraphQLBody>;
+
+export const RequestBody = z.discriminatedUnion('type', [
+  TextBody,
+  FileBody,
+  FormDataBody,
+  GraphQLBody,
+]);
 export type RequestBody = z.infer<typeof RequestBody>;
 
 export const TrufosRequest = z.object({

--- a/src/shim/objects/response.ts
+++ b/src/shim/objects/response.ts
@@ -12,6 +12,7 @@ export const MetaInfo = z.object({
   duration: z.number(),
   size: ResponseSize,
   status: z.number(),
+  graphqlErrors: z.number().optional(),
 });
 export type MetaInfo = z.infer<typeof MetaInfo>;
 


### PR DESCRIPTION
Closes #839.

## What changed

- Adds GraphQL as a request body type, not as an HTTP method.
- Adds GraphQL query, variables, operationName, and manual schema storage to request metadata.
- Serializes GraphQL POST requests as `{ query, variables, operationName }`.
- Supports GraphQL queries over GET using URL-encoded `query`, `variables`, and `operationName`.
- Blocks GraphQL mutations over GET.
- Reuses the existing send path for introspection, so request auth, headers, environment variables, and TLS/dispatcher behavior stay consistent.
- Adds a GraphQL body editor with query, variables, operationName selection, introspection, and manual schema fallback.
- Surfaces GraphQL `errors` returned with HTTP 200 in response metadata/status UI.

## Why

PR #887 modeled GraphQL as an HTTP method and added a separate introspection request path. That conflated transport and body protocol, forced POST, and bypassed normal request context. This implementation keeps HTTP methods unchanged and makes GraphQL a body type as requested in #839.

## Validation

- `yarn tsc --noEmit`
- `yarn test`
- `yarn exec prettier --check ...` on touched files
- targeted `yarn eslint ...` on touched files

Targeted ESLint reports no errors; it still prints the existing `z` default-import warnings in shim files.
