### PR TITLE
feat: move collection runner and settings into the Collection menu

### DIFF
--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -26,9 +26,11 @@ vi.mock('electron', () => ({
 
 import { MenuBuilder } from './menu';
 
+const sendMock = vi.fn();
+
 function createMainWindow() {
   return {
-    webContents: { on: vi.fn(), inspectElement: vi.fn() },
+    webContents: { on: vi.fn(), inspectElement: vi.fn(), send: sendMock },
   } as unknown as BrowserWindow;
 }
 
@@ -84,6 +86,7 @@ describe('MenuBuilder', () => {
     expect(template.map((item) => item.label ?? item.role)).toEqual([
       'Trufos',
       'Edit',
+      'Collection',
       'View',
       'Window',
       'help',
@@ -96,6 +99,7 @@ describe('MenuBuilder', () => {
     expect(template.map((item) => item.label ?? item.role)).toEqual([
       '&File',
       '&Edit',
+      '&Collection',
       '&View',
       'help',
     ]);
@@ -115,6 +119,25 @@ describe('MenuBuilder', () => {
       expect(prodStrings).not.toContain('reload');
       expect(prodStrings).not.toContain('toggleDevTools');
       expect(prodStrings).toContain('togglefullscreen');
+    }
+  );
+
+  it.each(['darwin', 'win32'] as const)(
+    'opens the collection runner and settings from the Collection menu on %s',
+    (platform) => {
+      const template = buildTemplate(platform);
+      const collectionMenu = template.find((item) => item.label?.includes('Collection'))!;
+      const items = collectionMenu.submenu as MenuItemConstructorOptions[];
+
+      const runItem = items.find((item) => item.label === 'Run Collection')!;
+      expect(runItem.accelerator).toBe('CmdOrCtrl+Shift+R');
+      (runItem.click as () => void)();
+      expect(sendMock).toHaveBeenCalledWith('show-collection-runner');
+
+      const settingsItem = items.find((item) => item.label === 'Settings…')!;
+      expect(settingsItem.accelerator).toBe('CmdOrCtrl+Shift+,');
+      (settingsItem.click as () => void)();
+      expect(sendMock).toHaveBeenCalledWith('show-collection-settings');
     }
   );
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -53,6 +53,23 @@ export class MenuBuilder {
     return submenu;
   }
 
+  private buildCollectionSubmenu(): MenuItemConstructorOptions[] {
+    return [
+      {
+        label: 'Run Collection',
+        accelerator: 'CmdOrCtrl+Shift+R',
+        click: () => this.mainWindow.webContents.send('show-collection-runner'),
+      },
+      { type: 'separator' },
+      {
+        // CmdOrCtrl+, stays reserved for the general app settings.
+        label: 'Settings…',
+        accelerator: 'CmdOrCtrl+Shift+,',
+        click: () => this.mainWindow.webContents.send('show-collection-settings'),
+      },
+    ];
+  }
+
   private buildHelpSubmenu(): MenuItemConstructorOptions[] {
     return [
       {
@@ -83,6 +100,7 @@ export class MenuBuilder {
         ],
       },
       { label: 'Edit', submenu: this.buildEditSubmenu() },
+      { label: 'Collection', submenu: this.buildCollectionSubmenu() },
       { label: 'View', submenu: this.buildViewSubmenu() },
       {
         label: 'Window',
@@ -105,6 +123,7 @@ export class MenuBuilder {
         submenu: [{ role: 'close' }, { role: 'quit' }],
       },
       { label: '&Edit', submenu: this.buildEditSubmenu() },
+      { label: '&Collection', submenu: this.buildCollectionSubmenu() },
       { label: '&View', submenu: this.buildViewSubmenu() },
       { role: 'help', submenu: this.buildHelpSubmenu() },
     ];

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -51,20 +51,21 @@ export const App = () => {
       <ThemeProvider>
         <TooltipProvider delayDuration={750}>
           <SidebarProvider className="grid">
-            <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
-              <ResizablePanel defaultSize="25%" minSize={MIN_SIDEBAR_PIXELS}>
-                <Menubar />
-              </ResizablePanel>
-              <ResizableHandle />
-              <ResizablePanel defaultSize="75%" minSize={MIN_REQUEST_WINDOW_PIXELS}>
-                {/* The runner replaces the request window as an alternative main view. */}
-                {isCollectionRunnerOpen ? (
-                  <CollectionRunner open onClose={closeCollectionRunner} />
-                ) : (
+            {/* The runner replaces the whole layout as an alternative full-width view;
+                its own request checklist makes the sidebar redundant. */}
+            {isCollectionRunnerOpen ? (
+              <CollectionRunner open onClose={closeCollectionRunner} />
+            ) : (
+              <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
+                <ResizablePanel defaultSize="25%" minSize={MIN_SIDEBAR_PIXELS}>
+                  <Menubar />
+                </ResizablePanel>
+                <ResizableHandle />
+                <ResizablePanel defaultSize="75%" minSize={MIN_REQUEST_WINDOW_PIXELS}>
                   <RequestWindow />
-                )}
-              </ResizablePanel>
-            </ResizablePanelGroup>
+                </ResizablePanel>
+              </ResizablePanelGroup>
+            )}
             <CollectionSettingsModal
               isOpen={isCollectionSettingsOpen}
               onClose={closeCollectionSettings}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { Menubar } from '@/view/Menubar';
 import { RequestWindow } from '@/view/RequestWindow';
 import { CollectionRunner } from '@/view/CollectionRunner';
+import { CollectionSettingsModal } from '@/components/shared/settings/CollectionSettingsModal';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { ResizablePanel, ResizablePanelGroup, ResizableHandle } from '@/components/ui/resizable';
@@ -10,7 +11,12 @@ import { ThemeProvider } from '@/contexts/ThemeContext';
 import { CollectionStoreProvider } from '@/state/CollectionStoreProvider';
 import { RendererEventService } from '@/services/event/renderer-event-service';
 import { useAppSettingsStore } from '@/state/appSettingsStore';
-import { selectIsCollectionRunnerOpen, useViewActions, useViewStore } from '@/state/viewStore';
+import {
+  selectIsCollectionRunnerOpen,
+  selectIsCollectionSettingsOpen,
+  useViewActions,
+  useViewStore,
+} from '@/state/viewStore';
 import { showError } from '@/error/errorHandler';
 
 const MIN_SIDEBAR_PIXELS = 300;
@@ -18,9 +24,15 @@ const MIN_REQUEST_WINDOW_PIXELS = 500;
 
 export const App = () => {
   const isCollectionRunnerOpen = useViewStore(selectIsCollectionRunnerOpen);
-  const { closeCollectionRunner } = useViewActions();
+  const isCollectionSettingsOpen = useViewStore(selectIsCollectionSettingsOpen);
+  const { closeCollectionRunner, closeCollectionSettings } = useViewActions();
 
   useEffect(() => {
+    // Entry points of the native application menu (Collection > ...).
+    RendererEventService.instance
+      .on('show-collection-runner', () => useViewStore.getState().openCollectionRunner())
+      .on('show-collection-settings', () => useViewStore.getState().openCollectionSettings());
+
     RendererEventService.instance
       .getAppSettings()
       .catch((err) => {
@@ -49,6 +61,10 @@ export const App = () => {
               </ResizablePanel>
             </ResizablePanelGroup>
             <CollectionRunner open={isCollectionRunnerOpen} onClose={closeCollectionRunner} />
+            <CollectionSettingsModal
+              isOpen={isCollectionSettingsOpen}
+              onClose={closeCollectionSettings}
+            />
           </SidebarProvider>
         </TooltipProvider>
       </ThemeProvider>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -57,10 +57,14 @@ export const App = () => {
               </ResizablePanel>
               <ResizableHandle />
               <ResizablePanel defaultSize="75%" minSize={MIN_REQUEST_WINDOW_PIXELS}>
-                <RequestWindow />
+                {/* The runner replaces the request window as an alternative main view. */}
+                {isCollectionRunnerOpen ? (
+                  <CollectionRunner open onClose={closeCollectionRunner} />
+                ) : (
+                  <RequestWindow />
+                )}
               </ResizablePanel>
             </ResizablePanelGroup>
-            <CollectionRunner open={isCollectionRunnerOpen} onClose={closeCollectionRunner} />
             <CollectionSettingsModal
               isOpen={isCollectionSettingsOpen}
               onClose={closeCollectionSettings}

--- a/src/renderer/components/sidebar/SidebarHeaderBar.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.tsx
@@ -1,15 +1,13 @@
-import { useState } from 'react';
 import { SidebarHeader } from '@/components/ui/sidebar';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { AddFolderIcon, CreateRequestIcon, SettingsIcon, SwapIcon } from '@/components/icons';
-import { ArrowUpAZ, ArrowDownAZ, ClockArrowUp, ClockArrowDown, Play } from 'lucide-react';
+import { ArrowUpAZ, ArrowDownAZ, ClockArrowUp, ClockArrowDown } from 'lucide-react';
 
 import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
 import { useViewActions } from '@/state/viewStore';
 import CollectionDropdown from '@/components/sidebar/CollectionDropdown';
 import { Divider } from '@/components/shared/Divider';
-import { CollectionSettingsModal } from '@/components/shared/settings/CollectionSettingsModal';
 import { SortMode, SORT_CYCLE } from '@/components/sidebar/SidebarRequestList/treeUtilities';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { CreatingItem } from '@/components/sidebar/SidebarRequestList/types';
@@ -47,9 +45,8 @@ export const SidebarHeaderBar = ({ onCreateItem }: SidebarHeaderBarProps) => {
 
   const sortMode = useCollectionStore((state) => state.sortMode);
   const { setSortMode } = useCollectionActions();
-  const { openCollectionRunner } = useViewActions();
+  const { openCollectionSettings } = useViewActions();
 
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const buttonClassName = cn('flex h-4 w-4 items-center justify-center gap-1');
 
   const openModal = (type: 'request' | 'folder') => {
@@ -65,93 +62,68 @@ export const SidebarHeaderBar = ({ onCreateItem }: SidebarHeaderBarProps) => {
   useHotkeys([{ keys: 'mod+n', handler: () => openModal('request') }]);
 
   return (
-    <>
-      <SidebarHeader className="flex-col gap-6">
-        <CollectionDropdown />
+    <SidebarHeader className="flex-col gap-6">
+      <CollectionDropdown />
 
-        <Divider />
+      <Divider />
 
-        <div className="-mt-4 mb-2 flex w-full items-center justify-between">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                className={cn(buttonClassName, 'text-text-secondary ml-3')}
-                variant={'ghost'}
-                type="button"
-                size={'icon'}
-                onClick={cycleSortMode}
-                aria-label="Sort collection"
-              >
-                <SortIcon mode={sortMode} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent
-              side="right"
-              className="bg-sidebar-accent text-sidebar-accent-foreground border-0 px-2.5 py-1 text-xs font-medium tracking-wide shadow-sm"
-            >
-              {SORT_MODE_LABELS[sortMode]}
-            </TooltipContent>
-          </Tooltip>
-
-          <div className="flex items-center gap-2">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  className={cn(buttonClassName, 'text-text-secondary')}
-                  variant={'ghost'}
-                  type="button"
-                  size={'icon'}
-                  onClick={openCollectionRunner}
-                  aria-label="Run collection"
-                >
-                  <Play size={16} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent
-                side="bottom"
-                className="bg-sidebar-accent text-sidebar-accent-foreground border-0 px-2.5 py-1 text-xs font-medium tracking-wide shadow-sm"
-              >
-                Run collection
-              </TooltipContent>
-            </Tooltip>
-
+      <div className="-mt-4 mb-2 flex w-full items-center justify-between">
+        <Tooltip>
+          <TooltipTrigger asChild>
             <Button
-              className={buttonClassName}
+              className={cn(buttonClassName, 'text-text-secondary ml-3')}
               variant={'ghost'}
               type="button"
               size={'icon'}
-              onClick={() => openModal('request')}
-              aria-label="Add new request"
+              onClick={cycleSortMode}
+              aria-label="Sort collection"
             >
-              <CreateRequestIcon size={16} color={'secondary'} />
+              <SortIcon mode={sortMode} />
             </Button>
+          </TooltipTrigger>
+          <TooltipContent
+            side="right"
+            className="bg-sidebar-accent text-sidebar-accent-foreground border-0 px-2.5 py-1 text-xs font-medium tracking-wide shadow-sm"
+          >
+            {SORT_MODE_LABELS[sortMode]}
+          </TooltipContent>
+        </Tooltip>
 
-            <Button
-              className={buttonClassName}
-              variant={'ghost'}
-              size={'icon'}
-              type="button"
-              onClick={() => openModal('folder')}
-              aria-label="Add new folder"
-            >
-              <AddFolderIcon size={16} color={'secondary'} />
-            </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            className={buttonClassName}
+            variant={'ghost'}
+            type="button"
+            size={'icon'}
+            onClick={() => openModal('request')}
+            aria-label="Add new request"
+          >
+            <CreateRequestIcon size={16} color={'secondary'} />
+          </Button>
 
-            <Button
-              className={buttonClassName}
-              variant={'ghost'}
-              size={'icon'}
-              type="button"
-              onClick={() => setIsSettingsOpen(true)}
-              aria-label="Collection settings"
-            >
-              <SettingsIcon size={16} color={'secondary'} />
-            </Button>
-          </div>
+          <Button
+            className={buttonClassName}
+            variant={'ghost'}
+            size={'icon'}
+            type="button"
+            onClick={() => openModal('folder')}
+            aria-label="Add new folder"
+          >
+            <AddFolderIcon size={16} color={'secondary'} />
+          </Button>
+
+          <Button
+            className={buttonClassName}
+            variant={'ghost'}
+            size={'icon'}
+            type="button"
+            onClick={openCollectionSettings}
+            aria-label="Collection settings"
+          >
+            <SettingsIcon size={16} color={'secondary'} />
+          </Button>
         </div>
-      </SidebarHeader>
-
-      <CollectionSettingsModal isOpen={isSettingsOpen} onClose={() => setIsSettingsOpen(false)} />
-    </>
+      </div>
+    </SidebarHeader>
   );
 };

--- a/src/renderer/services/event/renderer-event-service.ts
+++ b/src/renderer/services/event/renderer-event-service.ts
@@ -25,6 +25,10 @@ function createEventMethod<T extends keyof IEventService>(methodName: T) {
 export interface RendererEventService {
   on(event: 'before-close', listener: () => void): this;
 
+  on(event: 'show-collection-runner', listener: () => void): this;
+
+  on(event: 'show-collection-settings', listener: () => void): this;
+
   emit(event: 'ready-to-close'): this;
 }
 

--- a/src/renderer/state/viewStore.ts
+++ b/src/renderer/state/viewStore.ts
@@ -5,16 +5,21 @@ import { useActions } from '@/state/helper/util';
 interface ViewState {
   /** Whether the collection runner modal is open */
   isCollectionRunnerOpen: boolean;
+  /** Whether the collection settings modal is open */
+  isCollectionSettingsOpen: boolean;
 }
 
 interface ViewActions {
   openCollectionRunner(): void;
   closeCollectionRunner(): void;
+  openCollectionSettings(): void;
+  closeCollectionSettings(): void;
 }
 
 export const useViewStore = create<ViewState & ViewActions>()(
   immer((set) => ({
     isCollectionRunnerOpen: false,
+    isCollectionSettingsOpen: false,
 
     openCollectionRunner() {
       set((state) => {
@@ -27,8 +32,21 @@ export const useViewStore = create<ViewState & ViewActions>()(
         state.isCollectionRunnerOpen = false;
       });
     },
+
+    openCollectionSettings() {
+      set((state) => {
+        state.isCollectionSettingsOpen = true;
+      });
+    },
+
+    closeCollectionSettings() {
+      set((state) => {
+        state.isCollectionSettingsOpen = false;
+      });
+    },
   }))
 );
 
 export const selectIsCollectionRunnerOpen = (state: ViewState) => state.isCollectionRunnerOpen;
+export const selectIsCollectionSettingsOpen = (state: ViewState) => state.isCollectionSettingsOpen;
 export const useViewActions = (): ViewActions => useViewStore(useActions());

--- a/src/renderer/test-setup.ts
+++ b/src/renderer/test-setup.ts
@@ -19,6 +19,13 @@ HTMLElement.prototype.setPointerCapture = vi.fn();
 // Scroll APIs (used by Radix UI for keyboard navigation)
 HTMLElement.prototype.scrollIntoView = vi.fn();
 
+// ResizeObserver (used by react-resizable-panels)
+globalThis.ResizeObserver = class ResizeObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+};
+
 afterEach(() => {
   cleanup();
 });

--- a/src/renderer/view/CollectionRunner.test.tsx
+++ b/src/renderer/view/CollectionRunner.test.tsx
@@ -39,6 +39,15 @@ vi.mock('@/components/mainWindow/bodyTabs/OutputTabs/PrettyRenderer', () => ({
   useResponseData: vi.fn(),
 }));
 
+// react-resizable-panels registers document-level pointer handlers that call
+// preventDefault; with jsdom's zero-sized rects they swallow clicks meant for
+// Radix items, so the layout components are reduced to plain containers here.
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => null,
+}));
+
 vi.mock('@/error/errorHandler', () => ({
   showError: (...args: unknown[]) => showErrorMock(...args),
 }));
@@ -183,6 +192,21 @@ describe('CollectionRunner rendering', () => {
     expect(screen.getByText('Orders')).toBeDefined();
     const folderRow = screen.getByText('Orders').closest('label')!;
     expect(within(folderRow).getByText('2')).toBeDefined();
+  });
+
+  it('collapses and expands folder contents in the checklist', async () => {
+    const user = userEvent.setup();
+    renderRunner();
+
+    // Folder children appear in the checklist and in the results table.
+    expect(screen.getAllByText('List Orders')).toHaveLength(2);
+
+    await user.click(screen.getByRole('button', { name: 'Collapse Orders' }));
+    // Hidden in the checklist, still listed in the results table.
+    expect(screen.getAllByText('List Orders')).toHaveLength(1);
+
+    await user.click(screen.getByRole('button', { name: 'Expand Orders' }));
+    expect(screen.getAllByText('List Orders')).toHaveLength(2);
   });
 
   it('selects all requests by default and shows the count on the run button', () => {

--- a/src/renderer/view/CollectionRunner.test.tsx
+++ b/src/renderer/view/CollectionRunner.test.tsx
@@ -394,9 +394,10 @@ describe('CollectionRunner execution', () => {
 
     await user.click(screen.getByRole('button', { name: /run 4 requests/i }));
 
-    // "Running" appears twice: as the result pill and as the run button label.
-    expect(screen.getAllByText('Running')).toHaveLength(2);
-    expect(screen.getByRole('button', { name: /stop/i })).toBeDefined();
+    // "Running" appears once as the result pill; the run button becomes the stop button.
+    expect(screen.getAllByText('Running')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /stop run/i })).toBeDefined();
+    expect(screen.queryByRole('button', { name: /run 4 requests/i })).toBeNull();
     expect(screen.getByText('0 / 4 done')).toBeDefined();
     for (const checkbox of screen.getAllByRole('checkbox')) {
       expect(checkbox.hasAttribute('disabled')).toBe(true);

--- a/src/renderer/view/CollectionRunner.tsx
+++ b/src/renderer/view/CollectionRunner.tsx
@@ -12,8 +12,9 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { ResizablePanel, ResizablePanelGroup, ResizableHandle } from '@/components/ui/resizable';
 import { useResponseData } from '@/components/mainWindow/bodyTabs/OutputTabs/PrettyRenderer';
-import { FolderIcon } from '@/components/icons';
+import { FolderIcon, SmallArrow } from '@/components/icons';
 import { HttpService } from '@/services/http/http-service';
 import { httpMethodColor } from '@/services/StyleHelper';
 import { getIndentation } from '@/components/sidebar/SidebarRequestList/Nav/indentation';
@@ -37,12 +38,18 @@ const httpService = HttpService.instance;
 /** Sentinel for "no environment" since radix Select does not allow empty item values. */
 const NO_ENVIRONMENT = '__none__';
 
+// Same constraints as the main layout in App so the rail matches the sidebar.
+const MIN_SIDEBAR_PIXELS = 300;
+const MIN_RESULTS_PIXELS = 500;
+
 type RunnerItem =
   | {
       type: 'folder';
       id: string;
       title: string;
       depth: number;
+      /** Ids of all folders this item is nested in */
+      ancestors: string[];
       requestIds: string[];
     }
   | {
@@ -50,6 +57,8 @@ type RunnerItem =
       id: string;
       title: string;
       depth: number;
+      /** Ids of all folders this item is nested in */
+      ancestors: string[];
       request: TrufosRequest;
     };
 
@@ -79,7 +88,8 @@ function buildRunnerItems(
   children: Array<Folder | TrufosRequest>,
   folders: Map<string, Folder>,
   requests: Map<string, TrufosRequest>,
-  depth = 0
+  depth = 0,
+  ancestors: string[] = []
 ): RunnerItem[] {
   return children.flatMap((child): RunnerItem[] => {
     if (child.type === 'request') {
@@ -90,6 +100,7 @@ function buildRunnerItems(
           id: request.id,
           title: request.title || request.url.base,
           depth,
+          ancestors,
           request,
         },
       ];
@@ -102,9 +113,10 @@ function buildRunnerItems(
         id: folder.id,
         title: folder.title,
         depth,
+        ancestors,
         requestIds: collectRequestIds(folder, folders),
       },
-      ...buildRunnerItems(folder.children, folders, requests, depth + 1),
+      ...buildRunnerItems(folder.children, folders, requests, depth + 1, [...ancestors, folder.id]),
     ];
   });
 }
@@ -226,6 +238,7 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
   const [results, setResults] = useState<Record<string, RunnerResult>>({});
   const [runOrder, setRunOrder] = useState<string[]>([]);
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+  const [collapsedFolders, setCollapsedFolders] = useState<Set<string>>(new Set());
   const [totalDuration, setTotalDuration] = useState<number | null>(null);
 
   // Incremented to invalidate an in-flight run (stop button, collection switch, unmount).
@@ -279,6 +292,7 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
     setResults({});
     setRunOrder([]);
     setExpandedRows(new Set());
+    setCollapsedFolders(new Set());
     setTotalDuration(null);
     setIsRunning(false);
   }, [abortActiveRequest, collection?.id]);
@@ -300,6 +314,12 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
   const items = useMemo(
     () => buildRunnerItems(collection?.children ?? [], folders, requests),
     [collection?.children, folders, requests]
+  );
+
+  // Items inside a collapsed folder are hidden from the checklist but stay selected.
+  const visibleItems = useMemo(
+    () => items.filter((item) => !item.ancestors.some((id) => collapsedFolders.has(id))),
+    [items, collapsedFolders]
   );
 
   const orderedRequests = useMemo(
@@ -343,6 +363,18 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
         } else {
           next.delete(requestId);
         }
+      }
+      return next;
+    });
+  };
+
+  const toggleFolderCollapsed = (folderId: string) => {
+    setCollapsedFolders((current) => {
+      const next = new Set(current);
+      if (next.has(folderId)) {
+        next.delete(folderId);
+      } else {
+        next.add(folderId);
       }
       return next;
     });
@@ -437,85 +469,9 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
   if (!open) return null;
 
   return (
-    <div className="grid h-full w-full grid-rows-[auto_auto_1fr_auto] p-6">
-      <div className="mb-4 flex items-center justify-between gap-4">
-        <div className="min-w-0">
-          <h2 className="text-xl leading-6 font-semibold">Collection Runner</h2>
-          <p className="text-text-secondary mt-1 truncate text-sm">
-            {collection?.title ?? 'Current collection'}
-          </p>
-        </div>
-
-        <div className="flex shrink-0 items-center gap-3">
-          <div className="flex items-center gap-2 text-sm">
-            <span className="text-text-secondary">Environment</span>
-            <Select
-              value={selectedEnvironment ?? NO_ENVIRONMENT}
-              onValueChange={(value) =>
-                void selectEnvironment(value === NO_ENVIRONMENT ? undefined : value)
-              }
-              disabled={isRunning}
-            >
-              <SelectTrigger
-                className="border-border h-8 gap-2 rounded-md border px-3"
-                aria-label="Select environment"
-              >
-                <SelectValue placeholder="No environment" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={NO_ENVIRONMENT}>No environment</SelectItem>
-                {Object.keys(environments).map((key) => (
-                  <SelectItem key={key} value={key}>
-                    {key}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          {isRunning && (
-            <>
-              <span className="text-text-secondary text-sm tabular-nums">
-                {done} / {runOrder.length} done
-              </span>
-              <Button className="text-danger gap-2" onClick={stopRun} variant="secondary">
-                <Square className="h-3.5 w-3.5" />
-                Stop
-              </Button>
-            </>
-          )}
-          <Button
-            className="text-text-secondary hover:text-text-primary"
-            variant="ghost"
-            size="icon"
-            type="button"
-            onClick={onClose}
-            aria-label="Close collection runner"
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-
-      <div className={cn('flex gap-1', runOrder.length > 0 && 'mb-4')}>
-        {runOrder.map((requestId) => {
-          const result = results[requestId];
-          return (
-            <span
-              key={requestId}
-              className={cn(
-                'h-1 flex-1 rounded-full',
-                result?.state === 'passed' && 'bg-state-success',
-                isFailure(result) && 'bg-danger',
-                result?.state === 'running' && 'bg-accent-primary animate-pulse',
-                result == null && 'bg-border'
-              )}
-            />
-          );
-        })}
-      </div>
-
-      <div className="grid min-h-0 grid-cols-[minmax(260px,360px)_1fr] gap-6">
-        <aside className="border-border bg-sidebar flex min-h-0 flex-col rounded-lg border">
+    <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
+      <ResizablePanel defaultSize="25%" minSize={MIN_SIDEBAR_PIXELS}>
+        <aside className="bg-sidebar flex h-full flex-col">
           <div className="border-border flex items-center justify-between border-b px-4 py-3">
             <span className="text-sm font-semibold">Requests</span>
             <div className="flex gap-2 text-xs">
@@ -547,7 +503,7 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
           </div>
 
           <div className="tabs-scrollbar min-h-0 flex-1 overflow-y-auto py-2">
-            {items.map((item) => {
+            {visibleItems.map((item) => {
               if (item.type === 'folder') {
                 const checkedCount = item.requestIds.filter((id) =>
                   selectedRequestIds.has(id)
@@ -558,6 +514,7 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
                     : checkedCount === item.requestIds.length
                       ? true
                       : 'indeterminate';
+                const isCollapsed = collapsedFolders.has(item.id);
                 return (
                   <label
                     key={item.id}
@@ -574,6 +531,21 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
                         setRequestsSelected(item.requestIds, value === true)
                       }
                     />
+                    <button
+                      className={cn(
+                        'h-6 w-6 shrink-0 cursor-pointer transition-transform duration-300 ease-in-out',
+                        isCollapsed ? 'rotate-270' : 'rotate-0'
+                      )}
+                      type="button"
+                      aria-label={isCollapsed ? `Expand ${item.title}` : `Collapse ${item.title}`}
+                      aria-expanded={!isCollapsed}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        toggleFolderCollapsed(item.id);
+                      }}
+                    >
+                      <SmallArrow size={24} />
+                    </button>
                     <FolderIcon size={16} />
                     <span className="flex-1 truncate">{item.title}</span>
                     <span className="text-text-secondary ml-auto text-xs tabular-nums">
@@ -638,100 +610,182 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
             </Button>
           </div>
         </aside>
+      </ResizablePanel>
 
-        <main className="border-border bg-card flex min-h-0 flex-col rounded-lg border">
-          <div className="border-border text-text-secondary grid grid-cols-[minmax(180px,1fr)_90px_100px_90px] gap-4 border-b px-4 py-3 text-xs font-semibold tracking-wide uppercase">
-            <span>Name</span>
-            <span>Status</span>
-            <span>Result</span>
-            <span>Time</span>
+      <ResizableHandle />
+
+      <ResizablePanel defaultSize="75%" minSize={MIN_RESULTS_PIXELS}>
+        <div className="grid h-full grid-rows-[auto_auto_1fr_auto] p-6">
+          <div className="mb-4 flex items-center justify-between gap-4">
+            <div className="min-w-0">
+              <h2 className="text-xl leading-6 font-semibold">Collection Runner</h2>
+              <p className="text-text-secondary mt-1 truncate text-sm">
+                {collection?.title ?? 'Current collection'}
+              </p>
+            </div>
+
+            <div className="flex shrink-0 items-center gap-3">
+              <div className="flex items-center gap-2 text-sm">
+                <span className="text-text-secondary">Environment</span>
+                <Select
+                  value={selectedEnvironment ?? NO_ENVIRONMENT}
+                  onValueChange={(value) =>
+                    void selectEnvironment(value === NO_ENVIRONMENT ? undefined : value)
+                  }
+                  disabled={isRunning}
+                >
+                  <SelectTrigger
+                    className="border-border h-8 gap-2 rounded-md border px-3"
+                    aria-label="Select environment"
+                  >
+                    <SelectValue placeholder="No environment" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NO_ENVIRONMENT}>No environment</SelectItem>
+                    {Object.keys(environments).map((key) => (
+                      <SelectItem key={key} value={key}>
+                        {key}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {isRunning && (
+                <>
+                  <span className="text-text-secondary text-sm tabular-nums">
+                    {done} / {runOrder.length} done
+                  </span>
+                  <Button className="text-danger gap-2" onClick={stopRun} variant="secondary">
+                    <Square className="h-3.5 w-3.5" />
+                    Stop
+                  </Button>
+                </>
+              )}
+              <Button
+                className="text-text-secondary hover:text-text-primary"
+                variant="ghost"
+                size="icon"
+                type="button"
+                onClick={onClose}
+                aria-label="Close collection runner"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
           </div>
 
-          <div className="tabs-scrollbar min-h-0 flex-1 overflow-y-auto">
-            {orderedRequests.map((request) => {
-              const result = results[request.id];
-              const response =
-                result?.state === 'passed' || result?.state === 'failed'
-                  ? result.response
-                  : undefined;
-              const isExpanded = expandedRows.has(request.id);
-              const isSelected = selectedRequestIds.has(request.id);
-              const duration =
-                response?.metaInfo.duration ??
-                (result?.state === 'error' ? result.duration : undefined);
+          <div className={cn('flex gap-1', runOrder.length > 0 && 'mb-4')}>
+            {runOrder.map((requestId) => {
+              const result = results[requestId];
               return (
-                <Collapsible
-                  key={request.id}
-                  open={isExpanded}
-                  onOpenChange={() => toggleExpanded(request.id)}
-                >
-                  <CollapsibleTrigger asChild>
-                    <button
-                      className={cn(
-                        'hover:bg-sidebar-accent grid w-full grid-cols-[minmax(180px,1fr)_90px_100px_90px] items-center gap-4 border-b px-4 py-3 text-left text-sm',
-                        !isSelected && 'opacity-50'
-                      )}
-                      type="button"
-                    >
-                      <span className="flex min-w-0 items-center gap-2">
-                        {isExpanded ? (
-                          <ChevronDown className="h-4 w-4 shrink-0" />
-                        ) : (
-                          <ChevronRight className="h-4 w-4 shrink-0" />
-                        )}
-                        <span
-                          className={cn(
-                            'w-12 shrink-0 text-xs font-bold',
-                            httpMethodColor(request.method)
-                          )}
-                        >
-                          {request.method}
-                        </span>
-                        <span className="truncate">{request.title || request.url.base}</span>
-                      </span>
-                      <span className="tabular-nums">{response?.metaInfo.status ?? '-'}</span>
-                      <ResultPill result={result} />
-                      <span className="tabular-nums">
-                        {duration == null ? '-' : formatDuration(duration)}
-                      </span>
-                    </button>
-                  </CollapsibleTrigger>
-
-                  <CollapsibleContent className="border-border bg-background-secondary/40 border-b px-4 py-4">
-                    {result == null ? (
-                      <p className="text-text-secondary text-sm">No result yet.</p>
-                    ) : result.state === 'error' ? (
-                      <p className="text-danger text-sm">{result.error}</p>
-                    ) : result.state === 'running' ? (
-                      <p className="text-text-secondary text-sm">Request is running.</p>
-                    ) : (
-                      <ResponseDetail response={result.response} />
-                    )}
-                  </CollapsibleContent>
-                </Collapsible>
+                <span
+                  key={requestId}
+                  className={cn(
+                    'h-1 flex-1 rounded-full',
+                    result?.state === 'passed' && 'bg-state-success',
+                    isFailure(result) && 'bg-danger',
+                    result?.state === 'running' && 'bg-accent-primary animate-pulse',
+                    result == null && 'bg-border'
+                  )}
+                />
               );
             })}
           </div>
-        </main>
-      </div>
 
-      <div className="flex items-center gap-3 pt-4">
-        <div className="border-border bg-card flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
-          <span className="text-base font-bold tabular-nums">{totalInRun}</span>
-          <span className="text-text-secondary text-xs">total</span>
+          <main className="border-border bg-card flex min-h-0 flex-col rounded-lg border">
+            <div className="border-border text-text-secondary grid grid-cols-[minmax(180px,1fr)_90px_100px_90px] gap-4 border-b px-4 py-3 text-xs font-semibold tracking-wide uppercase">
+              <span>Name</span>
+              <span>Status</span>
+              <span>Result</span>
+              <span>Time</span>
+            </div>
+
+            <div className="tabs-scrollbar min-h-0 flex-1 overflow-y-auto">
+              {orderedRequests.map((request) => {
+                const result = results[request.id];
+                const response =
+                  result?.state === 'passed' || result?.state === 'failed'
+                    ? result.response
+                    : undefined;
+                const isExpanded = expandedRows.has(request.id);
+                const isSelected = selectedRequestIds.has(request.id);
+                const duration =
+                  response?.metaInfo.duration ??
+                  (result?.state === 'error' ? result.duration : undefined);
+                return (
+                  <Collapsible
+                    key={request.id}
+                    open={isExpanded}
+                    onOpenChange={() => toggleExpanded(request.id)}
+                  >
+                    <CollapsibleTrigger asChild>
+                      <button
+                        className={cn(
+                          'hover:bg-sidebar-accent grid w-full grid-cols-[minmax(180px,1fr)_90px_100px_90px] items-center gap-4 border-b px-4 py-3 text-left text-sm',
+                          !isSelected && 'opacity-50'
+                        )}
+                        type="button"
+                      >
+                        <span className="flex min-w-0 items-center gap-2">
+                          {isExpanded ? (
+                            <ChevronDown className="h-4 w-4 shrink-0" />
+                          ) : (
+                            <ChevronRight className="h-4 w-4 shrink-0" />
+                          )}
+                          <span
+                            className={cn(
+                              'w-12 shrink-0 text-xs font-bold',
+                              httpMethodColor(request.method)
+                            )}
+                          >
+                            {request.method}
+                          </span>
+                          <span className="truncate">{request.title || request.url.base}</span>
+                        </span>
+                        <span className="tabular-nums">{response?.metaInfo.status ?? '-'}</span>
+                        <ResultPill result={result} />
+                        <span className="tabular-nums">
+                          {duration == null ? '-' : formatDuration(duration)}
+                        </span>
+                      </button>
+                    </CollapsibleTrigger>
+
+                    <CollapsibleContent className="border-border bg-background-secondary/40 border-b px-4 py-4">
+                      {result == null ? (
+                        <p className="text-text-secondary text-sm">No result yet.</p>
+                      ) : result.state === 'error' ? (
+                        <p className="text-danger text-sm">{result.error}</p>
+                      ) : result.state === 'running' ? (
+                        <p className="text-text-secondary text-sm">Request is running.</p>
+                      ) : (
+                        <ResponseDetail response={result.response} />
+                      )}
+                    </CollapsibleContent>
+                  </Collapsible>
+                );
+              })}
+            </div>
+          </main>
+
+          <div className="flex items-center gap-3 pt-4">
+            <div className="border-border bg-card flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
+              <span className="text-base font-bold tabular-nums">{totalInRun}</span>
+              <span className="text-text-secondary text-xs">total</span>
+            </div>
+            <div className="border-border bg-card flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
+              <span className="text-state-success text-base font-bold tabular-nums">{passed}</span>
+              <span className="text-text-secondary text-xs">passed</span>
+            </div>
+            <div className="border-border bg-card flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
+              <span className="text-danger text-base font-bold tabular-nums">{failed}</span>
+              <span className="text-text-secondary text-xs">failed</span>
+            </div>
+            <span className="text-text-secondary ml-auto text-sm tabular-nums">
+              Elapsed {totalDuration == null ? '-' : formatDuration(totalDuration)}
+            </span>
+          </div>
         </div>
-        <div className="border-border bg-card flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
-          <span className="text-state-success text-base font-bold tabular-nums">{passed}</span>
-          <span className="text-text-secondary text-xs">passed</span>
-        </div>
-        <div className="border-border bg-card flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
-          <span className="text-danger text-base font-bold tabular-nums">{failed}</span>
-          <span className="text-text-secondary text-xs">failed</span>
-        </div>
-        <span className="text-text-secondary ml-auto text-sm tabular-nums">
-          Elapsed {totalDuration == null ? '-' : formatDuration(totalDuration)}
-        </span>
-      </div>
-    </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
   );
 }

--- a/src/renderer/view/CollectionRunner.tsx
+++ b/src/renderer/view/CollectionRunner.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { editor } from 'monaco-editor';
-import { ChevronDown, ChevronRight, Loader2, Play, Square } from 'lucide-react';
+import { ChevronDown, ChevronRight, Loader2, Play, Square, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import {
   Select,
   SelectContent,
@@ -253,7 +252,7 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
     [abortActiveRequest]
   );
 
-  // Abort an in-flight run when the modal is closed.
+  // Abort an in-flight run when the runner view is closed.
   useEffect(() => {
     if (!open) {
       runIdRef.current++;
@@ -261,6 +260,16 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
       setIsRunning(false);
     }
   }, [abortActiveRequest, open]);
+
+  // Close the runner view with Escape, like the previous dialog did.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [open, onClose]);
 
   useEffect(() => {
     runIdRef.current++;
@@ -424,142 +433,130 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
     setIsRunning(false);
   };
 
+  if (!open) return null;
+
   return (
-    <Dialog open={open} onOpenChange={(value) => !value && onClose()}>
-      <DialogContent className="top-0 left-0 grid h-screen w-screen max-w-none translate-x-0 translate-y-0 grid-rows-[auto_auto_1fr_auto] gap-0 rounded-none border-0 p-6 sm:rounded-none">
-        <div className="mb-4 flex items-center justify-between gap-4">
-          <div className="min-w-0">
-            <DialogTitle className="text-xl leading-6 font-semibold">Collection Runner</DialogTitle>
-            <DialogDescription className="text-text-secondary mt-1 truncate text-sm">
-              {collection?.title ?? 'Current collection'}
-            </DialogDescription>
-          </div>
+    <div className="grid h-full w-full grid-rows-[auto_auto_1fr_auto] p-6">
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <h2 className="text-xl leading-6 font-semibold">Collection Runner</h2>
+          <p className="text-text-secondary mt-1 truncate text-sm">
+            {collection?.title ?? 'Current collection'}
+          </p>
+        </div>
 
-          <div className="mr-10 flex shrink-0 items-center gap-3">
-            <div className="flex items-center gap-2 text-sm">
-              <span className="text-text-secondary">Environment</span>
-              <Select
-                value={selectedEnvironment ?? NO_ENVIRONMENT}
-                onValueChange={(value) =>
-                  void selectEnvironment(value === NO_ENVIRONMENT ? undefined : value)
-                }
-                disabled={isRunning}
+        <div className="flex shrink-0 items-center gap-3">
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-text-secondary">Environment</span>
+            <Select
+              value={selectedEnvironment ?? NO_ENVIRONMENT}
+              onValueChange={(value) =>
+                void selectEnvironment(value === NO_ENVIRONMENT ? undefined : value)
+              }
+              disabled={isRunning}
+            >
+              <SelectTrigger
+                className="border-border h-8 gap-2 rounded-md border px-3"
+                aria-label="Select environment"
               >
-                <SelectTrigger
-                  className="border-border h-8 gap-2 rounded-md border px-3"
-                  aria-label="Select environment"
-                >
-                  <SelectValue placeholder="No environment" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={NO_ENVIRONMENT}>No environment</SelectItem>
-                  {Object.keys(environments).map((key) => (
-                    <SelectItem key={key} value={key}>
-                      {key}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            {isRunning && (
-              <>
-                <span className="text-text-secondary text-sm tabular-nums">
-                  {done} / {runOrder.length} done
-                </span>
-                <Button className="text-danger gap-2" onClick={stopRun} variant="secondary">
-                  <Square className="h-3.5 w-3.5" />
-                  Stop
-                </Button>
-              </>
-            )}
+                <SelectValue placeholder="No environment" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_ENVIRONMENT}>No environment</SelectItem>
+                {Object.keys(environments).map((key) => (
+                  <SelectItem key={key} value={key}>
+                    {key}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
+          {isRunning && (
+            <>
+              <span className="text-text-secondary text-sm tabular-nums">
+                {done} / {runOrder.length} done
+              </span>
+              <Button className="text-danger gap-2" onClick={stopRun} variant="secondary">
+                <Square className="h-3.5 w-3.5" />
+                Stop
+              </Button>
+            </>
+          )}
+          <Button
+            className="text-text-secondary hover:text-text-primary"
+            variant="ghost"
+            size="icon"
+            type="button"
+            onClick={onClose}
+            aria-label="Close collection runner"
+          >
+            <X className="h-4 w-4" />
+          </Button>
         </div>
+      </div>
 
-        <div className={cn('flex gap-1', runOrder.length > 0 && 'mb-4')}>
-          {runOrder.map((requestId) => {
-            const result = results[requestId];
-            return (
-              <span
-                key={requestId}
-                className={cn(
-                  'h-1 flex-1 rounded-full',
-                  result?.state === 'passed' && 'bg-state-success',
-                  isFailure(result) && 'bg-danger',
-                  result?.state === 'running' && 'bg-accent-primary animate-pulse',
-                  result == null && 'bg-border'
-                )}
-              />
-            );
-          })}
-        </div>
+      <div className={cn('flex gap-1', runOrder.length > 0 && 'mb-4')}>
+        {runOrder.map((requestId) => {
+          const result = results[requestId];
+          return (
+            <span
+              key={requestId}
+              className={cn(
+                'h-1 flex-1 rounded-full',
+                result?.state === 'passed' && 'bg-state-success',
+                isFailure(result) && 'bg-danger',
+                result?.state === 'running' && 'bg-accent-primary animate-pulse',
+                result == null && 'bg-border'
+              )}
+            />
+          );
+        })}
+      </div>
 
-        <div className="grid min-h-0 grid-cols-[minmax(260px,360px)_1fr] gap-6">
-          <aside className="border-border flex min-h-0 flex-col rounded-lg border">
-            <div className="border-border flex items-center justify-between border-b px-4 py-3">
-              <span className="text-sm font-semibold">Requests</span>
-              <div className="flex gap-2 text-xs">
-                <button
-                  className="text-accent-primary cursor-pointer"
-                  type="button"
-                  onClick={() =>
-                    setRequestsSelected(
-                      orderedRequests.map((request) => request.id),
-                      true
-                    )
-                  }
-                >
-                  All
-                </button>
-                <button
-                  className="text-text-secondary cursor-pointer"
-                  type="button"
-                  onClick={() =>
-                    setRequestsSelected(
-                      orderedRequests.map((request) => request.id),
-                      false
-                    )
-                  }
-                >
-                  None
-                </button>
-              </div>
-            </div>
-
-            <div className="tabs-scrollbar min-h-0 flex-1 overflow-y-auto py-2">
-              {items.map((item) => {
-                if (item.type === 'folder') {
-                  const checkedCount = item.requestIds.filter((id) =>
-                    selectedRequestIds.has(id)
-                  ).length;
-                  const checked =
-                    checkedCount === 0
-                      ? false
-                      : checkedCount === item.requestIds.length
-                        ? true
-                        : 'indeterminate';
-                  return (
-                    <label
-                      key={item.id}
-                      className={cn(
-                        'hover:bg-sidebar-accent flex cursor-pointer items-center gap-2 py-2 pr-4 text-sm',
-                        getIndentation(item.depth)
-                      )}
-                    >
-                      <Checkbox
-                        checked={checked}
-                        disabled={isRunning || item.requestIds.length === 0}
-                        onCheckedChange={(value) =>
-                          setRequestsSelected(item.requestIds, value === true)
-                        }
-                      />
-                      <span className="truncate font-medium">{item.title}</span>
-                      <span className="text-text-secondary ml-auto text-xs tabular-nums">
-                        {item.requestIds.length}
-                      </span>
-                    </label>
-                  );
+      <div className="grid min-h-0 grid-cols-[minmax(260px,360px)_1fr] gap-6">
+        <aside className="border-border flex min-h-0 flex-col rounded-lg border">
+          <div className="border-border flex items-center justify-between border-b px-4 py-3">
+            <span className="text-sm font-semibold">Requests</span>
+            <div className="flex gap-2 text-xs">
+              <button
+                className="text-accent-primary cursor-pointer"
+                type="button"
+                onClick={() =>
+                  setRequestsSelected(
+                    orderedRequests.map((request) => request.id),
+                    true
+                  )
                 }
+              >
+                All
+              </button>
+              <button
+                className="text-text-secondary cursor-pointer"
+                type="button"
+                onClick={() =>
+                  setRequestsSelected(
+                    orderedRequests.map((request) => request.id),
+                    false
+                  )
+                }
+              >
+                None
+              </button>
+            </div>
+          </div>
 
+          <div className="tabs-scrollbar min-h-0 flex-1 overflow-y-auto py-2">
+            {items.map((item) => {
+              if (item.type === 'folder') {
+                const checkedCount = item.requestIds.filter((id) =>
+                  selectedRequestIds.has(id)
+                ).length;
+                const checked =
+                  checkedCount === 0
+                    ? false
+                    : checkedCount === item.requestIds.length
+                      ? true
+                      : 'indeterminate';
                 return (
                   <label
                     key={item.id}
@@ -569,146 +566,168 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
                     )}
                   >
                     <Checkbox
-                      checked={selectedRequestIds.has(item.id)}
-                      disabled={isRunning}
-                      onCheckedChange={(value) => setRequestSelected(item.id, value === true)}
+                      checked={checked}
+                      disabled={isRunning || item.requestIds.length === 0}
+                      onCheckedChange={(value) =>
+                        setRequestsSelected(item.requestIds, value === true)
+                      }
                     />
-                    <span
-                      className={cn(
-                        'w-12 shrink-0 text-xs font-bold',
-                        httpMethodColor(item.request.method)
-                      )}
-                    >
-                      {item.request.method}
+                    <span className="truncate font-medium">{item.title}</span>
+                    <span className="text-text-secondary ml-auto text-xs tabular-nums">
+                      {item.requestIds.length}
                     </span>
-                    <span className="truncate">{item.title}</span>
                   </label>
                 );
-              })}
-            </div>
+              }
 
-            <div className="border-border space-y-4 border-t p-4">
-              <label className="flex cursor-pointer items-center gap-2 text-sm">
-                <Checkbox
-                  checked={stopOnFirstFailure}
-                  disabled={isRunning}
-                  onCheckedChange={(value) => setStopOnFirstFailure(value === true)}
-                />
-                Stop on first failure
-              </label>
-
-              <Button
-                className="w-full gap-2"
-                disabled={isRunning || selectedRequests.length === 0}
-                onClick={runCollection}
-                variant="secondary"
-              >
-                {isRunning ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Play className="h-4 w-4" />
-                )}
-                {isRunning
-                  ? 'Running'
-                  : `Run ${totalRequests} ${totalRequests === 1 ? 'request' : 'requests'}`}
-              </Button>
-            </div>
-          </aside>
-
-          <main className="border-border flex min-h-0 flex-col rounded-lg border">
-            <div className="border-border text-text-secondary grid grid-cols-[minmax(180px,1fr)_90px_100px_90px] gap-4 border-b px-4 py-3 text-xs font-semibold tracking-wide uppercase">
-              <span>Name</span>
-              <span>Status</span>
-              <span>Result</span>
-              <span>Time</span>
-            </div>
-
-            <div className="tabs-scrollbar min-h-0 flex-1 overflow-y-auto">
-              {orderedRequests.map((request) => {
-                const result = results[request.id];
-                const response =
-                  result?.state === 'passed' || result?.state === 'failed'
-                    ? result.response
-                    : undefined;
-                const isExpanded = expandedRows.has(request.id);
-                const isSelected = selectedRequestIds.has(request.id);
-                const duration =
-                  response?.metaInfo.duration ??
-                  (result?.state === 'error' ? result.duration : undefined);
-                return (
-                  <Collapsible
-                    key={request.id}
-                    open={isExpanded}
-                    onOpenChange={() => toggleExpanded(request.id)}
+              return (
+                <label
+                  key={item.id}
+                  className={cn(
+                    'hover:bg-sidebar-accent flex cursor-pointer items-center gap-2 py-2 pr-4 text-sm',
+                    getIndentation(item.depth)
+                  )}
+                >
+                  <Checkbox
+                    checked={selectedRequestIds.has(item.id)}
+                    disabled={isRunning}
+                    onCheckedChange={(value) => setRequestSelected(item.id, value === true)}
+                  />
+                  <span
+                    className={cn(
+                      'w-12 shrink-0 text-xs font-bold',
+                      httpMethodColor(item.request.method)
+                    )}
                   >
-                    <CollapsibleTrigger asChild>
-                      <button
-                        className={cn(
-                          'hover:bg-sidebar-accent grid w-full grid-cols-[minmax(180px,1fr)_90px_100px_90px] items-center gap-4 border-b px-4 py-3 text-left text-sm',
-                          !isSelected && 'opacity-50'
-                        )}
-                        type="button"
-                      >
-                        <span className="flex min-w-0 items-center gap-2">
-                          {isExpanded ? (
-                            <ChevronDown className="h-4 w-4 shrink-0" />
-                          ) : (
-                            <ChevronRight className="h-4 w-4 shrink-0" />
-                          )}
-                          <span
-                            className={cn(
-                              'w-12 shrink-0 text-xs font-bold',
-                              httpMethodColor(request.method)
-                            )}
-                          >
-                            {request.method}
-                          </span>
-                          <span className="truncate">{request.title || request.url.base}</span>
-                        </span>
-                        <span className="tabular-nums">{response?.metaInfo.status ?? '-'}</span>
-                        <ResultPill result={result} />
-                        <span className="tabular-nums">
-                          {duration == null ? '-' : formatDuration(duration)}
-                        </span>
-                      </button>
-                    </CollapsibleTrigger>
+                    {item.request.method}
+                  </span>
+                  <span className="truncate">{item.title}</span>
+                </label>
+              );
+            })}
+          </div>
 
-                    <CollapsibleContent className="border-border bg-background-secondary/40 border-b px-4 py-4">
-                      {result == null ? (
-                        <p className="text-text-secondary text-sm">No result yet.</p>
-                      ) : result.state === 'error' ? (
-                        <p className="text-danger text-sm">{result.error}</p>
-                      ) : result.state === 'running' ? (
-                        <p className="text-text-secondary text-sm">Request is running.</p>
-                      ) : (
-                        <ResponseDetail response={result.response} />
+          <div className="border-border space-y-4 border-t p-4">
+            <label className="flex cursor-pointer items-center gap-2 text-sm">
+              <Checkbox
+                checked={stopOnFirstFailure}
+                disabled={isRunning}
+                onCheckedChange={(value) => setStopOnFirstFailure(value === true)}
+              />
+              Stop on first failure
+            </label>
+
+            <Button
+              className="w-full gap-2"
+              disabled={isRunning || selectedRequests.length === 0}
+              onClick={runCollection}
+              variant="secondary"
+            >
+              {isRunning ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Play className="h-4 w-4" />
+              )}
+              {isRunning
+                ? 'Running'
+                : `Run ${totalRequests} ${totalRequests === 1 ? 'request' : 'requests'}`}
+            </Button>
+          </div>
+        </aside>
+
+        <main className="border-border flex min-h-0 flex-col rounded-lg border">
+          <div className="border-border text-text-secondary grid grid-cols-[minmax(180px,1fr)_90px_100px_90px] gap-4 border-b px-4 py-3 text-xs font-semibold tracking-wide uppercase">
+            <span>Name</span>
+            <span>Status</span>
+            <span>Result</span>
+            <span>Time</span>
+          </div>
+
+          <div className="tabs-scrollbar min-h-0 flex-1 overflow-y-auto">
+            {orderedRequests.map((request) => {
+              const result = results[request.id];
+              const response =
+                result?.state === 'passed' || result?.state === 'failed'
+                  ? result.response
+                  : undefined;
+              const isExpanded = expandedRows.has(request.id);
+              const isSelected = selectedRequestIds.has(request.id);
+              const duration =
+                response?.metaInfo.duration ??
+                (result?.state === 'error' ? result.duration : undefined);
+              return (
+                <Collapsible
+                  key={request.id}
+                  open={isExpanded}
+                  onOpenChange={() => toggleExpanded(request.id)}
+                >
+                  <CollapsibleTrigger asChild>
+                    <button
+                      className={cn(
+                        'hover:bg-sidebar-accent grid w-full grid-cols-[minmax(180px,1fr)_90px_100px_90px] items-center gap-4 border-b px-4 py-3 text-left text-sm',
+                        !isSelected && 'opacity-50'
                       )}
-                    </CollapsibleContent>
-                  </Collapsible>
-                );
-              })}
-            </div>
-          </main>
-        </div>
+                      type="button"
+                    >
+                      <span className="flex min-w-0 items-center gap-2">
+                        {isExpanded ? (
+                          <ChevronDown className="h-4 w-4 shrink-0" />
+                        ) : (
+                          <ChevronRight className="h-4 w-4 shrink-0" />
+                        )}
+                        <span
+                          className={cn(
+                            'w-12 shrink-0 text-xs font-bold',
+                            httpMethodColor(request.method)
+                          )}
+                        >
+                          {request.method}
+                        </span>
+                        <span className="truncate">{request.title || request.url.base}</span>
+                      </span>
+                      <span className="tabular-nums">{response?.metaInfo.status ?? '-'}</span>
+                      <ResultPill result={result} />
+                      <span className="tabular-nums">
+                        {duration == null ? '-' : formatDuration(duration)}
+                      </span>
+                    </button>
+                  </CollapsibleTrigger>
 
-        <div className="flex items-center gap-3 pt-4">
-          <div className="border-border flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
-            <span className="text-base font-bold tabular-nums">{totalInRun}</span>
-            <span className="text-text-secondary text-xs">total</span>
+                  <CollapsibleContent className="border-border bg-background-secondary/40 border-b px-4 py-4">
+                    {result == null ? (
+                      <p className="text-text-secondary text-sm">No result yet.</p>
+                    ) : result.state === 'error' ? (
+                      <p className="text-danger text-sm">{result.error}</p>
+                    ) : result.state === 'running' ? (
+                      <p className="text-text-secondary text-sm">Request is running.</p>
+                    ) : (
+                      <ResponseDetail response={result.response} />
+                    )}
+                  </CollapsibleContent>
+                </Collapsible>
+              );
+            })}
           </div>
-          <div className="border-border flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
-            <span className="text-state-success text-base font-bold tabular-nums">{passed}</span>
-            <span className="text-text-secondary text-xs">passed</span>
-          </div>
-          <div className="border-border flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
-            <span className="text-danger text-base font-bold tabular-nums">{failed}</span>
-            <span className="text-text-secondary text-xs">failed</span>
-          </div>
-          <span className="text-text-secondary ml-auto text-sm tabular-nums">
-            Elapsed {totalDuration == null ? '-' : formatDuration(totalDuration)}
-          </span>
+        </main>
+      </div>
+
+      <div className="flex items-center gap-3 pt-4">
+        <div className="border-border flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
+          <span className="text-base font-bold tabular-nums">{totalInRun}</span>
+          <span className="text-text-secondary text-xs">total</span>
         </div>
-      </DialogContent>
-    </Dialog>
+        <div className="border-border flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
+          <span className="text-state-success text-base font-bold tabular-nums">{passed}</span>
+          <span className="text-text-secondary text-xs">passed</span>
+        </div>
+        <div className="border-border flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
+          <span className="text-danger text-base font-bold tabular-nums">{failed}</span>
+          <span className="text-text-secondary text-xs">failed</span>
+        </div>
+        <span className="text-text-secondary ml-auto text-sm tabular-nums">
+          Elapsed {totalDuration == null ? '-' : formatDuration(totalDuration)}
+        </span>
+      </div>
+    </div>
   );
 }

--- a/src/renderer/view/CollectionRunner.tsx
+++ b/src/renderer/view/CollectionRunner.tsx
@@ -477,6 +477,7 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
       <ResizablePanel defaultSize="25%" minSize={MIN_SIDEBAR_PIXELS}>
         <aside className="bg-sidebar flex h-full flex-col">
           <div className="border-border flex items-center gap-2 border-b px-4 py-3">
+            <span className="text-text-secondary shrink-0 text-xs">Environment</span>
             <Select
               value={selectedEnvironment ?? NO_ENVIRONMENT}
               onValueChange={(value) =>
@@ -485,7 +486,7 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
               disabled={isRunning}
             >
               <SelectTrigger
-                className="border-border h-8 min-w-0 flex-1 gap-2 rounded-md border px-3"
+                className="border-border h-7 w-auto min-w-0 flex-1 gap-2 rounded-md border px-2 text-xs"
                 aria-label="Select environment"
               >
                 <SelectValue placeholder="No environment" />
@@ -633,20 +634,21 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
               Stop on first failure
             </label>
 
-            <Button
-              className="w-full gap-2"
-              disabled={isRunning || selectedRequests.length === 0}
-              onClick={runCollection}
-            >
-              {isRunning ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
+            {isRunning ? (
+              <Button className="text-danger w-full gap-2" onClick={stopRun} variant="secondary">
+                <Square className="h-3.5 w-3.5" />
+                Stop run
+              </Button>
+            ) : (
+              <Button
+                className="w-full gap-2"
+                disabled={selectedRequests.length === 0}
+                onClick={runCollection}
+              >
                 <Play className="h-4 w-4" />
-              )}
-              {isRunning
-                ? 'Running'
-                : `Run ${totalRequests} ${totalRequests === 1 ? 'request' : 'requests'}`}
-            </Button>
+                {`Run ${totalRequests} ${totalRequests === 1 ? 'request' : 'requests'}`}
+              </Button>
+            )}
           </div>
         </aside>
       </ResizablePanel>
@@ -665,15 +667,9 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
 
             <div className="flex shrink-0 items-center gap-3">
               {isRunning && (
-                <>
-                  <span className="text-text-secondary text-sm tabular-nums">
-                    {done} / {runOrder.length} done
-                  </span>
-                  <Button className="text-danger gap-2" onClick={stopRun} variant="secondary">
-                    <Square className="h-3.5 w-3.5" />
-                    Stop
-                  </Button>
-                </>
+                <span className="text-text-secondary text-sm tabular-nums">
+                  {done} / {runOrder.length} done
+                </span>
               )}
             </div>
           </div>

--- a/src/renderer/view/CollectionRunner.tsx
+++ b/src/renderer/view/CollectionRunner.tsx
@@ -514,7 +514,7 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
       </div>
 
       <div className="grid min-h-0 grid-cols-[minmax(260px,360px)_1fr] gap-6">
-        <aside className="border-border flex min-h-0 flex-col rounded-lg border">
+        <aside className="border-border bg-card flex min-h-0 flex-col rounded-lg border">
           <div className="border-border flex items-center justify-between border-b px-4 py-3">
             <span className="text-sm font-semibold">Requests</span>
             <div className="flex gap-2 text-xs">
@@ -621,7 +621,6 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
               className="w-full gap-2"
               disabled={isRunning || selectedRequests.length === 0}
               onClick={runCollection}
-              variant="secondary"
             >
               {isRunning ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -635,7 +634,7 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
           </div>
         </aside>
 
-        <main className="border-border flex min-h-0 flex-col rounded-lg border">
+        <main className="border-border bg-card flex min-h-0 flex-col rounded-lg border">
           <div className="border-border text-text-secondary grid grid-cols-[minmax(180px,1fr)_90px_100px_90px] gap-4 border-b px-4 py-3 text-xs font-semibold tracking-wide uppercase">
             <span>Name</span>
             <span>Status</span>
@@ -712,15 +711,15 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
       </div>
 
       <div className="flex items-center gap-3 pt-4">
-        <div className="border-border flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
+        <div className="border-border bg-card flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
           <span className="text-base font-bold tabular-nums">{totalInRun}</span>
           <span className="text-text-secondary text-xs">total</span>
         </div>
-        <div className="border-border flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
+        <div className="border-border bg-card flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
           <span className="text-state-success text-base font-bold tabular-nums">{passed}</span>
           <span className="text-text-secondary text-xs">passed</span>
         </div>
-        <div className="border-border flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
+        <div className="border-border bg-card flex items-baseline gap-2 rounded-lg border px-3.5 py-1.5">
           <span className="text-danger text-base font-bold tabular-nums">{failed}</span>
           <span className="text-text-secondary text-xs">failed</span>
         </div>

--- a/src/renderer/view/CollectionRunner.tsx
+++ b/src/renderer/view/CollectionRunner.tsx
@@ -335,6 +335,10 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
     [orderedRequests, selectedRequestIds]
   );
 
+  // The progress bar shows the last run once one exists, the current selection otherwise.
+  const progressIds =
+    runOrder.length > 0 ? runOrder : selectedRequests.map((request) => request.id);
+
   const passed = runOrder.filter((id) => results[id]?.state === 'passed').length;
   const failed = runOrder.filter((id) => isFailure(results[id])).length;
   const done = passed + failed;
@@ -472,6 +476,41 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
     <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
       <ResizablePanel defaultSize="25%" minSize={MIN_SIDEBAR_PIXELS}>
         <aside className="bg-sidebar flex h-full flex-col">
+          <div className="border-border flex items-center gap-2 border-b px-4 py-3">
+            <Select
+              value={selectedEnvironment ?? NO_ENVIRONMENT}
+              onValueChange={(value) =>
+                void selectEnvironment(value === NO_ENVIRONMENT ? undefined : value)
+              }
+              disabled={isRunning}
+            >
+              <SelectTrigger
+                className="border-border h-8 min-w-0 flex-1 gap-2 rounded-md border px-3"
+                aria-label="Select environment"
+              >
+                <SelectValue placeholder="No environment" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_ENVIRONMENT}>No environment</SelectItem>
+                {Object.keys(environments).map((key) => (
+                  <SelectItem key={key} value={key}>
+                    {key}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              className="text-text-secondary hover:text-text-primary shrink-0"
+              variant="ghost"
+              size="icon"
+              type="button"
+              onClick={onClose}
+              aria-label="Close collection runner"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+
           <div className="border-border flex items-center justify-between border-b px-4 py-3">
             <span className="text-sm font-semibold">Requests</span>
             <div className="flex gap-2 text-xs">
@@ -625,31 +664,6 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
             </div>
 
             <div className="flex shrink-0 items-center gap-3">
-              <div className="flex items-center gap-2 text-sm">
-                <span className="text-text-secondary">Environment</span>
-                <Select
-                  value={selectedEnvironment ?? NO_ENVIRONMENT}
-                  onValueChange={(value) =>
-                    void selectEnvironment(value === NO_ENVIRONMENT ? undefined : value)
-                  }
-                  disabled={isRunning}
-                >
-                  <SelectTrigger
-                    className="border-border h-8 gap-2 rounded-md border px-3"
-                    aria-label="Select environment"
-                  >
-                    <SelectValue placeholder="No environment" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={NO_ENVIRONMENT}>No environment</SelectItem>
-                    {Object.keys(environments).map((key) => (
-                      <SelectItem key={key} value={key}>
-                        {key}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
               {isRunning && (
                 <>
                   <span className="text-text-secondary text-sm tabular-nums">
@@ -661,35 +675,30 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
                   </Button>
                 </>
               )}
-              <Button
-                className="text-text-secondary hover:text-text-primary"
-                variant="ghost"
-                size="icon"
-                type="button"
-                onClick={onClose}
-                aria-label="Close collection runner"
-              >
-                <X className="h-4 w-4" />
-              </Button>
             </div>
           </div>
 
-          <div className={cn('flex gap-1', runOrder.length > 0 && 'mb-4')}>
-            {runOrder.map((requestId) => {
-              const result = results[requestId];
-              return (
-                <span
-                  key={requestId}
-                  className={cn(
-                    'h-1 flex-1 rounded-full',
-                    result?.state === 'passed' && 'bg-state-success',
-                    isFailure(result) && 'bg-danger',
-                    result?.state === 'running' && 'bg-accent-primary animate-pulse',
-                    result == null && 'bg-border'
-                  )}
-                />
-              );
-            })}
+          {/* Before the first run the bar previews one neutral segment per selected request. */}
+          <div className="mb-4 flex gap-1">
+            {progressIds.length === 0 ? (
+              <span className="bg-border h-1 flex-1 rounded-full" />
+            ) : (
+              progressIds.map((requestId) => {
+                const result = runOrder.length > 0 ? results[requestId] : undefined;
+                return (
+                  <span
+                    key={requestId}
+                    className={cn(
+                      'h-1 flex-1 rounded-full',
+                      result?.state === 'passed' && 'bg-state-success',
+                      isFailure(result) && 'bg-danger',
+                      result?.state === 'running' && 'bg-accent-primary animate-pulse',
+                      result == null && 'bg-border'
+                    )}
+                  />
+                );
+              })
+            )}
           </div>
 
           <main className="border-border bg-card flex min-h-0 flex-col rounded-lg border">

--- a/src/renderer/view/CollectionRunner.tsx
+++ b/src/renderer/view/CollectionRunner.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useResponseData } from '@/components/mainWindow/bodyTabs/OutputTabs/PrettyRenderer';
+import { FolderIcon } from '@/components/icons';
 import { HttpService } from '@/services/http/http-service';
 import { httpMethodColor } from '@/services/StyleHelper';
 import { getIndentation } from '@/components/sidebar/SidebarRequestList/Nav/indentation';
@@ -514,7 +515,7 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
       </div>
 
       <div className="grid min-h-0 grid-cols-[minmax(260px,360px)_1fr] gap-6">
-        <aside className="border-border bg-card flex min-h-0 flex-col rounded-lg border">
+        <aside className="border-border bg-sidebar flex min-h-0 flex-col rounded-lg border">
           <div className="border-border flex items-center justify-between border-b px-4 py-3">
             <span className="text-sm font-semibold">Requests</span>
             <div className="flex gap-2 text-xs">
@@ -561,18 +562,20 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
                   <label
                     key={item.id}
                     className={cn(
-                      'hover:bg-sidebar-accent flex cursor-pointer items-center gap-2 py-2 pr-4 text-sm',
+                      'hover:bg-sidebar-accent flex cursor-pointer items-center gap-1 py-2 pr-4 text-sm',
                       getIndentation(item.depth)
                     )}
                   >
                     <Checkbox
+                      className="mr-2"
                       checked={checked}
                       disabled={isRunning || item.requestIds.length === 0}
                       onCheckedChange={(value) =>
                         setRequestsSelected(item.requestIds, value === true)
                       }
                     />
-                    <span className="truncate font-medium">{item.title}</span>
+                    <FolderIcon size={16} />
+                    <span className="flex-1 truncate">{item.title}</span>
                     <span className="text-text-secondary ml-auto text-xs tabular-nums">
                       {item.requestIds.length}
                     </span>
@@ -584,7 +587,7 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
                 <label
                   key={item.id}
                   className={cn(
-                    'hover:bg-sidebar-accent flex cursor-pointer items-center gap-2 py-2 pr-4 text-sm',
+                    'hover:bg-sidebar-accent flex cursor-pointer items-center gap-3 py-3.5 pr-4',
                     getIndentation(item.depth)
                   )}
                 >
@@ -595,13 +598,15 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
                   />
                   <span
                     className={cn(
-                      'w-12 shrink-0 text-xs font-bold',
+                      'shrink-0 text-xs leading-3 font-normal',
                       httpMethodColor(item.request.method)
                     )}
                   >
                     {item.request.method}
                   </span>
-                  <span className="truncate">{item.title}</span>
+                  <span className="font-lato flex-1 truncate text-xs leading-3 text-(--text-secondary)">
+                    {item.title}
+                  </span>
                 </label>
               );
             })}


### PR DESCRIPTION
## Changes

Implements #939 and reworks the Collection Runner presentation on top of it.

### Collection menu

- **New Collection menu** in the native application menu (macOS: between Edit and View; Windows/Linux: `&Collection`) with:
  - **Run Collection** (`CmdOrCtrl+Shift+R`) — replaces the Play icon in the sidebar header (removed); the entry in the collection dropdown remains.
  - **Settings…** (`CmdOrCtrl+Shift+,`) as an additional entry point; the gear icon stays. `CmdOrCtrl+,` stays reserved for the future general app settings.
- Menu items reach the renderer via IPC push events (`show-collection-runner`, `show-collection-settings`) with typed overloads in `RendererEventService`; the settings-modal state lives in the `viewStore` and the modal is rendered in `App`.

### Collection Runner as full-width view

- The runner is no longer a fullscreen dialog: it **replaces the whole layout** as an alternative main view (matching the original design proposal). Escape and a close button return to the normal layout; closing still aborts an in-flight run.
- **Request rail styled like the main sidebar**: full height, `bg-sidebar`, same row design as `RequestView`/`NavFolder` (method chip, text styles, folder icon, indentation), in a `ResizablePanelGroup` with the same default/min sizes as the app layout, so the rail width is draggable.
- **Collapsible folders** in the checklist (same arrow control as the sidebar tree); collapsed contents stay selected and keep running.
- **Environment select (with label, compact) and the close button** sit at the top of the rail; the results header keeps title, collection name and the done-counter.
- **Run button swaps to a danger-styled "Stop run"** while a run is active (previously a disabled Running state plus a separate header stop button).
- **Progress bar is always visible**: previews one neutral segment per selected request before the first run.
- Run button uses the primary accent variant; results and summary tiles use the card background token.

### Test infrastructure

- jsdom `ResizeObserver` stub in the shared test setup and a passthrough mock of the resizable layout in the runner tests — `react-resizable-panels` registers document-level pointer handlers that swallow clicks with jsdom's zero-sized rects.

Closes #939

Note for #931: the request-history branch adds its History item to the same `buildCollectionSubmenu`; whichever PR merges second resolves a small, mechanical conflict in `menu.ts` + `menu.test.ts`.

## Testing

- `yarn test`: 434 passed (menu items incl. accelerators and IPC events, folder collapse, run/stop swap, close via button and Escape).
- `yarn lint` / `yarn prettier-check`: clean.
- Manual: app started in dev mode; runner opened via menu and shortcut, resized the rail, collapsed folders, ran and stopped a run.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary (not applicable)
- [ ] Changes have been reviewed by second person

🤖 Generated with [Claude Code](https://claude.com/claude-code)