### PR TITLE
feat: add request history (#840)

### DIFF
--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -21,6 +21,8 @@ import { ScriptingService } from 'main/scripting/scripting-service';
 import { ResponseBodyService } from 'main/network/service/response-body-service';
 import { getSuggestedFilename } from 'main/network/response-filename';
 import { updateElectronApp } from 'update-electron-app';
+import { HistoryService } from 'main/history/history-service';
+import type { HistoryEntry } from 'shim/objects/history';
 
 // register stream events
 import './stream-events';
@@ -110,17 +112,38 @@ export class MainEventService implements IEventService {
   }
 
   async sendRequest(request: TrufosRequest, abortKey?: string) {
-    if (abortKey == null) {
-      return await HttpService.instance.fetchAsync(request);
-    }
-
-    const abortController = new AbortController();
-    this.abortControllers.set(abortKey, abortController);
-
+    let response: TrufosResponse;
+    const startedAt = Date.now();
     try {
-      return await HttpService.instance.fetchAsync(request, abortController.signal);
-    } finally {
-      this.abortControllers.delete(abortKey);
+      if (abortKey == null) {
+        response = await HttpService.instance.fetchAsync(request);
+      } else {
+        const abortController = new AbortController();
+        this.abortControllers.set(abortKey, abortController);
+
+        try {
+          response = await HttpService.instance.fetchAsync(request, abortController.signal);
+        } finally {
+          this.abortControllers.delete(abortKey);
+        }
+      }
+
+      // Record successful history entry in the background
+      void HistoryService.instance.recordEntry(request, response).catch((err) => {
+        logger.error('Failed to log request history:', err);
+      });
+
+      return response;
+    } catch (error) {
+      // Record failed history entry in the background
+      const duration = Date.now() - startedAt;
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      void HistoryService.instance
+        .recordEntry(request, { error: errorMessage, duration })
+        .catch((err) => {
+          logger.error('Failed to log failed request history:', err);
+        });
+      throw error;
     }
   }
 
@@ -266,6 +289,14 @@ export class MainEventService implements IEventService {
 
   async saveAppSettings(settings: AppSettings): Promise<void> {
     await SettingsService.instance.updateSettings({ preferences: settings });
+  }
+
+  async getHistory(limit?: number): Promise<HistoryEntry[]> {
+    return await HistoryService.instance.loadEntries(limit);
+  }
+
+  async clearHistory(): Promise<void> {
+    await HistoryService.instance.clearHistory();
   }
 
   updateApp() {

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -6,6 +6,7 @@ import type {
   TrufosObject,
   Folder,
   TrufosRequest,
+  TrufosResponse,
   VariableMap,
   EnvironmentMap,
   ScriptType,
@@ -13,6 +14,7 @@ import type {
   ImportStrategy,
   AppSettings,
 } from 'shim';
+import { MainProcessEvent } from 'shim/event-service';
 import type { ClientCertificate } from 'shim/objects/collection';
 import { SettingsService } from '../persistence/service/settings-service';
 import { PersistenceService } from '../persistence/service/persistence-service';
@@ -91,7 +93,10 @@ export class MainEventService implements IEventService {
       void persistenceService
         .saveCollection(environmentService.currentCollection)
         .then(() =>
-          this.webContents?.send('collection-variables-updated', { variables, environments })
+          this.webContents?.send(MainProcessEvent.CollectionVariablesUpdated, {
+            variables,
+            environments,
+          })
         )
         .catch((err) => logger.error('Failed to persist variable changes', err));
     });

--- a/src/main/history/history-service.test.ts
+++ b/src/main/history/history-service.test.ts
@@ -4,7 +4,7 @@ import { EnvironmentService } from 'main/environment/service/environment-service
 import { USER_DATA_DIR, exists } from 'main/util/fs-util';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { TrufosRequest, TrufosResponse, RequestMethod } from 'shim';
+import { TrufosRequest, TrufosResponse, RequestMethod, RequestBodyType } from 'shim';
 import type { Collection } from 'shim/objects/collection';
 
 const testCollectionDir = path.join(USER_DATA_DIR, 'test-history-collection');
@@ -20,6 +20,7 @@ describe('HistoryService', () => {
       variables: {},
       environments: {},
       children: [],
+      lastModified: Date.now(),
     };
     (
       EnvironmentService.instance as unknown as { _currentCollection: Collection }
@@ -50,7 +51,7 @@ describe('HistoryService', () => {
         { key: 'Content-Type', value: 'application/json', isActive: true },
         { key: 'Authorization', value: 'Bearer super-secret-token', isActive: true },
       ],
-      body: { type: 'text', mimeType: 'application/json', text: 'hello body' },
+      body: { type: RequestBodyType.TEXT, mimeType: 'application/json', text: 'hello body' },
     };
 
     const response: TrufosResponse = {
@@ -93,7 +94,7 @@ describe('HistoryService', () => {
       url: { base: 'https://example.com/api', query: [] },
       method: RequestMethod.GET,
       headers: [],
-      body: { type: 'text', mimeType: 'application/json', text: '' },
+      body: { type: RequestBodyType.TEXT, mimeType: 'application/json', text: '' },
     };
 
     await HistoryService.instance.recordEntry(request, {
@@ -118,7 +119,7 @@ describe('HistoryService', () => {
       url: { base: 'https://example.com/api', query: [] },
       method: RequestMethod.GET,
       headers: [],
-      body: { type: 'text', mimeType: 'application/json', text: '' },
+      body: { type: RequestBodyType.TEXT, mimeType: 'application/json', text: '' },
     };
 
     const response: TrufosResponse = {
@@ -146,6 +147,26 @@ describe('HistoryService', () => {
     expect(entries[0].timestamp).toBe(1700000000000 + 104 * 10);
   });
 
+  it('clears the history of all given collections on startup', async () => {
+    const request: TrufosRequest = {
+      id: 'req-1',
+      parentId: 'col-1',
+      type: 'request',
+      lastModified: Date.now(),
+      title: 'My Request',
+      url: { base: 'https://example.com/api', query: [] },
+      method: RequestMethod.GET,
+      headers: [],
+      body: { type: RequestBodyType.TEXT, mimeType: 'application/json', text: '' },
+    };
+
+    await HistoryService.instance.recordEntry(request, { error: 'boom', duration: 1 });
+    expect(await HistoryService.instance.loadEntries()).toHaveLength(1);
+
+    await HistoryService.instance.clearOnStartup([testCollectionDir, '/does/not/exist']);
+    expect(await HistoryService.instance.loadEntries()).toHaveLength(0);
+  });
+
   it('clears history correctly', async () => {
     const request: TrufosRequest = {
       id: 'req-1',
@@ -156,7 +177,7 @@ describe('HistoryService', () => {
       url: { base: 'https://example.com/api', query: [] },
       method: RequestMethod.GET,
       headers: [],
-      body: { type: 'text', mimeType: 'application/json', text: '' },
+      body: { type: RequestBodyType.TEXT, mimeType: 'application/json', text: '' },
     };
 
     const response: TrufosResponse = {

--- a/src/main/history/history-service.test.ts
+++ b/src/main/history/history-service.test.ts
@@ -1,0 +1,181 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { HistoryService } from './history-service';
+import { EnvironmentService } from 'main/environment/service/environment-service';
+import { USER_DATA_DIR, exists } from 'main/util/fs-util';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { TrufosRequest, TrufosResponse, RequestMethod } from 'shim';
+import type { Collection } from 'shim/objects/collection';
+
+const testCollectionDir = path.join(USER_DATA_DIR, 'test-history-collection');
+
+describe('HistoryService', () => {
+  beforeEach(async () => {
+    // Reset/Mock EnvironmentService collection dir
+    const testCollection: Collection = {
+      id: 'test-col-id',
+      type: 'collection',
+      title: 'Test Collection',
+      dirPath: testCollectionDir,
+      variables: {},
+      environments: {},
+      children: [],
+    };
+    (
+      EnvironmentService.instance as unknown as { _currentCollection: Collection }
+    )._currentCollection = testCollection;
+
+    if (await exists(testCollectionDir)) {
+      await fs.rm(testCollectionDir, { recursive: true, force: true });
+    }
+    await fs.mkdir(testCollectionDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (await exists(testCollectionDir)) {
+      await fs.rm(testCollectionDir, { recursive: true, force: true });
+    }
+  });
+
+  it('records history entries and redacts sensitive headers', async () => {
+    const request: TrufosRequest = {
+      id: 'req-1',
+      parentId: 'col-1',
+      type: 'request',
+      lastModified: Date.now(),
+      title: 'My Request',
+      url: { base: 'https://example.com/api', query: [] },
+      method: RequestMethod.GET,
+      headers: [
+        { key: 'Content-Type', value: 'application/json', isActive: true },
+        { key: 'Authorization', value: 'Bearer super-secret-token', isActive: true },
+      ],
+      body: { type: 'text', mimeType: 'application/json', text: 'hello body' },
+    };
+
+    const response: TrufosResponse = {
+      type: 'response',
+      metaInfo: {
+        status: 200,
+        duration: 120,
+        size: { totalSizeInBytes: 150, headersSizeInBytes: 50, bodySizeInBytes: 100 },
+      },
+      headers: {},
+      id: 'resp-1',
+    };
+
+    await HistoryService.instance.recordEntry(request, response);
+
+    const entries = await HistoryService.instance.loadEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].request.method).toBe('GET');
+    expect(entries[0].request.url).toBe('https://example.com/api');
+
+    // Headers should have Authorization redacted, Content-Type kept
+    const authHeader = entries[0].request.headers.find((h) => h.key === 'Authorization');
+    expect(authHeader?.value).toBe('***REDACTED***');
+
+    const typeHeader = entries[0].request.headers.find((h) => h.key === 'Content-Type');
+    expect(typeHeader?.value).toBe('application/json');
+
+    expect(entries[0].response.status).toBe(200);
+    expect(entries[0].response.duration).toBe(120);
+    expect(entries[0].response.size).toBe(150);
+  });
+
+  it('records error entries correctly', async () => {
+    const request: TrufosRequest = {
+      id: 'req-1',
+      parentId: 'col-1',
+      type: 'request',
+      lastModified: Date.now(),
+      title: 'My Request',
+      url: { base: 'https://example.com/api', query: [] },
+      method: RequestMethod.GET,
+      headers: [],
+      body: { type: 'text', mimeType: 'application/json', text: '' },
+    };
+
+    await HistoryService.instance.recordEntry(request, {
+      error: 'Failed to connect',
+      duration: 450,
+    });
+
+    const entries = await HistoryService.instance.loadEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].response.status).toBe(0);
+    expect(entries[0].response.duration).toBe(450);
+    expect(entries[0].response.error).toBe('Failed to connect');
+  });
+
+  it('enforces retention limit by keeping newest 100 entries', async () => {
+    const request: TrufosRequest = {
+      id: 'req-1',
+      parentId: 'col-1',
+      type: 'request',
+      lastModified: Date.now(),
+      title: 'My Request',
+      url: { base: 'https://example.com/api', query: [] },
+      method: RequestMethod.GET,
+      headers: [],
+      body: { type: 'text', mimeType: 'application/json', text: '' },
+    };
+
+    const response: TrufosResponse = {
+      type: 'response',
+      metaInfo: {
+        status: 200,
+        duration: 100,
+        size: { totalSizeInBytes: 50, headersSizeInBytes: 0, bodySizeInBytes: 50 },
+      },
+      headers: {},
+      id: 'resp-1',
+    };
+
+    // Record 105 entries
+    for (let i = 0; i < 105; i++) {
+      // Mock Date.now to increments to avoid exact collisions
+      vi.spyOn(Date, 'now').mockReturnValue(1700000000000 + i * 10);
+      await HistoryService.instance.recordEntry(request, response);
+    }
+    vi.spyOn(Date, 'now').mockRestore();
+
+    const entries = await HistoryService.instance.loadEntries();
+    expect(entries).toHaveLength(100);
+    // Newest timestamp should be 1700000000000 + 1040
+    expect(entries[0].timestamp).toBe(1700000000000 + 104 * 10);
+  });
+
+  it('clears history correctly', async () => {
+    const request: TrufosRequest = {
+      id: 'req-1',
+      parentId: 'col-1',
+      type: 'request',
+      lastModified: Date.now(),
+      title: 'My Request',
+      url: { base: 'https://example.com/api', query: [] },
+      method: RequestMethod.GET,
+      headers: [],
+      body: { type: 'text', mimeType: 'application/json', text: '' },
+    };
+
+    const response: TrufosResponse = {
+      type: 'response',
+      metaInfo: {
+        status: 200,
+        duration: 100,
+        size: { totalSizeInBytes: 50, headersSizeInBytes: 0, bodySizeInBytes: 50 },
+      },
+      headers: {},
+      id: 'resp-1',
+    };
+
+    await HistoryService.instance.recordEntry(request, response);
+    let entries = await HistoryService.instance.loadEntries();
+    expect(entries).toHaveLength(1);
+
+    await HistoryService.instance.clearHistory();
+    entries = await HistoryService.instance.loadEntries();
+    expect(entries).toHaveLength(0);
+  });
+});

--- a/src/main/history/history-service.ts
+++ b/src/main/history/history-service.ts
@@ -27,6 +27,22 @@ export class HistoryService {
   }
 
   /**
+   * Deletes the history of all given collections. Called once on app startup so
+   * the history is ephemeral per session and its schema can change freely
+   * without needing migrations.
+   * @param collectionDirPaths The directories of all known collections.
+   */
+  public async clearOnStartup(collectionDirPaths: string[]): Promise<void> {
+    for (const dirPath of collectionDirPaths) {
+      try {
+        await fs.rm(this.getHistoryDir(dirPath), { recursive: true, force: true });
+      } catch (error) {
+        logger.warn(`Failed to clear history of collection at ${dirPath}:`, error);
+      }
+    }
+  }
+
+  /**
    * Records a request/response entry in the history.
    * Redacts sensitive headers and limits body/response size.
    */

--- a/src/main/history/history-service.ts
+++ b/src/main/history/history-service.ts
@@ -1,0 +1,179 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { HistoryEntry } from 'shim/objects/history';
+import { TrufosRequest, TrufosResponse } from 'shim';
+import { buildUrl } from 'shim/objects/url';
+import { EnvironmentService } from 'main/environment/service/environment-service';
+import { exists } from 'main/util/fs-util';
+
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'proxy-authorization',
+]);
+
+const MAX_HISTORY_ENTRIES = 100;
+
+export class HistoryService {
+  public static readonly instance = new HistoryService();
+
+  private constructor() {}
+
+  private getHistoryDir(collectionDirPath: string): string {
+    return path.join(collectionDirPath, '.history');
+  }
+
+  /**
+   * Records a request/response entry in the history.
+   * Redacts sensitive headers and limits body/response size.
+   */
+  public async recordEntry(
+    request: TrufosRequest,
+    responseOrError: TrufosResponse | { error: string; duration: number }
+  ): Promise<void> {
+    try {
+      const collection = EnvironmentService.instance.currentCollection;
+      if (!collection || !collection.dirPath) {
+        return;
+      }
+
+      const historyDir = this.getHistoryDir(collection.dirPath);
+      await fs.mkdir(historyDir, { recursive: true });
+
+      // Redact sensitive headers
+      const redactedHeaders = request.headers.map((h) => {
+        const keyLower = h.key.toLowerCase();
+        if (SENSITIVE_HEADERS.has(keyLower)) {
+          return { ...h, value: '***REDACTED***' };
+        }
+        return h;
+      });
+
+      // Get body summary if text body
+      let bodySummary: string | undefined;
+      if (request.body && request.body.type === 'text' && request.body.text) {
+        bodySummary =
+          request.body.text.length > 500
+            ? request.body.text.substring(0, 500) + '...'
+            : request.body.text;
+      }
+
+      const isError = 'error' in responseOrError;
+      const entry: HistoryEntry = {
+        id: randomUUID(),
+        timestamp: Date.now(),
+        request: {
+          url: buildUrl(request.url),
+          method: request.method,
+          headers: redactedHeaders,
+          bodySummary,
+        },
+        response: {
+          status: isError ? 0 : responseOrError.metaInfo.status,
+          duration: isError
+            ? responseOrError.duration
+            : Math.round(responseOrError.metaInfo.duration),
+          size: isError ? 0 : responseOrError.metaInfo.size.totalSizeInBytes,
+          error: isError ? responseOrError.error : undefined,
+        },
+        sourceRequestId: request.id,
+        sourceRequestTitle: request.title,
+      };
+
+      const filename = `${entry.timestamp}_${entry.id}.json`;
+      await fs.writeFile(path.join(historyDir, filename), JSON.stringify(entry, null, 2), 'utf8');
+
+      // Apply retention policy (enforce MAX_HISTORY_ENTRIES limit)
+      await this.enforceRetentionLimit(historyDir);
+    } catch (error) {
+      logger.error('Failed to record history entry:', error);
+    }
+  }
+
+  /**
+   * Loads history entries for the current collection, newest first.
+   */
+  public async loadEntries(limit = MAX_HISTORY_ENTRIES): Promise<HistoryEntry[]> {
+    try {
+      const collection = EnvironmentService.instance.currentCollection;
+      if (!collection || !collection.dirPath) {
+        return [];
+      }
+
+      const historyDir = this.getHistoryDir(collection.dirPath);
+      if (!(await exists(historyDir))) {
+        return [];
+      }
+
+      const files = await fs.readdir(historyDir);
+      const jsonFiles = files.filter((f) => f.endsWith('.json'));
+
+      const entries: HistoryEntry[] = [];
+      for (const file of jsonFiles) {
+        try {
+          const content = await fs.readFile(path.join(historyDir, file), 'utf8');
+          entries.push(HistoryEntry.parse(JSON.parse(content)));
+        } catch (e) {
+          logger.error(`Failed to parse history file ${file}:`, e);
+        }
+      }
+
+      // Sort newest first
+      entries.sort((a, b) => b.timestamp - a.timestamp);
+
+      return entries.slice(0, limit);
+    } catch (error) {
+      logger.error('Failed to load history entries:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Clears all history entries for the current collection.
+   */
+  public async clearHistory(): Promise<void> {
+    try {
+      const collection = EnvironmentService.instance.currentCollection;
+      if (!collection || !collection.dirPath) {
+        return;
+      }
+
+      const historyDir = this.getHistoryDir(collection.dirPath);
+      if (await exists(historyDir)) {
+        await fs.rm(historyDir, { recursive: true, force: true });
+      }
+    } catch (error) {
+      logger.error('Failed to clear history:', error);
+    }
+  }
+
+  private async enforceRetentionLimit(historyDir: string): Promise<void> {
+    try {
+      const files = await fs.readdir(historyDir);
+      const jsonFiles = files.filter((f) => f.endsWith('.json'));
+      if (jsonFiles.length <= MAX_HISTORY_ENTRIES) {
+        return;
+      }
+
+      // Parse and sort files by timestamp from file name or stat
+      const filesWithTimestamp = jsonFiles.map((file) => {
+        const parts = file.split('_');
+        const timestamp = parseInt(parts[0], 10);
+        return { file, timestamp: isNaN(timestamp) ? 0 : timestamp };
+      });
+
+      filesWithTimestamp.sort((a, b) => b.timestamp - a.timestamp); // newest first
+
+      // Delete files beyond the limit
+      const filesToDelete = filesWithTimestamp.slice(MAX_HISTORY_ENTRIES);
+      for (const item of filesToDelete) {
+        await fs.unlink(path.join(historyDir, item.file));
+      }
+    } catch (e) {
+      logger.warn('Failed to enforce history retention limit:', e);
+    }
+  }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10,6 +10,8 @@ import { SettingsService } from './persistence/service/settings-service';
 import { once } from 'node:events';
 import process from 'node:process';
 import { ResponseBodyService } from 'main/network/service/response-body-service';
+import { HistoryService } from 'main/history/history-service';
+import { MainProcessEvent, RendererEvent } from 'shim/event-service';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
@@ -41,6 +43,9 @@ const createWindow = async () => {
     await environmentService.init();
     mainEventService.updateApp(); // check for updates in the background
 
+    // History is ephemeral per session, so schema changes never need migrations.
+    void HistoryService.instance.clearOnStartup(settingsService.settings.collections);
+
     // create the browser window
     const mainWindow = new BrowserWindow({
       ...settingsService.settings.windowState,
@@ -59,7 +64,7 @@ const createWindow = async () => {
     new MenuBuilder(mainWindow).buildMenu();
 
     // show once the renderer has loaded and applied the saved theme
-    once(ipcMain, 'renderer-ready').then(() => mainWindow.show());
+    once(ipcMain, RendererEvent.RendererReady).then(() => mainWindow.show());
 
     // open links in default browser
     mainWindow.webContents.setWindowOpenHandler(({ url }) => {
@@ -73,7 +78,7 @@ const createWindow = async () => {
       if (!isClosing) {
         isClosing = true;
         event.preventDefault();
-        setImmediate(() => mainWindow.webContents.send('before-close'));
+        setImmediate(() => mainWindow.webContents.send(MainProcessEvent.BeforeClose));
 
         async function saveWindowState() {
           try {
@@ -87,7 +92,7 @@ const createWindow = async () => {
 
         // save settings and wait for renderer to be ready to close in parallel
         await Promise.race([
-          Promise.allSettled([saveWindowState(), once(ipcMain, 'ready-to-close')]),
+          Promise.allSettled([saveWindowState(), once(ipcMain, RendererEvent.ReadyToClose)]),
           new Promise((_, reject) =>
             setTimeout(() => reject(new Error('Timeout during close')), 30000)
           ),

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -141,6 +141,21 @@ describe('MenuBuilder', () => {
     }
   );
 
+  it.each(['darwin', 'win32'] as const)(
+    'shows the History item with shortcut in the Collection menu on %s',
+    (platform) => {
+      const template = buildTemplate(platform);
+      const collectionMenu = template.find((item) => item.label?.includes('Collection'))!;
+      const items = collectionMenu.submenu as MenuItemConstructorOptions[];
+      const historyItem = items.find((item) => item.label === 'History')!;
+
+      expect(historyItem.accelerator).toBe('CmdOrCtrl+Shift+H');
+
+      (historyItem.click as () => void)();
+      expect(sendMock).toHaveBeenCalledWith('show-history');
+    }
+  );
+
   it('opens the Trufos documentation and issue tracker from the Help menu', () => {
     const template = buildTemplate('darwin');
     const help = template.find((item) => item.role === 'help')!;

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, Menu, MenuItemConstructorOptions, shell } from 'electron';
+import { MainProcessEvent } from 'shim/event-service';
 
 const REPOSITORY_URL = 'https://github.com/EXXETA/trufos';
 const DOCUMENTATION_URL = `${REPOSITORY_URL}#readme`;
@@ -58,19 +59,19 @@ export class MenuBuilder {
       {
         label: 'Run Collection',
         accelerator: 'CmdOrCtrl+Shift+R',
-        click: () => this.mainWindow.webContents.send('show-collection-runner'),
+        click: () => this.mainWindow.webContents.send(MainProcessEvent.ShowCollectionRunner),
       },
       {
         label: 'History',
         accelerator: 'CmdOrCtrl+Shift+H',
-        click: () => this.mainWindow.webContents.send('show-history'),
+        click: () => this.mainWindow.webContents.send(MainProcessEvent.ShowHistory),
       },
       { type: 'separator' },
       {
         // CmdOrCtrl+, stays reserved for the general app settings.
         label: 'Settings…',
         accelerator: 'CmdOrCtrl+Shift+,',
-        click: () => this.mainWindow.webContents.send('show-collection-settings'),
+        click: () => this.mainWindow.webContents.send(MainProcessEvent.ShowCollectionSettings),
       },
     ];
   }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -60,6 +60,11 @@ export class MenuBuilder {
         accelerator: 'CmdOrCtrl+Shift+R',
         click: () => this.mainWindow.webContents.send('show-collection-runner'),
       },
+      {
+        label: 'History',
+        accelerator: 'CmdOrCtrl+Shift+H',
+        click: () => this.mainWindow.webContents.send('show-history'),
+      },
       { type: 'separator' },
       {
         // CmdOrCtrl+, stays reserved for the general app settings.

--- a/src/main/persistence/service/info-files/v2-0-0.ts
+++ b/src/main/persistence/service/info-files/v2-0-0.ts
@@ -119,5 +119,5 @@ export class InfoFileMigrator extends AbstractInfoFileMigrator<OldInfoFile, Info
 export async function createGitIgnore(dirPath: string) {
   const filePath = path.join(dirPath, GIT_IGNORE_FILE_NAME);
   logger.info(`Creating .gitignore file at`, filePath);
-  await fs.writeFile(filePath, ['.draft', '.secrets.bin'].join('\n'));
+  await fs.writeFile(filePath, ['.draft', '.secrets.bin', '.history'].join('\n'));
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -31,7 +31,8 @@ export const App = () => {
     // Entry points of the native application menu (Collection > ...).
     RendererEventService.instance
       .on('show-collection-runner', () => useViewStore.getState().openCollectionRunner())
-      .on('show-collection-settings', () => useViewStore.getState().openCollectionSettings());
+      .on('show-collection-settings', () => useViewStore.getState().openCollectionSettings())
+      .on('show-history', () => useViewStore.getState().setSidebarTab('history'));
 
     RendererEventService.instance
       .getAppSettings()

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,6 +10,7 @@ import { ResizablePanel, ResizablePanelGroup, ResizableHandle } from '@/componen
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { CollectionStoreProvider } from '@/state/CollectionStoreProvider';
 import { RendererEventService } from '@/services/event/renderer-event-service';
+import { MainProcessEvent, RendererEvent } from 'shim/event-service';
 import { useAppSettingsStore } from '@/state/appSettingsStore';
 import {
   selectIsCollectionRunnerOpen,
@@ -30,9 +31,13 @@ export const App = () => {
   useEffect(() => {
     // Entry points of the native application menu (Collection > ...).
     RendererEventService.instance
-      .on('show-collection-runner', () => useViewStore.getState().openCollectionRunner())
-      .on('show-collection-settings', () => useViewStore.getState().openCollectionSettings())
-      .on('show-history', () => useViewStore.getState().setSidebarTab('history'));
+      .on(MainProcessEvent.ShowCollectionRunner, () =>
+        useViewStore.getState().openCollectionRunner()
+      )
+      .on(MainProcessEvent.ShowCollectionSettings, () =>
+        useViewStore.getState().openCollectionSettings()
+      )
+      .on(MainProcessEvent.ShowHistory, () => useViewStore.getState().setSidebarTab('history'));
 
     RendererEventService.instance
       .getAppSettings()
@@ -43,7 +48,7 @@ export const App = () => {
         if (settings) {
           useAppSettingsStore.getState().initialize(settings);
         }
-        window.electron.ipcRenderer.send('renderer-ready');
+        window.electron.ipcRenderer.send(RendererEvent.RendererReady);
       });
   }, []);
 

--- a/src/renderer/components/mainWindow/responseStatus/ResponseStatus.tsx
+++ b/src/renderer/components/mainWindow/responseStatus/ResponseStatus.tsx
@@ -1,9 +1,8 @@
 import {
-  getDurationTextInSec,
   getHttpStatusColorClass,
   getHttpStatusText,
-  getSizeText,
 } from '@/components/mainWindow/responseStatus/ResponseStatusFormatter';
+import { getDurationTextInSec, getSizeText } from '@/util/format-util';
 import { selectResponse, useResponseStore } from '@/state/responseStore';
 import { useCollectionStore } from '@/state/collectionStore';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';

--- a/src/renderer/components/mainWindow/responseStatus/ResponseStatusFormatter.test.ts
+++ b/src/renderer/components/mainWindow/responseStatus/ResponseStatusFormatter.test.ts
@@ -1,9 +1,4 @@
-import {
-  getDurationTextInSec,
-  getHttpStatusColorClass,
-  getHttpStatusText,
-  getSizeText,
-} from './ResponseStatusFormatter';
+import { getHttpStatusColorClass, getHttpStatusText } from './ResponseStatusFormatter';
 import { describe, it, expect } from 'vitest';
 
 describe('ResponseStatusFormatter', () => {
@@ -23,13 +18,6 @@ describe('ResponseStatusFormatter', () => {
     });
   });
 
-  describe('getDurationTextinSec', () => {
-    it('converts milliseconds to seconds with two decimal places', () => {
-      expect(getDurationTextInSec(1234)).toBe('1.23 s');
-      expect(getDurationTextInSec(1000)).toBe('1.00 s');
-    });
-  });
-
   describe('getHttpStatusText', () => {
     it('returns the status text for known status codes', () => {
       expect(getHttpStatusText(200)).toBe('200 OK');
@@ -38,36 +26,6 @@ describe('ResponseStatusFormatter', () => {
 
     it('returns the status code as string for unknown status codes', () => {
       expect(getHttpStatusText(999)).toBe('999');
-    });
-  });
-
-  describe('getSizeText', () => {
-    it('converts bytes to kilobytes with two decimal places', () => {
-      expect(getSizeText(1024)).toBe('1.02 KB');
-      expect(getSizeText(2048)).toBe('2.05 KB');
-    });
-
-    it('converts bytes to megabytes with two decimal places', () => {
-      expect(getSizeText(1048576)).toBe('1.05 MB');
-      expect(getSizeText(2097152)).toBe('2.10 MB');
-    });
-
-    it('converts bytes to gigabytes with two decimal places', () => {
-      expect(getSizeText(1073741824)).toBe('1.07 GB');
-      expect(getSizeText(2147483648)).toBe('2.15 GB');
-    });
-
-    it('converts bytes to terabytes with two decimal places', () => {
-      expect(getSizeText(1099511627776)).toBe('1.10 TB');
-      expect(getSizeText(2199023255552)).toBe('2.20 TB');
-    });
-
-    it('returns bytes without conversion if less than 1000', () => {
-      expect(getSizeText(999)).toBe('999 B');
-    });
-
-    it('handles edge case of exactly 1000 bytes', () => {
-      expect(getSizeText(1000)).toBe('1.00 KB');
     });
   });
 });

--- a/src/renderer/components/mainWindow/responseStatus/ResponseStatusFormatter.ts
+++ b/src/renderer/components/mainWindow/responseStatus/ResponseStatusFormatter.ts
@@ -8,30 +8,12 @@ export function getHttpStatusColorClass(statusCode: number) {
   return 'neutral';
 }
 
-export function getDurationTextInSec(durationMs: number) {
-  return `${(durationMs / 1000).toFixed(2)} s`;
-}
-
 export function getHttpStatusText(statusCode: number) {
   if (!(statusCode in HTTP_STATUS_NAME)) {
     return statusCode.toString();
   }
   const statusKey = statusCode as keyof typeof HTTP_STATUS_NAME;
   return `${statusCode} ${HTTP_STATUS_NAME[statusKey]}`;
-}
-
-export function getSizeText(sizeInByte: number) {
-  const units = ['', 'K', 'M', 'G', 'T'];
-  let size = sizeInByte;
-
-  let i = 0;
-  for (; i < units.length && size >= 1e3; i++) {
-    size /= 1e3;
-  }
-
-  const sizeWithDigits = i == 0 ? size : size.toFixed(2);
-
-  return `${sizeWithDigits} ${units[i]}B`;
 }
 
 const HTTP_STATUS_NAME = {

--- a/src/renderer/services/event/renderer-event-service.ts
+++ b/src/renderer/services/event/renderer-event-service.ts
@@ -1,5 +1,6 @@
 import { MainProcessError } from '@/error/MainProcessError';
-import { IEventService } from 'shim/event-service';
+import { IEventService, MainProcessEvent, RendererEvent } from 'shim/event-service';
+import type { EnvironmentMap, VariableMap } from 'shim/objects';
 
 /**
  * Creates a method that sends an IPC event to the main process and returns the result. If the
@@ -23,23 +24,28 @@ function createEventMethod<T extends keyof IEventService>(methodName: T) {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface RendererEventService {
-  on(event: 'before-close', listener: () => void): this;
+  on(
+    event: MainProcessEvent.CollectionVariablesUpdated,
+    listener: (
+      event: unknown,
+      data: { variables: VariableMap; environments: EnvironmentMap }
+    ) => void
+  ): this;
 
-  on(event: 'show-collection-runner', listener: () => void): this;
+  on(
+    event: Exclude<MainProcessEvent, MainProcessEvent.CollectionVariablesUpdated>,
+    listener: () => void
+  ): this;
 
-  on(event: 'show-collection-settings', listener: () => void): this;
-
-  on(event: 'show-history', listener: () => void): this;
-
-  emit(event: 'ready-to-close'): this;
+  emit(event: RendererEvent.ReadyToClose): this;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class RendererEventService implements IEventService {
   public static readonly instance = new RendererEventService();
 
-  on(event: string, listener: (...args: unknown[]) => void) {
-    window.electron.ipcRenderer.on(event, listener);
+  on(event: string, listener: (...args: never[]) => void) {
+    window.electron.ipcRenderer.on(event, listener as (...args: unknown[]) => void);
     return this;
   }
 

--- a/src/renderer/services/event/renderer-event-service.ts
+++ b/src/renderer/services/event/renderer-event-service.ts
@@ -29,6 +29,8 @@ export interface RendererEventService {
 
   on(event: 'show-collection-settings', listener: () => void): this;
 
+  on(event: 'show-history', listener: () => void): this;
+
   emit(event: 'ready-to-close'): this;
 }
 
@@ -78,4 +80,6 @@ export class RendererEventService implements IEventService {
   setClientCertificate = createEventMethod('setClientCertificate');
   getAppSettings = createEventMethod('getAppSettings');
   saveAppSettings = createEventMethod('saveAppSettings');
+  getHistory = createEventMethod('getHistory');
+  clearHistory = createEventMethod('clearHistory');
 }

--- a/src/renderer/services/http/http-service.ts
+++ b/src/renderer/services/http/http-service.ts
@@ -19,11 +19,9 @@ export class HttpService {
       console.info('Sending request:', request);
       const response = await eventService.sendRequest(request, abortKey);
       console.info('Received response:', response);
-      void useHistoryStore.getState().loadHistory();
       return response;
     } catch (error) {
       console.error('Error during request:', error);
-      void useHistoryStore.getState().loadHistory();
       let description = 'An error occurred while sending the request';
       if (error instanceof DisplayableError) {
         throw error;
@@ -35,6 +33,9 @@ export class HttpService {
         }
       }
       throw new DisplayableError(description, 'Could not send Request', error);
+    } finally {
+      // The main process records a history entry for both outcomes.
+      void useHistoryStore.getState().loadHistory();
     }
   }
 

--- a/src/renderer/services/http/http-service.ts
+++ b/src/renderer/services/http/http-service.ts
@@ -1,6 +1,7 @@
 import { RendererEventService } from '@/services/event/renderer-event-service';
 import { DisplayableError } from '@/error/DisplayableError';
 import { TrufosRequest } from 'shim/objects/request';
+import { useHistoryStore } from '@/state/historyStore';
 
 const eventService = RendererEventService.instance;
 
@@ -18,9 +19,11 @@ export class HttpService {
       console.info('Sending request:', request);
       const response = await eventService.sendRequest(request, abortKey);
       console.info('Received response:', response);
+      void useHistoryStore.getState().loadHistory();
       return response;
     } catch (error) {
       console.error('Error during request:', error);
+      void useHistoryStore.getState().loadHistory();
       let description = 'An error occurred while sending the request';
       if (error instanceof DisplayableError) {
         throw error;

--- a/src/renderer/state/CollectionStoreProvider.tsx
+++ b/src/renderer/state/CollectionStoreProvider.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, FC, PropsWithChildren } from 'react';
 import { Loader2 } from 'lucide-react';
 import { RendererEventService } from '@/services/event/renderer-event-service';
+import { MainProcessEvent, RendererEvent } from 'shim/event-service';
 import {
   createCollectionStore,
   CollectionStoreProvider as StoreProvider,
@@ -26,9 +27,8 @@ export const CollectionStoreProvider: FC<PropsWithChildren> = ({ children }) => 
         storeRef.current = createCollectionStore(collection);
 
         // Sync variables changed by scripts back to the frontend stores
-        // @ts-expect-error listener receives ipcEvent + payload but on() only types ...unknown[]
         rendererEventService.on(
-          'collection-variables-updated',
+          MainProcessEvent.CollectionVariablesUpdated,
           (_ipcEvent, { variables, environments }) => {
             useVariableStore.getState().initialize(variables);
             useEnvironmentStore.getState().initialize(environments);
@@ -36,14 +36,14 @@ export const CollectionStoreProvider: FC<PropsWithChildren> = ({ children }) => 
         );
 
         // Set up before-close handler: flush all active editor models to disk
-        rendererEventService.on('before-close', async () => {
+        rendererEventService.on(MainProcessEvent.BeforeClose, async () => {
           try {
             console.info('Saving all active editor models before close');
             await Promise.all(editor.getModels().map(saveModelContent));
           } catch (error) {
             console.error('Error while saving models before closing:', error);
           } finally {
-            rendererEventService.emit('ready-to-close');
+            rendererEventService.emit(RendererEvent.ReadyToClose);
           }
         });
 

--- a/src/renderer/state/historyStore.test.ts
+++ b/src/renderer/state/historyStore.test.ts
@@ -1,5 +1,6 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { useHistoryStore } from './historyStore';
+import { RequestMethod } from 'shim/objects/request-method';
 
 const getHistoryMock = vi.fn();
 const clearHistoryMock = vi.fn().mockResolvedValue(undefined);
@@ -57,7 +58,7 @@ describe('historyStore', () => {
           {
             id: '1',
             timestamp: 12345,
-            request: { url: 'http://example.com', method: 'GET', headers: [] },
+            request: { url: 'http://example.com', method: RequestMethod.GET, headers: [] },
             response: { status: 200, duration: 100, size: 50 },
           },
         ],

--- a/src/renderer/state/historyStore.test.ts
+++ b/src/renderer/state/historyStore.test.ts
@@ -1,0 +1,71 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useHistoryStore } from './historyStore';
+
+const getHistoryMock = vi.fn();
+const clearHistoryMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/services/event/renderer-event-service', () => ({
+  RendererEventService: {
+    instance: {
+      getHistory: () => getHistoryMock(),
+      clearHistory: () => clearHistoryMock(),
+    },
+  },
+}));
+
+describe('historyStore', () => {
+  beforeEach(() => {
+    getHistoryMock.mockClear();
+    clearHistoryMock.mockClear();
+    useHistoryStore.setState({ entries: [], isLoading: false });
+  });
+
+  describe('loadHistory', () => {
+    it('sets loading state and retrieves entries', async () => {
+      const mockEntries = [
+        {
+          id: '1',
+          timestamp: 12345,
+          request: { url: 'http://example.com', method: 'GET', headers: [] },
+          response: { status: 200, duration: 100, size: 50 },
+        },
+      ];
+      getHistoryMock.mockResolvedValue(mockEntries);
+
+      const promise = useHistoryStore.getState().loadHistory();
+      expect(useHistoryStore.getState().isLoading).toBe(true);
+
+      await promise;
+      expect(useHistoryStore.getState().isLoading).toBe(false);
+      expect(useHistoryStore.getState().entries).toEqual(mockEntries);
+      expect(getHistoryMock).toHaveBeenCalled();
+    });
+
+    it('handles errors gracefully', async () => {
+      getHistoryMock.mockRejectedValue(new Error('IPC failed'));
+
+      await useHistoryStore.getState().loadHistory();
+      expect(useHistoryStore.getState().isLoading).toBe(false);
+      expect(useHistoryStore.getState().entries).toEqual([]);
+    });
+  });
+
+  describe('clearHistory', () => {
+    it('notifies IPC and clears entries from state', async () => {
+      useHistoryStore.setState({
+        entries: [
+          {
+            id: '1',
+            timestamp: 12345,
+            request: { url: 'http://example.com', method: 'GET', headers: [] },
+            response: { status: 200, duration: 100, size: 50 },
+          },
+        ],
+      });
+
+      await useHistoryStore.getState().clearHistory();
+      expect(useHistoryStore.getState().entries).toEqual([]);
+      expect(clearHistoryMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/renderer/state/historyStore.ts
+++ b/src/renderer/state/historyStore.ts
@@ -1,0 +1,57 @@
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import type { HistoryEntry } from 'shim/objects/history';
+import { useActions } from '@/state/helper/util';
+import { RendererEventService } from '@/services/event/renderer-event-service';
+
+const eventService = RendererEventService.instance;
+
+interface HistoryState {
+  entries: HistoryEntry[];
+  isLoading: boolean;
+}
+
+interface HistoryActions {
+  loadHistory(): Promise<void>;
+  clearHistory(): Promise<void>;
+}
+
+export const useHistoryStore = create<HistoryState & HistoryActions>()(
+  immer((set) => ({
+    entries: [],
+    isLoading: false,
+
+    async loadHistory() {
+      set((state) => {
+        state.isLoading = true;
+      });
+      try {
+        const entries = await eventService.getHistory();
+        set((state) => {
+          state.entries = entries;
+          state.isLoading = false;
+        });
+      } catch (error) {
+        console.error('Failed to load history:', error);
+        set((state) => {
+          state.isLoading = false;
+        });
+      }
+    },
+
+    async clearHistory() {
+      try {
+        await eventService.clearHistory();
+        set((state) => {
+          state.entries = [];
+        });
+      } catch (error) {
+        console.error('Failed to clear history:', error);
+      }
+    },
+  }))
+);
+
+export const selectHistoryEntries = (state: HistoryState) => state.entries;
+export const selectHistoryIsLoading = (state: HistoryState) => state.isLoading;
+export const useHistoryActions = () => useHistoryStore(useActions());

--- a/src/renderer/state/viewStore.ts
+++ b/src/renderer/state/viewStore.ts
@@ -2,11 +2,15 @@ import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { useActions } from '@/state/helper/util';
 
+export type SidebarTab = 'requests' | 'history';
+
 interface ViewState {
   /** Whether the collection runner modal is open */
   isCollectionRunnerOpen: boolean;
   /** Whether the collection settings modal is open */
   isCollectionSettingsOpen: boolean;
+  /** The active tab of the sidebar (request list or history panel) */
+  sidebarTab: SidebarTab;
 }
 
 interface ViewActions {
@@ -14,12 +18,14 @@ interface ViewActions {
   closeCollectionRunner(): void;
   openCollectionSettings(): void;
   closeCollectionSettings(): void;
+  setSidebarTab(tab: SidebarTab): void;
 }
 
 export const useViewStore = create<ViewState & ViewActions>()(
   immer((set) => ({
     isCollectionRunnerOpen: false,
     isCollectionSettingsOpen: false,
+    sidebarTab: 'requests',
 
     openCollectionRunner() {
       set((state) => {
@@ -44,9 +50,16 @@ export const useViewStore = create<ViewState & ViewActions>()(
         state.isCollectionSettingsOpen = false;
       });
     },
+
+    setSidebarTab(tab: SidebarTab) {
+      set((state) => {
+        state.sidebarTab = tab;
+      });
+    },
   }))
 );
 
 export const selectIsCollectionRunnerOpen = (state: ViewState) => state.isCollectionRunnerOpen;
 export const selectIsCollectionSettingsOpen = (state: ViewState) => state.isCollectionSettingsOpen;
+export const selectSidebarTab = (state: ViewState) => state.sidebarTab;
 export const useViewActions = (): ViewActions => useViewStore(useActions());

--- a/src/renderer/util/format-util.test.ts
+++ b/src/renderer/util/format-util.test.ts
@@ -1,0 +1,41 @@
+import { getDurationTextInSec, getSizeText } from './format-util';
+import { describe, it, expect } from 'vitest';
+
+describe('format-util', () => {
+  describe('getDurationTextInSec', () => {
+    it('converts milliseconds to seconds with two decimal places', () => {
+      expect(getDurationTextInSec(1234)).toBe('1.23 s');
+      expect(getDurationTextInSec(1000)).toBe('1.00 s');
+    });
+  });
+
+  describe('getSizeText', () => {
+    it('converts bytes to kilobytes with two decimal places', () => {
+      expect(getSizeText(1024)).toBe('1.02 KB');
+      expect(getSizeText(2048)).toBe('2.05 KB');
+    });
+
+    it('converts bytes to megabytes with two decimal places', () => {
+      expect(getSizeText(1048576)).toBe('1.05 MB');
+      expect(getSizeText(2097152)).toBe('2.10 MB');
+    });
+
+    it('converts bytes to gigabytes with two decimal places', () => {
+      expect(getSizeText(1073741824)).toBe('1.07 GB');
+      expect(getSizeText(2147483648)).toBe('2.15 GB');
+    });
+
+    it('converts bytes to terabytes with two decimal places', () => {
+      expect(getSizeText(1099511627776)).toBe('1.10 TB');
+      expect(getSizeText(2199023255552)).toBe('2.20 TB');
+    });
+
+    it('returns bytes without conversion if less than 1000', () => {
+      expect(getSizeText(999)).toBe('999 B');
+    });
+
+    it('handles edge case of exactly 1000 bytes', () => {
+      expect(getSizeText(1000)).toBe('1.00 KB');
+    });
+  });
+});

--- a/src/renderer/util/format-util.ts
+++ b/src/renderer/util/format-util.ts
@@ -1,0 +1,48 @@
+/**
+ * Formats a byte count as a human readable size, e.g. `1.23 KB`.
+ * @param sizeInByte The size in bytes.
+ */
+export function getSizeText(sizeInByte: number) {
+  const units = ['', 'K', 'M', 'G', 'T'];
+  let size = sizeInByte;
+
+  let i = 0;
+  for (; i < units.length && size >= 1e3; i++) {
+    size /= 1e3;
+  }
+
+  const sizeWithDigits = i == 0 ? size : size.toFixed(2);
+
+  return `${sizeWithDigits} ${units[i]}B`;
+}
+
+/**
+ * Formats a duration in milliseconds as seconds with two digits, e.g. `1.23 s`.
+ * @param durationMs The duration in milliseconds.
+ */
+export function getDurationTextInSec(durationMs: number) {
+  return `${(durationMs / 1000).toFixed(2)} s`;
+}
+
+/**
+ * Formats a timestamp as a localized time, e.g. `14:05:59`.
+ * @param timestamp The timestamp in milliseconds since the epoch.
+ */
+export function getTimeText(timestamp: number) {
+  return new Date(timestamp).toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+/**
+ * Formats a timestamp as a short localized date, e.g. `Jul 9`.
+ * @param timestamp The timestamp in milliseconds since the epoch.
+ */
+export function getDateText(timestamp: number) {
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}

--- a/src/renderer/view/HistoryPanel.tsx
+++ b/src/renderer/view/HistoryPanel.tsx
@@ -12,6 +12,7 @@ import { Trash2, RotateCw, Clock, ArrowUpRight, X } from 'lucide-react';
 import { httpMethodColor } from '@/services/StyleHelper';
 import { cn } from '@/lib/utils';
 import { parseUrl } from 'shim/objects/url';
+import { getDateText, getSizeText, getTimeText } from '@/util/format-util';
 
 export const HistoryPanel = () => {
   const entries = useHistoryStore(selectHistoryEntries);
@@ -33,49 +34,21 @@ export const HistoryPanel = () => {
     }
   };
 
+  // Restoring intentionally edits the original request (it becomes a draft, like
+  // any manual edit would). It is only offered while that request still exists
+  // and only via the explicit restore button, never as a side effect of merely
+  // clicking a history entry.
   const handleRestore = (entry: (typeof entries)[number]) => {
-    // If the original request exists in the current collection, select it first
-    let targetRequestId = selectedRequestId;
-    if (entry.sourceRequestId && requests.has(entry.sourceRequestId)) {
+    if (!entry.sourceRequestId || !requests.has(entry.sourceRequestId)) return;
+
+    if (entry.sourceRequestId !== selectedRequestId) {
       setSelectedRequest(entry.sourceRequestId);
-      targetRequestId = entry.sourceRequestId;
     }
-
-    if (!targetRequestId) {
-      alert('Please select or create a request to restore these details into.');
-      return;
-    }
-
-    // Parse the URL and update the request
-    const parsedUrl = parseUrl(entry.request.url);
     updateRequest({
-      url: parsedUrl,
+      url: parseUrl(entry.request.url),
       method: entry.request.method,
       headers: entry.request.headers,
     });
-  };
-
-  const formatTime = (timestamp: number) => {
-    return new Date(timestamp).toLocaleTimeString(undefined, {
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-    });
-  };
-
-  const formatDate = (timestamp: number) => {
-    return new Date(timestamp).toLocaleDateString(undefined, {
-      month: 'short',
-      day: 'numeric',
-    });
-  };
-
-  const formatSize = (bytes: number) => {
-    if (bytes === 0) return '0 B';
-    const k = 1024;
-    const sizes = ['B', 'KB', 'MB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
   };
 
   return (
@@ -130,12 +103,12 @@ export const HistoryPanel = () => {
           </div>
         ) : (
           entries.map((entry) => {
-            const hasOriginal = entry.sourceRequestId && requests.has(entry.sourceRequestId);
+            const hasOriginal =
+              entry.sourceRequestId != null && requests.has(entry.sourceRequestId);
             return (
               <div
                 key={entry.id}
-                className="group hover:bg-sidebar-accent hover:border-border relative flex cursor-pointer flex-col rounded-lg border border-transparent p-2.5 transition-all duration-200"
-                onClick={() => handleRestore(entry)}
+                className="group hover:bg-sidebar-accent hover:border-border relative flex flex-col rounded-lg border border-transparent p-2.5 transition-all duration-200"
               >
                 <div className="mb-1 flex items-center justify-between">
                   <span
@@ -147,8 +120,8 @@ export const HistoryPanel = () => {
                     {entry.request.method}
                   </span>
                   <div className="text-text-secondary flex items-center gap-1.5 text-[10px]">
-                    <span>{formatDate(entry.timestamp)}</span>
-                    <span>{formatTime(entry.timestamp)}</span>
+                    <span>{getDateText(entry.timestamp)}</span>
+                    <span>{getTimeText(entry.timestamp)}</span>
                   </div>
                 </div>
 
@@ -181,7 +154,7 @@ export const HistoryPanel = () => {
                     {entry.response.size > 0 && (
                       <>
                         <span>•</span>
-                        <span>{formatSize(entry.response.size)}</span>
+                        <span>{getSizeText(entry.response.size)}</span>
                       </>
                     )}
                   </div>
@@ -197,9 +170,14 @@ export const HistoryPanel = () => {
                     size="icon"
                     variant="secondary"
                     className="border-border h-6 w-6 rounded-md border shadow-sm"
+                    onClick={() => handleRestore(entry)}
+                    disabled={!hasOriginal}
                     title={
-                      hasOriginal ? 'Restore to original request' : 'Restore to selected request'
+                      hasOriginal
+                        ? 'Restore to original request'
+                        : 'The original request no longer exists'
                     }
+                    aria-label="Restore request"
                   >
                     <ArrowUpRight className="h-3.5 w-3.5" />
                   </Button>

--- a/src/renderer/view/HistoryPanel.tsx
+++ b/src/renderer/view/HistoryPanel.tsx
@@ -1,0 +1,214 @@
+import React, { useEffect } from 'react';
+import {
+  useHistoryStore,
+  selectHistoryEntries,
+  selectHistoryIsLoading,
+} from '@/state/historyStore';
+import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
+import { useViewActions } from '@/state/viewStore';
+import { SidebarContent } from '@/components/ui/sidebar';
+import { Button } from '@/components/ui/button';
+import { Trash2, RotateCw, Clock, ArrowUpRight, X } from 'lucide-react';
+import { httpMethodColor } from '@/services/StyleHelper';
+import { cn } from '@/lib/utils';
+import { parseUrl } from 'shim/objects/url';
+
+export const HistoryPanel = () => {
+  const entries = useHistoryStore(selectHistoryEntries);
+  const isLoading = useHistoryStore(selectHistoryIsLoading);
+  const { loadHistory, clearHistory } = useHistoryStore();
+  const { setSidebarTab } = useViewActions();
+
+  const requests = useCollectionStore((state) => state.requests);
+  const selectedRequestId = useCollectionStore((state) => state.selectedRequestId);
+  const { setSelectedRequest, updateRequest } = useCollectionActions();
+
+  useEffect(() => {
+    void loadHistory();
+  }, [loadHistory]);
+
+  const handleClearHistory = () => {
+    if (window.confirm('Are you sure you want to clear the request history?')) {
+      void clearHistory();
+    }
+  };
+
+  const handleRestore = (entry: (typeof entries)[number]) => {
+    // If the original request exists in the current collection, select it first
+    let targetRequestId = selectedRequestId;
+    if (entry.sourceRequestId && requests.has(entry.sourceRequestId)) {
+      setSelectedRequest(entry.sourceRequestId);
+      targetRequestId = entry.sourceRequestId;
+    }
+
+    if (!targetRequestId) {
+      alert('Please select or create a request to restore these details into.');
+      return;
+    }
+
+    // Parse the URL and update the request
+    const parsedUrl = parseUrl(entry.request.url);
+    updateRequest({
+      url: parsedUrl,
+      method: entry.request.method,
+      headers: entry.request.headers,
+    });
+  };
+
+  const formatTime = (timestamp: number) => {
+    return new Date(timestamp).toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  };
+
+  const formatDate = (timestamp: number) => {
+    return new Date(timestamp).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  const formatSize = (bytes: number) => {
+    if (bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+  };
+
+  return (
+    <SidebarContent className="flex h-full flex-col overflow-hidden">
+      <div className="border-border flex shrink-0 items-center justify-between border-b px-2 py-3">
+        <div className="flex items-center gap-2">
+          <Clock className="text-text-secondary h-4 w-4" />
+          <span className="text-sm font-semibold">Request History</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-text-secondary hover:text-text-primary h-7 w-7"
+            onClick={() => void loadHistory()}
+            disabled={isLoading}
+            title="Refresh History"
+          >
+            <RotateCw className={cn('h-3.5 w-3.5', isLoading && 'animate-spin')} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-text-secondary hover:text-danger h-7 w-7"
+            onClick={handleClearHistory}
+            disabled={entries.length === 0}
+            title="Clear History"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-text-secondary hover:text-text-primary h-7 w-7"
+            onClick={() => setSidebarTab('requests')}
+            title="Close History"
+            aria-label="Close History"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex-1 space-y-2 overflow-y-auto py-2 pr-1">
+        {entries.length === 0 ? (
+          <div className="flex h-40 flex-col items-center justify-center p-4 text-center">
+            <Clock className="text-text-secondary/40 mb-2 h-8 w-8" />
+            <p className="text-text-secondary text-sm font-medium">No history yet</p>
+            <p className="text-text-secondary/60 mt-1 text-xs">
+              Requests you send will appear here.
+            </p>
+          </div>
+        ) : (
+          entries.map((entry) => {
+            const hasOriginal = entry.sourceRequestId && requests.has(entry.sourceRequestId);
+            return (
+              <div
+                key={entry.id}
+                className="group hover:bg-sidebar-accent hover:border-border relative flex cursor-pointer flex-col rounded-lg border border-transparent p-2.5 transition-all duration-200"
+                onClick={() => handleRestore(entry)}
+              >
+                <div className="mb-1 flex items-center justify-between">
+                  <span
+                    className={cn(
+                      'text-[10px] font-bold tracking-wider uppercase',
+                      httpMethodColor(entry.request.method)
+                    )}
+                  >
+                    {entry.request.method}
+                  </span>
+                  <div className="text-text-secondary flex items-center gap-1.5 text-[10px]">
+                    <span>{formatDate(entry.timestamp)}</span>
+                    <span>{formatTime(entry.timestamp)}</span>
+                  </div>
+                </div>
+
+                <div
+                  className="text-text-primary mb-1 truncate pr-6 text-xs font-medium"
+                  title={entry.request.url}
+                >
+                  {entry.request.url}
+                </div>
+
+                <div className="text-text-secondary flex items-center justify-between text-[10px]">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        'font-semibold',
+                        entry.response.status >= 200 &&
+                          entry.response.status < 300 &&
+                          'text-state-success',
+                        entry.response.status >= 300 &&
+                          entry.response.status < 400 &&
+                          'text-text-secondary',
+                        entry.response.status >= 400 && 'text-danger',
+                        entry.response.status === 0 && 'text-danger'
+                      )}
+                    >
+                      {entry.response.status === 0 ? 'ERR' : entry.response.status}
+                    </span>
+                    <span>•</span>
+                    <span>{entry.response.duration} ms</span>
+                    {entry.response.size > 0 && (
+                      <>
+                        <span>•</span>
+                        <span>{formatSize(entry.response.size)}</span>
+                      </>
+                    )}
+                  </div>
+                  {entry.sourceRequestTitle && (
+                    <span className="bg-background-secondary border-border max-w-[120px] truncate rounded border px-1 text-[9px]">
+                      {entry.sourceRequestTitle}
+                    </span>
+                  )}
+                </div>
+
+                <div className="absolute top-1/2 right-2.5 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100">
+                  <Button
+                    size="icon"
+                    variant="secondary"
+                    className="border-border h-6 w-6 rounded-md border shadow-sm"
+                    title={
+                      hasOriginal ? 'Restore to original request' : 'Restore to selected request'
+                    }
+                  >
+                    <ArrowUpRight className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </SidebarContent>
+  );
+};

--- a/src/renderer/view/Menubar.tsx
+++ b/src/renderer/view/Menubar.tsx
@@ -3,15 +3,26 @@ import { Sidebar } from '@/components/ui/sidebar';
 import { FooterBar } from '@/components/sidebar/FooterBar';
 import { SidebarHeaderBar } from '@/components/sidebar/SidebarHeaderBar';
 import { SidebarRequestList } from '@/components/sidebar/SidebarRequestList/SidebarRequestList';
+import { HistoryPanel } from '@/view/HistoryPanel';
+import { selectSidebarTab, useViewStore } from '@/state/viewStore';
 import type { CreatingItem } from '@/components/sidebar/SidebarRequestList/types';
 
 export const Menubar = () => {
   const [creatingItem, setCreatingItem] = useState<CreatingItem>(null);
+  const sidebarTab = useViewStore(selectSidebarTab);
 
   return (
     <Sidebar className={'flex h-screen flex-col p-6'} collapsible={'none'}>
-      <SidebarHeaderBar onCreateItem={setCreatingItem} />
-      <SidebarRequestList creatingItem={creatingItem} onCreateItem={setCreatingItem} />
+      {sidebarTab === 'requests' ? (
+        <>
+          <SidebarHeaderBar onCreateItem={setCreatingItem} />
+          <SidebarRequestList creatingItem={creatingItem} onCreateItem={setCreatingItem} />
+        </>
+      ) : (
+        // The history view intentionally hides the header bar so the collection
+        // cannot be switched while browsing the history of the current one.
+        <HistoryPanel />
+      )}
       <FooterBar />
     </Sidebar>
   );

--- a/src/renderer/view/RequestWindow.tsx
+++ b/src/renderer/view/RequestWindow.tsx
@@ -1,6 +1,7 @@
 import { MainTopBar } from '@/components/mainWindow/MainTopBar';
 import { MainBody } from '@/components/mainWindow/MainBody';
 import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
+import { selectSidebarTab, useViewStore } from '@/state/viewStore';
 import { EmptyWildWest } from '@/assets/EmptyWildWest';
 import { MouseEvent, useCallback, useEffect, useRef } from 'react';
 import { registerGetRequest } from '@/lib/monaco/models';
@@ -11,6 +12,7 @@ export function RequestWindow() {
   const selectedRequestId = useCollectionStore((state) => state.selectedRequestId);
   const requests = useCollectionStore((state) => state.requests);
   const { addNewRequest } = useCollectionActions();
+  const sidebarTab = useViewStore(selectSidebarTab);
 
   // Register the getRequest callback once so onWillDisposeModel can resolve requests.
   const requestsRef = useRef(requests);
@@ -43,15 +45,20 @@ export function RequestWindow() {
     return (
       <div className="flex h-full w-full flex-col items-center justify-center p-6">
         <EmptyWildWest />
-        <span className="mt-2 text-center">
-          <a
-            className="text-accent-primary mr-1 cursor-pointer underline"
-            onClick={handleAddNewRequest}
-          >
-            Create
-          </a>
-          or select a request to get started
-        </span>
+        {sidebarTab === 'history' ? (
+          // Creating a request makes no sense while browsing the history.
+          <span className="mt-2 text-center">Select a history entry to restore it</span>
+        ) : (
+          <span className="mt-2 text-center">
+            <a
+              className="text-accent-primary mr-1 cursor-pointer underline"
+              onClick={handleAddNewRequest}
+            >
+              Create
+            </a>
+            or select a request to get started
+          </span>
+        )}
       </div>
     );
   }

--- a/src/shim/event-service.ts
+++ b/src/shim/event-service.ts
@@ -9,6 +9,7 @@ import {
   VariableObject,
   EnvironmentMap,
   ClientCertificate,
+  HistoryEntry,
 } from './objects';
 import { ScriptType } from './scripting';
 import { AppSettings } from './app-settings';
@@ -256,4 +257,14 @@ export interface IEventService {
    * @param settings The new application settings.
    */
   saveAppSettings(settings: AppSettings): Promise<void>;
+
+  /**
+   * Get request history entries.
+   */
+  getHistory(limit?: number): Promise<HistoryEntry[]>;
+
+  /**
+   * Clear request history.
+   */
+  clearHistory(): Promise<void>;
 }

--- a/src/shim/event-service.ts
+++ b/src/shim/event-service.ts
@@ -14,6 +14,34 @@ import {
 import { ScriptType } from './scripting';
 import { AppSettings } from './app-settings';
 
+/**
+ * Fire-and-forget IPC events pushed from the main process to the renderer.
+ * Every `webContents.send()` call and its renderer-side listener must use this
+ * enum so event names stay unique and dead events are easy to spot.
+ */
+export enum MainProcessEvent {
+  /** The window is about to close; the renderer should flush unsaved state. */
+  BeforeClose = 'before-close',
+  /** The variables or environments of the current collection changed. */
+  CollectionVariablesUpdated = 'collection-variables-updated',
+  /** Opens the collection runner view (Collection menu). */
+  ShowCollectionRunner = 'show-collection-runner',
+  /** Opens the collection settings modal (Collection menu). */
+  ShowCollectionSettings = 'show-collection-settings',
+  /** Opens the sidebar history panel (Collection menu). */
+  ShowHistory = 'show-history',
+}
+
+/**
+ * Fire-and-forget IPC events sent from the renderer to the main process.
+ */
+export enum RendererEvent {
+  /** The renderer finished initializing and the window can be shown. */
+  RendererReady = 'renderer-ready',
+  /** All unsaved state is flushed; the window may close now. */
+  ReadyToClose = 'ready-to-close',
+}
+
 export type ImportStrategy = 'Postman' | 'OpenAPI' | 'Bruno' | 'Insomnia';
 
 export interface ImportWarning {

--- a/src/shim/objects/history.ts
+++ b/src/shim/objects/history.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import { RequestMethod } from './request-method';
+import { TrufosHeader } from './headers';
+
+export const HistoryEntry = z.object({
+  id: z.string(),
+  timestamp: z.number(), // timestamp as unix epoch ms
+  request: z.object({
+    url: z.string(),
+    method: z.enum(RequestMethod),
+    headers: z.array(TrufosHeader),
+    bodySummary: z.string().optional(),
+  }),
+  response: z.object({
+    status: z.number(),
+    duration: z.number(), // in ms
+    size: z.number(), // in bytes
+    error: z.string().optional(),
+  }),
+  sourceRequestId: z.string().optional(),
+  sourceRequestTitle: z.string().optional(),
+});
+export type HistoryEntry = z.infer<typeof HistoryEntry>;

--- a/src/shim/objects/index.ts
+++ b/src/shim/objects/index.ts
@@ -10,3 +10,4 @@ export * from './request-method';
 export * from './object';
 export * from './query-param';
 export * from './response';
+export * from './history';


### PR DESCRIPTION
### **User description**
## Changes

Implements the Request History feature (#840).

- **Backend**:
  - Created `HistoryService` that persists request history entries to a `.history/` directory inside the collection directory.
  - Automatically redacts sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`, `Proxy-Authorization`) and leaves variable templates unresolved.
  - Limits history size to 100 entries (retention policy).
  - Integrated history recording into `sendRequest` IPC method.
  - Ignored `.history/` in the generated `.gitignore`.

- **Frontend**:
  - Implemented `HistoryPanel` inside the sidebar.
  - Added toggle tabs in the menubar to switch between "Requests" list and "History" panel.
  - Clicking a history entry restores its URL, HTTP method, and headers to the active request (selecting the original request first if it still exists).
  - Added confirmation for clearing the request history.

## Testing

- Unit tests written for `HistoryService` in the main process.
- Unit tests written for `historyStore` in the renderer process.
- All tests pass successfully.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person

Closes #840


___

### **PR Type**
Enhancement


___

### **Description**
- Implements automatic request history recording with sensitive header redaction

- Adds History panel in sidebar with restore, clear, and refresh capabilities

- Consolidates event names into MainProcessEvent and RendererEvent enums

- Extracts format utilities (duration, size, date, time) for reuse

- Enforces 100-entry retention limit with ephemeral per-session storage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Request"] -->|sendRequest| B["HistoryService"]
  B -->|recordEntry| C[".history/ Directory"]
  C -->|loadEntries| D["historyStore"]
  D -->|selectHistoryEntries| E["HistoryPanel"]
  E -->|handleRestore| F["Update Active Request"]
  E -->|clearHistory| C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>history-service.ts</strong><dd><code>Backend service for recording and managing request history</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-8752a3416cd6be44cff21d105aa95e7b8cdd4c60a4ab1429ddf4ff477826fc67">+195/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main-event-service.ts</strong><dd><code>Integrate history recording into sendRequest flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-88f162ee0fb07a5f96655c4e842df6fb5072f17b7c130b8099cfb16c16e65588">+47/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong><dd><code>Initialize history cleanup on app startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-7adaa52a2eacb085ba5e07e6683a61fb3601547dc00b51fd50fbaf685e13fe96">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>menu.ts</strong><dd><code>Add History menu item with keyboard shortcut</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-a8e89ca92b72dea361635d6d87ba1a12933f5e0a701050e3e0a79aab0eea4ce2">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>historyStore.ts</strong><dd><code>Zustand store for managing history state and actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-f0c62d4cfe269c33c4121811f1ec6281c22a57b7fcf598d80acfd5e5ed230d23">+57/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HistoryPanel.tsx</strong><dd><code>UI component displaying history entries with restore button</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-a011b88b65705141c536a93734641097df9165887d6b936a68507408565c5d6e">+192/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Menubar.tsx</strong><dd><code>Toggle between requests list and history panel views</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-cc250f3311590dfd3658ab42da7506282879ccfe6caa66a353c5f7f8a3081085">+13/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RequestWindow.tsx</strong><dd><code>Adjust empty state message when history tab is active</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-a90c423eafea8410a44edb4f591fc68bdd2cb40470ffef7e0681863229b3630a">+16/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>http-service.ts</strong><dd><code>Reload history after request completion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-8bf140b3502821ad10c2fff82452b20a6d50b697bfca619b0d907911f42e503a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>renderer-event-service.ts</strong><dd><code>Add getHistory and clearHistory IPC methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-6446e2be18634b05193826bf484b2b8bc0a1c252f5207f424de9e77b82f4444f">+18/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CollectionStoreProvider.tsx</strong><dd><code>Use MainProcessEvent and RendererEvent enums</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-d253d97ef56503bec64b1ceea8742417a43d1bc94b1ac3bc9c6c2f497ff609b6">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>viewStore.ts</strong><dd><code>Add sidebarTab state to track requests vs history view</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-3f3242036ea07710b3828c5ecae6bcf8ed0bdfa1e31e303b9096f46300677a67">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>format-util.ts</strong><dd><code>New shared module with duration, size, date, time formatters</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-89883b74165a7e40526552c0554120ae16feaadf4abadd8fd625ea5e14273477">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>event-service.ts</strong><dd><code>Add MainProcessEvent and RendererEvent enums with history methods</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-9ca4fa37785e3ce6722e2ccb9049e915895c3efc6be7030ad0d8abf3e2933de3">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>history.ts</strong><dd><code>Define HistoryEntry schema with Zod validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-f5e0c3fb48f668c793093d2beb9c10e517e86cb661b4c650dfd5ead42dd51313">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export history object types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-a169c1780e1607bbba45a1f69e35919fb5f814c8dc408bb1dd638af4b3632db9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>history-service.test.ts</strong><dd><code>Unit tests for history recording and retention logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-86121f17a8ffd9fcb34fad601e27bc700a72dc20dd64ac0dfbe015d1b5e7b976">+202/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>menu.test.ts</strong><dd><code>Test History menu item in Collection menu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-8ecc1165efabb70ecb554fc43094ee7dbc2656dc73f9928cfd7931c568e1709f">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>historyStore.test.ts</strong><dd><code>Unit tests for history store load and clear operations</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-b48d086339dedc71a36f6883bca16f703bc508e1945e08ba1f7a9cb6b2413038">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>format-util.test.ts</strong><dd><code>Tests for centralized format utility functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-4ab29cbae83e87975aa8d3240ddd2f509d3a2a13e8b40b089f2cb76729a81b4e">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>v2-0-0.ts</strong><dd><code>Add .history directory to .gitignore template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-60eb66c7ac75e6a60a6c3fade67258cf982adadbacee507ab4eb3e3065977a2c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ResponseStatus.tsx</strong><dd><code>Import format utilities from shared format-util module</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-94452d91d6b72fa84f560daaf2e87168b22acc8f542bb30d3a0baab07aec936c">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ResponseStatusFormatter.ts</strong><dd><code>Remove getDurationTextInSec and getSizeText functions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-78ec4971450d59d8ea43832f50df83cc481ad713115ddfb0f6fb0b6324b8ecbd">+0/-18</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ResponseStatusFormatter.test.ts</strong><dd><code>Remove tests for moved format utility functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-aad1476b5612d655b8eb43e4bc65ba01c5f4e6268fec03c56f30bda39ddcce0f">+1/-43</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/931/files#diff-72348b6b222462c023d009b90544f2799da3cf5b1eafc2d280f8a19041271230">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

