### PR TITLE
refactor: align Collection Runner with AGENTS.md conventions

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import '@/styles/index.css';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Menubar } from '@/view/Menubar';
 import { RequestWindow } from '@/view/RequestWindow';
 import { CollectionRunner } from '@/view/CollectionRunner';
@@ -10,13 +10,15 @@ import { ThemeProvider } from '@/contexts/ThemeContext';
 import { CollectionStoreProvider } from '@/state/CollectionStoreProvider';
 import { RendererEventService } from '@/services/event/renderer-event-service';
 import { useAppSettingsStore } from '@/state/appSettingsStore';
+import { selectIsCollectionRunnerOpen, useViewActions, useViewStore } from '@/state/viewStore';
 import { showError } from '@/error/errorHandler';
 
 const MIN_SIDEBAR_PIXELS = 300;
 const MIN_REQUEST_WINDOW_PIXELS = 500;
 
 export const App = () => {
-  const [isCollectionRunnerOpen, setIsCollectionRunnerOpen] = useState(false);
+  const isCollectionRunnerOpen = useViewStore(selectIsCollectionRunnerOpen);
+  const { closeCollectionRunner } = useViewActions();
 
   useEffect(() => {
     RendererEventService.instance
@@ -39,17 +41,14 @@ export const App = () => {
           <SidebarProvider className="grid">
             <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
               <ResizablePanel defaultSize="25%" minSize={MIN_SIDEBAR_PIXELS}>
-                <Menubar onRunCollection={() => setIsCollectionRunnerOpen(true)} />
+                <Menubar />
               </ResizablePanel>
               <ResizableHandle />
               <ResizablePanel defaultSize="75%" minSize={MIN_REQUEST_WINDOW_PIXELS}>
                 <RequestWindow />
               </ResizablePanel>
             </ResizablePanelGroup>
-            <CollectionRunner
-              open={isCollectionRunnerOpen}
-              onClose={() => setIsCollectionRunnerOpen(false)}
-            />
+            <CollectionRunner open={isCollectionRunnerOpen} onClose={closeCollectionRunner} />
           </SidebarProvider>
         </TooltipProvider>
       </ThemeProvider>

--- a/src/renderer/components/sidebar/CollectionDropdown.tsx
+++ b/src/renderer/components/sidebar/CollectionDropdown.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
+import { useViewActions } from '@/state/viewStore';
 import { RendererEventService } from '@/services/event/renderer-event-service';
 import { CollectionBase } from 'shim/objects/collection';
 import { cn } from '@/lib/utils';
@@ -19,12 +20,9 @@ import { CollectionCreate } from '@/view/CollectionCreate';
 
 const eventService = RendererEventService.instance;
 
-interface CollectionDropdownProps {
-  onRunCollection?: () => void;
-}
-
-export default function CollectionDropdown({ onRunCollection }: CollectionDropdownProps) {
+export default function CollectionDropdown() {
   const { changeCollection } = useCollectionActions();
+  const { openCollectionRunner } = useViewActions();
   const collection = useCollectionStore((state) => state.collection);
   const [collections, setCollections] = useState<CollectionBase[]>([]);
   const [isOpen, setIsOpen] = useState(false);
@@ -74,7 +72,7 @@ export default function CollectionDropdown({ onRunCollection }: CollectionDropdo
               <span>Import Collection</span>
             </DropdownMenuItem>
 
-            <DropdownMenuItem onClick={() => onRunCollection?.()} className={'px-4 py-3'}>
+            <DropdownMenuItem onClick={openCollectionRunner} className={'px-4 py-3'}>
               <span>Run Collection</span>
             </DropdownMenuItem>
           </DropdownMenuGroup>

--- a/src/renderer/components/sidebar/SidebarHeaderBar.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.tsx
@@ -6,6 +6,7 @@ import { AddFolderIcon, CreateRequestIcon, SettingsIcon, SwapIcon } from '@/comp
 import { ArrowUpAZ, ArrowDownAZ, ClockArrowUp, ClockArrowDown, Play } from 'lucide-react';
 
 import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
+import { useViewActions } from '@/state/viewStore';
 import CollectionDropdown from '@/components/sidebar/CollectionDropdown';
 import { Divider } from '@/components/shared/Divider';
 import { CollectionSettingsModal } from '@/components/shared/settings/CollectionSettingsModal';
@@ -39,14 +40,14 @@ const SortIcon = ({ mode }: { mode: SortMode }) => {
 
 interface SidebarHeaderBarProps {
   onCreateItem: (item: CreatingItem) => void;
-  onRunCollection?: () => void;
 }
 
-export const SidebarHeaderBar = ({ onCreateItem, onRunCollection }: SidebarHeaderBarProps) => {
+export const SidebarHeaderBar = ({ onCreateItem }: SidebarHeaderBarProps) => {
   const collection = useCollectionStore((state) => state.collection);
 
   const sortMode = useCollectionStore((state) => state.sortMode);
   const { setSortMode } = useCollectionActions();
+  const { openCollectionRunner } = useViewActions();
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const buttonClassName = cn('flex h-4 w-4 items-center justify-center gap-1');
@@ -66,7 +67,7 @@ export const SidebarHeaderBar = ({ onCreateItem, onRunCollection }: SidebarHeade
   return (
     <>
       <SidebarHeader className="flex-col gap-6">
-        <CollectionDropdown onRunCollection={onRunCollection} />
+        <CollectionDropdown />
 
         <Divider />
 
@@ -100,7 +101,7 @@ export const SidebarHeaderBar = ({ onCreateItem, onRunCollection }: SidebarHeade
                   variant={'ghost'}
                   type="button"
                   size={'icon'}
-                  onClick={onRunCollection}
+                  onClick={openCollectionRunner}
                   aria-label="Run collection"
                 >
                   <Play size={16} />

--- a/src/renderer/state/viewStore.ts
+++ b/src/renderer/state/viewStore.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { useActions } from '@/state/helper/util';
+
+interface ViewState {
+  /** Whether the collection runner modal is open */
+  isCollectionRunnerOpen: boolean;
+}
+
+interface ViewActions {
+  openCollectionRunner(): void;
+  closeCollectionRunner(): void;
+}
+
+export const useViewStore = create<ViewState & ViewActions>()(
+  immer((set) => ({
+    isCollectionRunnerOpen: false,
+
+    openCollectionRunner() {
+      set((state) => {
+        state.isCollectionRunnerOpen = true;
+      });
+    },
+
+    closeCollectionRunner() {
+      set((state) => {
+        state.isCollectionRunnerOpen = false;
+      });
+    },
+  }))
+);
+
+export const selectIsCollectionRunnerOpen = (state: ViewState) => state.isCollectionRunnerOpen;
+export const useViewActions = () => useViewStore(useActions());

--- a/src/renderer/state/viewStore.ts
+++ b/src/renderer/state/viewStore.ts
@@ -31,4 +31,4 @@ export const useViewStore = create<ViewState & ViewActions>()(
 );
 
 export const selectIsCollectionRunnerOpen = (state: ViewState) => state.isCollectionRunnerOpen;
-export const useViewActions = () => useViewStore(useActions());
+export const useViewActions = (): ViewActions => useViewStore(useActions());

--- a/src/renderer/view/CollectionRunner.test.tsx
+++ b/src/renderer/view/CollectionRunner.test.tsx
@@ -463,7 +463,7 @@ describe('CollectionRunner result details', () => {
     expect(screen.getByText('Status:')).toBeDefined();
     expect(screen.getByText('Duration:')).toBeDefined();
 
-    await user.click(screen.getByRole('button', { name: 'Headers' }));
+    await user.click(screen.getByRole('tab', { name: 'Headers' }));
     expect(screen.getByText(/content-type/)).toBeDefined();
   });
 

--- a/src/renderer/view/CollectionRunner.tsx
+++ b/src/renderer/view/CollectionRunner.tsx
@@ -131,7 +131,12 @@ function ResponseBodyPreview({ response }: { response: TrufosResponse }) {
 }
 
 function ResponseDetail({ response }: { response: TrufosResponse }) {
-  const tabContentClassName = 'border-border min-h-0 rounded-md border bg-transparent p-3';
+  // Overrides the shadcn defaults to match the compact tab style from the runner design.
+  const tabTriggerClassName = cn(
+    'h-auto rounded-md px-3 py-1 text-xs font-semibold',
+    'data-[state=active]:bg-accent-primary/10 data-[state=active]:text-accent-primary data-[state=active]:shadow-none'
+  );
+  const tabContentClassName = 'border-border mt-3 min-h-0 rounded border bg-transparent p-3';
 
   return (
     <div className="grid min-h-[320px] grid-rows-[auto_1fr] gap-3">
@@ -148,14 +153,11 @@ function ResponseDetail({ response }: { response: TrufosResponse }) {
         </span>
       </div>
       <Tabs className="min-h-0 bg-transparent" defaultValue="body">
-        <TabsList className="h-auto bg-transparent">
-          <TabsTrigger className="h-auto rounded-md px-3 py-1 text-xs font-semibold" value="body">
+        <TabsList className="h-auto gap-1 bg-transparent">
+          <TabsTrigger className={tabTriggerClassName} value="body">
             Body
           </TabsTrigger>
-          <TabsTrigger
-            className="h-auto rounded-md px-3 py-1 text-xs font-semibold"
-            value="headers"
-          >
+          <TabsTrigger className={tabTriggerClassName} value="headers">
             Headers
           </TabsTrigger>
         </TabsList>

--- a/src/renderer/view/CollectionRunner.tsx
+++ b/src/renderer/view/CollectionRunner.tsx
@@ -12,9 +12,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useResponseData } from '@/components/mainWindow/bodyTabs/OutputTabs/PrettyRenderer';
 import { HttpService } from '@/services/http/http-service';
 import { httpMethodColor } from '@/services/StyleHelper';
+import { getIndentation } from '@/components/sidebar/SidebarRequestList/Nav/indentation';
 import { saveModelContent } from '@/lib/monaco/models';
 import { cn } from '@/lib/utils';
 import { useCollectionStore } from '@/state/collectionStore';
@@ -133,16 +135,10 @@ function ResponseBodyPreview({ response }: { response: TrufosResponse }) {
 }
 
 function ResponseDetail({ response }: { response: TrufosResponse }) {
-  const [tab, setTab] = useState<'body' | 'headers'>('body');
-
-  const tabClassName = (active: boolean) =>
-    cn(
-      'cursor-pointer rounded-md px-3 py-1 text-xs font-semibold',
-      active ? 'bg-accent-primary/10 text-accent-primary' : 'text-text-secondary'
-    );
+  const tabContentClassName = 'border-border min-h-0 rounded-md border bg-transparent p-3';
 
   return (
-    <div className="grid min-h-[320px] grid-rows-[auto_auto_1fr] gap-3">
+    <div className="grid min-h-[320px] grid-rows-[auto_1fr] gap-3">
       <div className="text-text-secondary flex gap-5 text-sm">
         <span>
           Status:{' '}
@@ -155,31 +151,25 @@ function ResponseDetail({ response }: { response: TrufosResponse }) {
           </span>
         </span>
       </div>
-      <div className="flex gap-1">
-        <button
-          className={tabClassName(tab === 'body')}
-          type="button"
-          onClick={() => setTab('body')}
-        >
-          Body
-        </button>
-        <button
-          className={tabClassName(tab === 'headers')}
-          type="button"
-          onClick={() => setTab('headers')}
-        >
-          Headers
-        </button>
-      </div>
-      <div className="border-border min-h-0 rounded border p-3">
-        {tab === 'body' ? (
+      <Tabs className="min-h-0 bg-transparent" defaultValue="body">
+        <TabsList className="h-auto bg-transparent">
+          <TabsTrigger className="h-auto rounded-md px-3 py-1 text-xs font-semibold" value="body">
+            Body
+          </TabsTrigger>
+          <TabsTrigger
+            className="h-auto rounded-md px-3 py-1 text-xs font-semibold"
+            value="headers"
+          >
+            Headers
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent className={tabContentClassName} value="body">
           <ResponseBodyPreview response={response} />
-        ) : (
-          <pre className="tabs-scrollbar h-full min-h-0 overflow-auto text-xs">
-            {formatHeaders(response.headers)}
-          </pre>
-        )}
-      </div>
+        </TabsContent>
+        <TabsContent className={tabContentClassName} value="headers">
+          <pre className="text-xs">{formatHeaders(response.headers)}</pre>
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }
@@ -550,8 +540,10 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
                   return (
                     <label
                       key={item.id}
-                      className="hover:bg-sidebar-accent flex cursor-pointer items-center gap-2 px-4 py-2 text-sm"
-                      style={{ paddingLeft: 16 + item.depth * 18 }}
+                      className={cn(
+                        'hover:bg-sidebar-accent flex cursor-pointer items-center gap-2 py-2 pr-4 text-sm',
+                        getIndentation(item.depth)
+                      )}
                     >
                       <Checkbox
                         checked={checked}
@@ -571,8 +563,10 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
                 return (
                   <label
                     key={item.id}
-                    className="hover:bg-sidebar-accent flex cursor-pointer items-center gap-2 px-4 py-2 text-sm"
-                    style={{ paddingLeft: 16 + item.depth * 18 }}
+                    className={cn(
+                      'hover:bg-sidebar-accent flex cursor-pointer items-center gap-2 py-2 pr-4 text-sm',
+                      getIndentation(item.depth)
+                    )}
                   >
                     <Checkbox
                       checked={selectedRequestIds.has(item.id)}

--- a/src/renderer/view/CollectionRunner.tsx
+++ b/src/renderer/view/CollectionRunner.tsx
@@ -127,11 +127,7 @@ function ResponseBodyPreview({ response }: { response: TrufosResponse }) {
 
   useResponseData(response, 'utf-8', setBody);
 
-  return (
-    <pre className="tabs-scrollbar h-full min-h-0 overflow-auto text-xs break-words whitespace-pre-wrap">
-      {body}
-    </pre>
-  );
+  return <pre className="text-xs break-words whitespace-pre-wrap">{body}</pre>;
 }
 
 function ResponseDetail({ response }: { response: TrufosResponse }) {
@@ -167,7 +163,9 @@ function ResponseDetail({ response }: { response: TrufosResponse }) {
           <ResponseBodyPreview response={response} />
         </TabsContent>
         <TabsContent className={tabContentClassName} value="headers">
-          <pre className="text-xs">{formatHeaders(response.headers)}</pre>
+          <pre className="text-xs break-words whitespace-pre-wrap">
+            {formatHeaders(response.headers)}
+          </pre>
         </TabsContent>
       </Tabs>
     </div>

--- a/src/renderer/view/Menubar.tsx
+++ b/src/renderer/view/Menubar.tsx
@@ -5,16 +5,12 @@ import { SidebarHeaderBar } from '@/components/sidebar/SidebarHeaderBar';
 import { SidebarRequestList } from '@/components/sidebar/SidebarRequestList/SidebarRequestList';
 import type { CreatingItem } from '@/components/sidebar/SidebarRequestList/types';
 
-interface MenubarProps {
-  onRunCollection: () => void;
-}
-
-export const Menubar = ({ onRunCollection }: MenubarProps) => {
+export const Menubar = () => {
   const [creatingItem, setCreatingItem] = useState<CreatingItem>(null);
 
   return (
     <Sidebar className={'flex h-screen flex-col p-6'} collapsible={'none'}>
-      <SidebarHeaderBar onCreateItem={setCreatingItem} onRunCollection={onRunCollection} />
+      <SidebarHeaderBar onCreateItem={setCreatingItem} />
       <SidebarRequestList creatingItem={creatingItem} onCreateItem={setCreatingItem} />
       <FooterBar />
     </Sidebar>


### PR DESCRIPTION
### **User description**
## Changes

Follow-up to #930: brings the Collection Runner in line with the conventions in `AGENTS.md` (clarified in #933/#934).

- **shadcn/ui `Tabs` instead of hand-rolled tab buttons** — `ResponseDetail` in `CollectionRunner.tsx` now uses the existing `Tabs`/`TabsList`/`TabsTrigger`/`TabsContent` components (same pattern as `OutputTabs`) instead of raw `<button>` elements with local tab state.
- **Tailwind indentation instead of inline styles** — the request checklist reuses the sidebar's `getIndentation(depth)` helper (`pl-*` classes) instead of `style={{ paddingLeft: 16 + item.depth * 18 }}`.
- **Runner-open state in a Zustand store instead of prop drilling** — new `src/renderer/state/viewStore.ts` holds `isCollectionRunnerOpen` with `openCollectionRunner`/`closeCollectionRunner` actions (follows the `environmentStore` pattern incl. `useActions` helper). The `onRunCollection` callback that was drilled through `App` → `Menubar` → `SidebarHeaderBar` → `CollectionDropdown` is removed; the two trigger sites call the store action directly. `CollectionRunner` itself stays a controlled dialog component (`open`/`onClose` props), so its component tests keep working unchanged.

Behaviour is unchanged; this is a conventions refactor only.

Closes #935

## Testing

- `yarn test`: 421 passed, 1 skipped (all 32 Collection Runner tests pass; one query updated from `role="button"` to `role="tab"` for the Headers tab).
- `yarn lint`: touched files are clean (remaining repo warnings are pre-existing on `main`).
- `yarn prettier-check`: clean.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible (existing tests cover the refactored behaviour)
- [ ] Manual testing has been performed
- [ ] Documentation has been updated, if necessary (not applicable)
- [ ] Changes have been reviewed by second person

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Replace hand-rolled tab buttons with shadcn/ui `Tabs` component in `ResponseDetail`

- Replace inline `paddingLeft` styles with `getIndentation()` Tailwind helper

- Move runner-open state from `App` useState into new `viewStore` Zustand store

- Remove `onRunCollection` prop drilling through `Menubar` → `SidebarHeaderBar` → `CollectionDropdown`

- Align Collection Runner with AGENTS.md conventions for UI components and state management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Collection Runner<br/>Refactor"] --> B["UI Components"]
  A --> C["Styling"]
  A --> D["State Management"]
  B --> B1["Hand-rolled tabs<br/>→ shadcn Tabs"]
  C --> C1["Inline styles<br/>→ Tailwind classes"]
  D --> D1["useState + prop drilling<br/>→ viewStore"]
  D1 --> D2["Remove onRunCollection<br/>callback chain"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>viewStore.ts</strong><dd><code>New Zustand store for collection runner state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/936/files#diff-3f3242036ea07710b3828c5ecae6bcf8ed0bdfa1e31e303b9096f46300677a67">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CollectionRunner.tsx</strong><dd><code>Replace tabs and inline styles with conventions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/936/files#diff-b5655adbcdeb3e9d56d181fea9fee71c069b86945b14efccfeea13a887231c91">+33/-39</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong><dd><code>Remove useState and prop drilling for runner state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/936/files#diff-72348b6b222462c023d009b90544f2799da3cf5b1eafc2d280f8a19041271230">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Menubar.tsx</strong><dd><code>Remove onRunCollection prop from interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/936/files#diff-cc250f3311590dfd3658ab42da7506282879ccfe6caa66a353c5f7f8a3081085">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SidebarHeaderBar.tsx</strong><dd><code>Remove onRunCollection prop drilling, use store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/936/files#diff-f309b743e133009344d22d2c557e2a5cfdf6a8c316871c358fb1175dad843a16">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CollectionDropdown.tsx</strong><dd><code>Remove onRunCollection prop, call store action directly</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/936/files#diff-2c778feb261e7cb6c820320f1f6d8352569c2fad8236c9b3f9a6db04c7827b82">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CollectionRunner.test.tsx</strong><dd><code>Update test query from button to tab role</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/936/files#diff-527ca15e097a654362cf7b9295fda5065079c047484750b44f645f4a27a8a7c0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

