### PR TITLE
docs: clarify UI and serialization conventions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,16 +45,45 @@ Key renderer directories:
 
 ## Code Conventions
 
-- All code must be **TypeScript** with strict typing – avoid `any`.
+- All code must be **TypeScript** with strict typing – never introduce `any`, and avoid
+  broad casts such as `as unknown as X` that bypass the type checker.
 - Use **functional React components** with hooks; no class components.
 - Prefer **named exports** over default exports for components and utilities.
-- Use **Tailwind CSS** utility classes for styling; avoid inline styles.
-- Use **shadcn/ui** components before writing custom UI primitives.
 - State shared across components belongs in a **Zustand store** (`src/renderer/state/`).
 - IPC communication must go through typed handlers defined in `src/main/event/` and exposed
   via preload.
-- Use **Zod** for runtime validation and schema definitions.
+- Use **Zod** for runtime validation and schema definitions. Validate data at runtime
+  boundaries (IPC payloads, files read from disk, network responses) instead of asserting
+  types with casts.
 - Use **Winston** for logging in the main process.
+
+### UI Components & Styling
+
+- Before writing a custom UI primitive, check in this order:
+  1. An existing **shadcn/ui** component in `src/renderer/components/ui/` (button, dialog,
+     dropdown-menu, select, popover, …).
+  2. A **Radix UI** primitive (`@radix-ui/react-*`) wrapped in the shadcn/ui style.
+  3. Only then a hand-rolled component.
+
+  This keeps focus handling, keyboard navigation, and accessibility consistent for free.
+
+- Use **Tailwind CSS v4** utility classes for styling; avoid inline styles and one-off CSS
+  files. Follow the patterns of neighbouring components – e.g. compose conditional classes
+  with the `cn()` helper (`src/renderer/lib/utils.ts`) rather than string concatenation.
+
+### Serialization & Comparison
+
+- Do **not** use `JSON.stringify` for equality checks, cache keys, memoization inputs, or
+  change detection. Property order is not semantically meaningful but changes the output
+  (`{"a":1,"b":2}` vs `{"b":2,"a":1}`), and values like `undefined`, `Map`, or `Date`
+  serialize lossily – both cause missed or spurious updates. If serialization genuinely is
+  the right tool for a comparison, document in a comment why the output is deterministic
+  for that data.
+- Prefer typed, structured comparisons: compare the relevant fields explicitly, or use a
+  dedicated deep-equality helper.
+- Prefer stable, typed data models plus **Zod** parsing over ad hoc string serialization
+  when data crosses a boundary (IPC, persistence). Parse into a typed structure once at the
+  boundary and work with that structure afterwards.
 
 ## Development Commands
 


### PR DESCRIPTION
### **User description**
## Changes

Clarifies day-to-day conventions in `AGENTS.md` as requested in #933:

- **UI Components & Styling** (new subsection): explicit reuse order — existing shadcn/ui components in `src/renderer/components/ui/`, then Radix primitives, then custom — plus Tailwind v4 styling guidance and the `cn()` helper pattern, with a short rationale (consistent focus handling, keyboard navigation, a11y).
- **Serialization & Comparison** (new subsection): no `JSON.stringify` for equality checks, cache keys, memoization inputs, or change detection (with an example of why it breaks); prefer typed, structured comparisons and stable data models with Zod parsing at boundaries. Documented escape hatch: a comment explaining why the output is deterministic.
- Strict-typing bullet extended: no `any`, no broad casts like `as unknown as X`; Zod bullet extended to cover validating runtime boundaries (IPC, disk, network) instead of type assertions.

Tool-specific instruction files (`CLAUDE.md`, `.github/copilot-instructions.md`) already defer to `AGENTS.md`, so no changes needed there.

Closes #933

## Testing

Documentation-only change. `yarn prettier-check` passes for `AGENTS.md`; no code touched, so `yarn test` / `yarn lint` are unaffected.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible (not applicable — docs only)
- [ ] Manual testing has been performed (not applicable — docs only)
- [x] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Clarifies UI component reuse order: shadcn/ui, Radix primitives, then custom

- Adds Tailwind v4 styling guidance with `cn()` helper pattern

- Prohibits `JSON.stringify` for equality checks and cache keys

- Extends strict typing rules: no `any`, no broad casts like `as unknown as X`

- Requires Zod validation at runtime boundaries instead of type assertions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AGENTS.md<br/>Code Conventions"] --> B["UI Components<br/>& Styling"]
  A --> C["Serialization<br/>& Comparison"]
  B --> D["shadcn/ui →<br/>Radix → Custom"]
  B --> E["Tailwind v4<br/>+ cn() helper"]
  C --> F["No JSON.stringify<br/>for equality"]
  C --> G["Typed comparisons<br/>+ Zod parsing"]
  A --> H["Strict TypeScript<br/>+ Zod boundaries"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Add UI and serialization convention guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Extended strict typing guidance to explicitly forbid <code>any</code> and broad <br>casts like <code>as unknown as X</code><br> <li> Added new "UI Components & Styling" subsection with component reuse <br>priority order and Tailwind v4 patterns<br> <li> Added new "Serialization & Comparison" subsection prohibiting <br><code>JSON.stringify</code> for equality/cache keys with detailed rationale<br> <li> Enhanced Zod guidance to emphasize runtime boundary validation instead <br>of type assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/934/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+33/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

