### PR TITLE
feat: replace boilerplate native menu with Trufos application menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,10 @@ Key renderer directories:
 
 - All code must be **TypeScript** with strict typing – never introduce `any`, and avoid
   broad casts such as `as unknown as X` that bypass the type checker.
+- Annotate **explicit return types** on exported functions, hooks, and public class methods
+  (e.g. `buildMenu(): Menu`, `useViewActions = (): ViewActions => …`). Inference is fine for
+  private helpers and inline callbacks. This is the most common finding of the PR review
+  bot – annotating up front avoids a review round-trip.
 - Use **functional React components** with hooks; no class components.
 - Prefer **named exports** over default exports for components and utilities.
 - State shared across components belongs in a **Zustand store** (`src/renderer/state/`).

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,6 +3,7 @@ import './logging/logger';
 import { app, BrowserWindow, dialog, ipcMain, safeStorage, shell } from 'electron';
 import { EnvironmentService } from 'main/environment/service/environment-service';
 import { MainEventService } from 'main/event/main-event-service';
+import { MenuBuilder } from 'main/menu';
 import path from 'node:path';
 import quit from 'electron-squirrel-startup';
 import { SettingsService } from './persistence/service/settings-service';
@@ -53,6 +54,9 @@ const createWindow = async () => {
 
     // pass webContents to MainEventService for push notifications
     mainEventService.webContents = mainWindow.webContents;
+
+    // register the native application menu
+    new MenuBuilder(mainWindow).buildMenu();
 
     // show once the renderer has loaded and applied the saved theme
     once(ipcMain, 'renderer-ready').then(() => mainWindow.show());

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -1,0 +1,146 @@
+import { vi, describe, it, beforeEach, expect } from 'vitest';
+import type { BrowserWindow, MenuItemConstructorOptions } from 'electron';
+
+const { appMock, buildFromTemplateMock, setApplicationMenuMock, openExternalMock } = vi.hoisted(
+  () => ({
+    appMock: { isPackaged: false, name: 'Trufos' },
+    buildFromTemplateMock: vi.fn((template: MenuItemConstructorOptions[]) => ({
+      template,
+      popup: vi.fn(),
+    })),
+    setApplicationMenuMock: vi.fn(),
+    openExternalMock: vi.fn(),
+  })
+);
+
+vi.mock('electron', () => ({
+  app: appMock,
+  Menu: {
+    buildFromTemplate: (template: MenuItemConstructorOptions[]) => buildFromTemplateMock(template),
+    setApplicationMenu: (menu: unknown) => setApplicationMenuMock(menu),
+  },
+  shell: {
+    openExternal: (url: string) => openExternalMock(url),
+  },
+}));
+
+import { MenuBuilder } from './menu';
+
+function createMainWindow() {
+  return {
+    webContents: { on: vi.fn(), inspectElement: vi.fn() },
+  } as unknown as BrowserWindow;
+}
+
+function buildTemplate(platform: NodeJS.Platform) {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform });
+  try {
+    new MenuBuilder(createMainWindow()).buildMenu();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  }
+  return buildFromTemplateMock.mock.calls[0][0];
+}
+
+function collectStrings(items: MenuItemConstructorOptions[]): string[] {
+  return items.flatMap((item) => [
+    ...(item.label ? [item.label] : []),
+    ...(item.role ? [item.role] : []),
+    ...(Array.isArray(item.submenu) ? collectStrings(item.submenu) : []),
+  ]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  appMock.isPackaged = false;
+});
+
+describe('MenuBuilder', () => {
+  it('registers the menu as the application menu', () => {
+    const menu = new MenuBuilder(createMainWindow()).buildMenu();
+
+    expect(setApplicationMenuMock).toHaveBeenCalledWith(menu);
+  });
+
+  it.each(['darwin', 'win32', 'linux'] as const)(
+    'contains no boilerplate references on %s',
+    (platform) => {
+      const strings = collectStrings(buildTemplate(platform)).join(' ');
+
+      expect(strings).not.toMatch(/ElectronReact|electronjs/i);
+      expect(strings).not.toMatch(/\bElectron\b/);
+    }
+  );
+
+  it('builds the macOS app menu with standard roles', () => {
+    const template = buildTemplate('darwin');
+
+    expect(template[0].label).toBe('Trufos');
+    const appRoles = collectStrings(template[0].submenu as MenuItemConstructorOptions[]);
+    expect(appRoles).toEqual(
+      expect.arrayContaining(['about', 'services', 'hide', 'hideOthers', 'unhide', 'quit'])
+    );
+    expect(template.map((item) => item.label ?? item.role)).toEqual([
+      'Trufos',
+      'Edit',
+      'View',
+      'Window',
+      'help',
+    ]);
+  });
+
+  it('builds the default menu with File, Edit, View and Help', () => {
+    const template = buildTemplate('win32');
+
+    expect(template.map((item) => item.label ?? item.role)).toEqual([
+      '&File',
+      '&Edit',
+      '&View',
+      'help',
+    ]);
+    const fileRoles = collectStrings(template[0].submenu as MenuItemConstructorOptions[]);
+    expect(fileRoles).toEqual(['close', 'quit']);
+  });
+
+  it.each(['darwin', 'win32'] as const)(
+    'includes Reload and DevTools on %s only in development',
+    (platform) => {
+      const devStrings = collectStrings(buildTemplate(platform));
+      expect(devStrings).toEqual(expect.arrayContaining(['reload', 'toggleDevTools']));
+
+      vi.clearAllMocks();
+      appMock.isPackaged = true;
+      const prodStrings = collectStrings(buildTemplate(platform));
+      expect(prodStrings).not.toContain('reload');
+      expect(prodStrings).not.toContain('toggleDevTools');
+      expect(prodStrings).toContain('togglefullscreen');
+    }
+  );
+
+  it('opens the Trufos documentation and issue tracker from the Help menu', () => {
+    const template = buildTemplate('darwin');
+    const help = template.find((item) => item.role === 'help')!;
+    const items = help.submenu as MenuItemConstructorOptions[];
+
+    for (const item of items) {
+      (item.click as () => void)();
+    }
+
+    expect(openExternalMock).toHaveBeenCalledWith('https://github.com/EXXETA/trufos#readme');
+    expect(openExternalMock).toHaveBeenCalledWith(
+      'https://github.com/EXXETA/trufos/issues/new/choose'
+    );
+  });
+
+  it('registers a context-menu handler only in development', () => {
+    const devWindow = createMainWindow();
+    new MenuBuilder(devWindow).buildMenu();
+    expect(devWindow.webContents.on).toHaveBeenCalledWith('context-menu', expect.any(Function));
+
+    appMock.isPackaged = true;
+    const prodWindow = createMainWindow();
+    new MenuBuilder(prodWindow).buildMenu();
+    expect(prodWindow.webContents.on).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,19 +1,14 @@
-import { app, Menu, shell, BrowserWindow, MenuItemConstructorOptions } from 'electron';
+import { app, BrowserWindow, Menu, MenuItemConstructorOptions, shell } from 'electron';
 
-interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions {
-  selector?: string;
-  submenu?: DarwinMenuItemConstructorOptions[] | Menu;
-}
+const REPOSITORY_URL = 'https://github.com/EXXETA/trufos';
+const DOCUMENTATION_URL = `${REPOSITORY_URL}#readme`;
+const REPORT_ISSUE_URL = `${REPOSITORY_URL}/issues/new/choose`;
 
-export default class MenuBuilder {
-  mainWindow: BrowserWindow;
-
-  constructor(mainWindow: BrowserWindow) {
-    this.mainWindow = mainWindow;
-  }
+export class MenuBuilder {
+  constructor(private readonly mainWindow: BrowserWindow) {}
 
   buildMenu(): Menu {
-    if (process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true') {
+    if (!app.isPackaged) {
       this.setupDevelopmentEnvironment();
     }
 
@@ -22,248 +17,96 @@ export default class MenuBuilder {
 
     const menu = Menu.buildFromTemplate(template);
     Menu.setApplicationMenu(menu);
-
     return menu;
   }
 
-  setupDevelopmentEnvironment(): void {
-    this.mainWindow.webContents.on('context-menu', (_, props) => {
+  private setupDevelopmentEnvironment(): void {
+    this.mainWindow.webContents.on('context-menu', (_event, props) => {
       const { x, y } = props;
 
       Menu.buildFromTemplate([
         {
-          label: 'Inspect element',
-          click: () => {
-            this.mainWindow.webContents.inspectElement(x, y);
-          },
+          label: 'Inspect Element',
+          click: () => this.mainWindow.webContents.inspectElement(x, y),
         },
       ]).popup({ window: this.mainWindow });
     });
   }
 
-  buildDarwinTemplate(): MenuItemConstructorOptions[] {
-    const subMenuAbout: DarwinMenuItemConstructorOptions = {
-      label: 'Electron',
-      submenu: [
-        {
-          label: 'About ElectronReact',
-          selector: 'orderFrontStandardAboutPanel:',
-        },
-        { type: 'separator' },
-        { label: 'Services', submenu: [] },
-        { type: 'separator' },
-        {
-          label: 'Hide ElectronReact',
-          accelerator: 'Command+H',
-          selector: 'hide:',
-        },
-        {
-          label: 'Hide Others',
-          accelerator: 'Command+Shift+H',
-          selector: 'hideOtherApplications:',
-        },
-        { label: 'Show All', selector: 'unhideAllApplications:' },
-        { type: 'separator' },
-        {
-          label: 'Quit',
-          accelerator: 'Command+Q',
-          click: () => {
-            app.quit();
-          },
-        },
-      ],
-    };
-    const subMenuEdit: DarwinMenuItemConstructorOptions = {
-      label: 'Edit',
-      submenu: [
-        { label: 'Undo', accelerator: 'Command+Z', selector: 'undo:' },
-        { label: 'Redo', accelerator: 'Shift+Command+Z', selector: 'redo:' },
-        { type: 'separator' },
-        { label: 'Cut', accelerator: 'Command+X', selector: 'cut:' },
-        { label: 'Copy', accelerator: 'Command+C', selector: 'copy:' },
-        { label: 'Paste', accelerator: 'Command+V', selector: 'paste:' },
-        {
-          label: 'Select All',
-          accelerator: 'Command+A',
-          selector: 'selectAll:',
-        },
-      ],
-    };
-    const subMenuViewDev: MenuItemConstructorOptions = {
-      label: 'View',
-      submenu: [
-        {
-          label: 'Reload',
-          accelerator: 'Command+R',
-          click: () => {
-            this.mainWindow.webContents.reload();
-          },
-        },
-        {
-          label: 'Toggle Full Screen',
-          accelerator: 'Ctrl+Command+F',
-          click: () => {
-            this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen());
-          },
-        },
-        {
-          label: 'Toggle Developer Tools',
-          accelerator: 'Alt+Command+I',
-          click: () => {
-            this.mainWindow.webContents.toggleDevTools();
-          },
-        },
-      ],
-    };
-    const subMenuViewProd: MenuItemConstructorOptions = {
-      label: 'View',
-      submenu: [
-        {
-          label: 'Toggle Full Screen',
-          accelerator: 'Ctrl+Command+F',
-          click: () => {
-            this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen());
-          },
-        },
-      ],
-    };
-    const subMenuWindow: DarwinMenuItemConstructorOptions = {
-      label: 'Window',
-      submenu: [
-        {
-          label: 'Minimize',
-          accelerator: 'Command+M',
-          selector: 'performMiniaturize:',
-        },
-        { label: 'Close', accelerator: 'Command+W', selector: 'performClose:' },
-        { type: 'separator' },
-        { label: 'Bring All to Front', selector: 'arrangeInFront:' },
-      ],
-    };
-    const subMenuHelp: MenuItemConstructorOptions = {
-      label: 'Help',
-      submenu: [
-        {
-          label: 'Learn More',
-          click() {
-            shell.openExternal('https://electronjs.org');
-          },
-        },
-        {
-          label: 'Documentation',
-          click() {
-            shell.openExternal('https://github.com/electron/electron/tree/main/docs#readme');
-          },
-        },
-        {
-          label: 'Community Discussions',
-          click() {
-            shell.openExternal('https://www.electronjs.org/community');
-          },
-        },
-        {
-          label: 'Search Issues',
-          click() {
-            shell.openExternal('https://github.com/electron/electron/issues');
-          },
-        },
-      ],
-    };
-
-    const subMenuView =
-      process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true'
-        ? subMenuViewDev
-        : subMenuViewProd;
-
-    return [subMenuAbout, subMenuEdit, subMenuView, subMenuWindow, subMenuHelp];
+  private buildEditSubmenu(): MenuItemConstructorOptions[] {
+    return [
+      { role: 'undo' },
+      { role: 'redo' },
+      { type: 'separator' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { role: 'selectAll' },
+    ];
   }
 
-  buildDefaultTemplate() {
-    const templateDefault = [
+  private buildViewSubmenu(): MenuItemConstructorOptions[] {
+    const submenu: MenuItemConstructorOptions[] = [{ role: 'togglefullscreen' }];
+    if (!app.isPackaged) {
+      submenu.push({ type: 'separator' }, { role: 'reload' }, { role: 'toggleDevTools' });
+    }
+    return submenu;
+  }
+
+  private buildHelpSubmenu(): MenuItemConstructorOptions[] {
+    return [
       {
-        label: '&File',
-        submenu: [
-          {
-            label: '&Open',
-            accelerator: 'Ctrl+O',
-          },
-          {
-            label: '&Close',
-            accelerator: 'Ctrl+W',
-            click: () => {
-              this.mainWindow.close();
-            },
-          },
-        ],
+        label: 'Documentation',
+        click: () => shell.openExternal(DOCUMENTATION_URL),
       },
       {
-        label: '&View',
-        submenu:
-          process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true'
-            ? [
-                {
-                  label: '&Reload',
-                  accelerator: 'Ctrl+R',
-                  click: () => {
-                    this.mainWindow.webContents.reload();
-                  },
-                },
-                {
-                  label: 'Toggle &Full Screen',
-                  accelerator: 'F11',
-                  click: () => {
-                    this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen());
-                  },
-                },
-                {
-                  label: 'Toggle &Developer Tools',
-                  accelerator: 'Alt+Ctrl+I',
-                  click: () => {
-                    this.mainWindow.webContents.toggleDevTools();
-                  },
-                },
-              ]
-            : [
-                {
-                  label: 'Toggle &Full Screen',
-                  accelerator: 'F11',
-                  click: () => {
-                    this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen());
-                  },
-                },
-              ],
-      },
-      {
-        label: 'Help',
-        submenu: [
-          {
-            label: 'Learn More',
-            click() {
-              shell.openExternal('https://electronjs.org');
-            },
-          },
-          {
-            label: 'Documentation',
-            click() {
-              shell.openExternal('https://github.com/electron/electron/tree/main/docs#readme');
-            },
-          },
-          {
-            label: 'Community Discussions',
-            click() {
-              shell.openExternal('https://www.electronjs.org/community');
-            },
-          },
-          {
-            label: 'Search Issues',
-            click() {
-              shell.openExternal('https://github.com/electron/electron/issues');
-            },
-          },
-        ],
+        label: 'Report an Issue',
+        click: () => shell.openExternal(REPORT_ISSUE_URL),
       },
     ];
+  }
 
-    return templateDefault;
+  private buildDarwinTemplate(): MenuItemConstructorOptions[] {
+    return [
+      {
+        label: app.name,
+        submenu: [
+          { role: 'about' },
+          { type: 'separator' },
+          { role: 'services' },
+          { type: 'separator' },
+          { role: 'hide' },
+          { role: 'hideOthers' },
+          { role: 'unhide' },
+          { type: 'separator' },
+          { role: 'quit' },
+        ],
+      },
+      { label: 'Edit', submenu: this.buildEditSubmenu() },
+      { label: 'View', submenu: this.buildViewSubmenu() },
+      {
+        label: 'Window',
+        submenu: [
+          { role: 'minimize' },
+          { role: 'zoom' },
+          { role: 'close' },
+          { type: 'separator' },
+          { role: 'front' },
+        ],
+      },
+      { role: 'help', submenu: this.buildHelpSubmenu() },
+    ];
+  }
+
+  private buildDefaultTemplate(): MenuItemConstructorOptions[] {
+    return [
+      {
+        label: '&File',
+        submenu: [{ role: 'close' }, { role: 'quit' }],
+      },
+      { label: '&Edit', submenu: this.buildEditSubmenu() },
+      { label: '&View', submenu: this.buildViewSubmenu() },
+      { role: 'help', submenu: this.buildHelpSubmenu() },
+    ];
   }
 }


### PR DESCRIPTION
### **User description**
## Changes

Implements #889 with a deliberately reduced scope (maintainer decision): **only the native menu itself, no app-specific actions yet.**

- **`src/main/menu.ts` rewritten** — the unused electron-react-boilerplate template (`Electron`/`ElectronReact` labels, `electronjs.org` links, deprecated `selector:` options) is gone. The new `MenuBuilder` builds the menu from standard Electron `role`s:
  - **macOS**: app menu (`about`, `services`, `hide`/`hideOthers`/`unhide`, `quit`), Edit (undo/redo/cut/copy/paste/selectAll), View, Window (`minimize`/`zoom`/`close`/`front`), Help.
  - **Windows/Linux**: File (`close`, `quit`), Edit, View, Help.
  - **Help** links to the Trufos README and `issues/new/choose` on the EXXETA/trufos repo.
  - **Dev-only** (`!app.isPackaged`): Reload + Toggle DevTools in the View menu and the Inspect Element context menu.
- **Wired up in `src/main/main.ts`** — `new MenuBuilder(mainWindow).buildMenu()` after window creation, so the menu is actually registered on app start (previously dead code; Electron fell back to its default menu).
- **`src/main/menu.test.ts`** — 10 unit tests: no boilerplate references on any platform, correct macOS/default structure, dev-only gating of Reload/DevTools and the context-menu handler, Help links open the Trufos URLs, menu registered via `Menu.setApplicationMenu`.
- Named export (`MenuBuilder`) instead of the previous default export, per `AGENTS.md`.

**Intentionally out of scope** (per maintainer): menu entries that trigger renderer actions via IPC (New Request/Folder/Collection, Import/Export, Settings, Theme toggle). The proposed File-menu actions from the issue can be added in a follow-up once wanted — the structure supports it.

## Acceptance criteria from #889

- [x] No `Electron`/`ElectronReact`/`electronjs.org` references remain in the menu.
- [x] The menu is actually registered on app start.
- [x] macOS and Windows/Linux variants both build correctly (covered by unit tests for both templates).
- [x] Dev-only items (Reload, DevTools) appear only in development builds.
- [ ] Menu items trigger Trufos actions through IPC — deliberately dropped from scope, see above.

Closes #889

## Testing

- `yarn test`: 431 passed, 1 skipped (10 new menu tests).
- `yarn lint` and `yarn prettier-check`: clean.
- Manual: started the app in dev mode (`yarn start`) — menu registration runs without errors on startup; only pre-existing SVG-prop renderer warnings in the log.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary (not applicable)
- [ ] Changes have been reviewed by second person

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Replace boilerplate electron-react-boilerplate menu with Trufos-branded native menu

- Wire up menu registration in main.ts so menu actually displays on app start

- Implement platform-specific menus using Electron roles (macOS app menu, Windows/Linux file menu)

- Add Help menu linking to Trufos documentation and issue tracker

- Limit Reload and DevTools to development builds only

- Add comprehensive unit tests covering all platforms and dev/prod scenarios

- Document explicit return type requirement in AGENTS.md for exported APIs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Boilerplate Menu<br/>electron-react-boilerplate"] -->|Rewrite| B["Trufos Menu<br/>Standard Electron roles"]
  B -->|Register| C["Menu.setApplicationMenu<br/>in main.ts"]
  C -->|Platform-specific| D["macOS: App/Edit/View/Window/Help"]
  C -->|Platform-specific| E["Windows/Linux: File/Edit/View/Help"]
  D -->|Dev-only| F["Reload + DevTools"]
  E -->|Dev-only| F
  B -->|Links to| G["Trufos GitHub Repo"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>menu.ts</strong><dd><code>Rewrite menu with Trufos branding and standard roles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/menu.ts

<ul><li>Removed all boilerplate references (Electron, ElectronReact, <br>electronjs.org links)<br> <li> Replaced deprecated <code>selector:</code> options with standard Electron <code>role</code>s<br> <li> Refactored into private helper methods for Edit, View, Help submenus<br> <li> macOS menu includes app menu with about/services/hide/quit, Edit, <br>View, Window, Help<br> <li> Windows/Linux menu includes File (close/quit), Edit, View, Help<br> <li> Help menu links to Trufos README and GitHub issues page<br> <li> Dev-only Reload and DevTools entries gated by <code>app.isPackaged</code><br> <li> Changed from default export to named export <code>MenuBuilder</code> class</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/937/files#diff-a8e89ca92b72dea361635d6d87ba1a12933f5e0a701050e3e0a79aab0eea4ce2">+72/-229</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.ts</strong><dd><code>Wire up menu registration on app start</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/main.ts

<ul><li>Import <code>MenuBuilder</code> from menu module<br> <li> Call <code>new MenuBuilder(mainWindow).buildMenu()</code> after window creation<br> <li> Menu is now registered on app start instead of being dead code</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/937/files#diff-7adaa52a2eacb085ba5e07e6683a61fb3601547dc00b51fd50fbaf685e13fe96">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>menu.test.ts</strong><dd><code>Add comprehensive menu builder unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/menu.test.ts

<ul><li>New comprehensive test suite with 10 unit tests<br> <li> Tests verify no boilerplate references on any platform<br> <li> Tests confirm correct macOS app menu structure with standard roles<br> <li> Tests verify Windows/Linux menu structure<br> <li> Tests ensure Reload and DevTools appear only in development builds<br> <li> Tests validate Help menu links open correct Trufos URLs<br> <li> Tests confirm menu is registered via <code>Menu.setApplicationMenu</code><br> <li> Tests verify context-menu handler only registered in development</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/937/files#diff-8ecc1165efabb70ecb554fc43094ee7dbc2656dc73f9928cfd7931c568e1709f">+146/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Document explicit return type requirement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Add documentation requirement for explicit return types on exported <br>functions, hooks, and public class methods<br> <li> Clarify that inference is acceptable for private helpers and inline <br>callbacks<br> <li> Note this is the most common PR review bot finding</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/937/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

