### PR TITLE
feat: copy request as cURL from the context menu

### DIFF
--- a/src/main/event/main-event-service.test.ts
+++ b/src/main/event/main-event-service.test.ts
@@ -149,6 +149,21 @@ describe('MainEventService', () => {
     });
   });
 
+  describe('setVariablesInString', () => {
+    it('delegates to environment service variable resolution', async () => {
+      const { EnvironmentService } = await import('../environment/service/environment-service.js');
+      const setVariablesInStringSpy = vi
+        .spyOn(EnvironmentService.instance, 'setVariablesInString')
+        .mockResolvedValue('pikachu');
+
+      const eventService = new MainEventService();
+      const result = await eventService.setVariablesInString('{{pokemon_name}}');
+
+      expect(result).toBe('pikachu');
+      expect(setVariablesInStringSpy).toHaveBeenCalledWith('{{pokemon_name}}');
+    });
+  });
+
   describe('sendRequest', () => {
     let EnvironmentService: Awaited<
       // @ts-expect-error ReturnType on module namespace is not callable but works at runtime

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -165,6 +165,10 @@ export class MainEventService implements IEventService {
     return environmentService.getVariable(key);
   }
 
+  async setVariablesInString(value: string): Promise<string> {
+    return await environmentService.setVariablesInString(value);
+  }
+
   async setCollectionVariables(variables: VariableMap) {
     environmentService.setCollectionVariables(variables);
     await persistenceService.saveCollection(environmentService.currentCollection);

--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/RequestDropdown.test.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/RequestDropdown.test.tsx
@@ -9,6 +9,7 @@ const openMock = vi.fn();
 const toastSuccessMock = vi.fn();
 const showErrorMock = vi.fn();
 const writeTextMock = vi.fn();
+const setVariablesInStringMock = vi.fn();
 
 vi.mock('@/lib/ipc-stream', () => ({
   IpcPushStream: { open: (...args: unknown[]) => openMock(...args) },
@@ -20,6 +21,14 @@ vi.mock('@/components/ui/sonner', () => ({
 
 vi.mock('@/error/errorHandler', () => ({
   showError: (...args: unknown[]) => showErrorMock(...args),
+}));
+
+vi.mock('@/services/event/renderer-event-service', () => ({
+  RendererEventService: {
+    instance: {
+      setVariablesInString: (value: string) => setVariablesInStringMock(value),
+    },
+  },
 }));
 
 vi.mock('@/state/collectionStore', () => ({
@@ -59,6 +68,7 @@ async function clickCopyAsCurl(request: TrufosRequest) {
 beforeEach(() => {
   vi.clearAllMocks();
   writeTextMock.mockResolvedValue(undefined);
+  setVariablesInStringMock.mockImplementation((value: string) => Promise.resolve(value));
 });
 
 describe('RequestDropdown copy as cURL', () => {
@@ -86,6 +96,28 @@ describe('RequestDropdown copy as cURL', () => {
     expect(command).toContain('curl -X POST');
     expect(command).not.toContain('--data-raw');
     expect(toastSuccessMock).toHaveBeenCalled();
+  });
+
+  it('resolves template variables before copying the command', async () => {
+    setVariablesInStringMock.mockImplementation((value: string) =>
+      Promise.resolve(value.replaceAll('{{pokemon_name}}', 'pikachu'))
+    );
+
+    await clickCopyAsCurl(
+      makeRequest({
+        method: RequestMethod.GET,
+        url: {
+          base: 'https://pokeapi.co/api/v2/pokemon/{{pokemon_name}}',
+          query: [{ key: 'limit', value: '10', isActive: true }],
+        },
+        body: { type: RequestBodyType.FILE },
+      })
+    );
+
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledTimes(1));
+    expect(writeTextMock.mock.calls[0][0]).toContain(
+      "curl -X GET 'https://pokeapi.co/api/v2/pokemon/pikachu?limit=10'"
+    );
   });
 
   it('shows an error when writing to the clipboard fails', async () => {

--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/RequestDropdown.test.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/RequestDropdown.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { RequestDropdown } from './RequestDropdown';
+import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
+import { RequestMethod } from 'shim/objects/request-method';
+
+const openMock = vi.fn();
+const toastSuccessMock = vi.fn();
+const showErrorMock = vi.fn();
+const writeTextMock = vi.fn();
+
+vi.mock('@/lib/ipc-stream', () => ({
+  IpcPushStream: { open: (...args: unknown[]) => openMock(...args) },
+}));
+
+vi.mock('@/components/ui/sonner', () => ({
+  toast: { success: (...args: unknown[]) => toastSuccessMock(...args) },
+}));
+
+vi.mock('@/error/errorHandler', () => ({
+  showError: (...args: unknown[]) => showErrorMock(...args),
+}));
+
+vi.mock('@/state/collectionStore', () => ({
+  useCollectionStore: <T,>(selector: (state: { selectedRequestId: string }) => T) =>
+    selector({ selectedRequestId: 'other' }),
+  useCollectionActions: () => ({ copyRequest: vi.fn(), deleteRequest: vi.fn() }),
+}));
+
+function makeRequest(overrides: Partial<TrufosRequest> = {}): TrufosRequest {
+  return {
+    id: 'req-1',
+    parentId: 'col-1',
+    type: 'request',
+    lastModified: 0,
+    title: 'Login',
+    url: { base: 'https://example.com/login', query: [] },
+    method: RequestMethod.POST,
+    headers: [{ key: 'Accept', value: 'application/json', isActive: true }],
+    body: { type: RequestBodyType.TEXT, mimeType: 'application/json' },
+    ...overrides,
+  } as TrufosRequest;
+}
+
+async function clickCopyAsCurl(request: TrufosRequest) {
+  const user = userEvent.setup();
+  // userEvent.setup() installs its own clipboard stub, so ours must come after it.
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: (text: string) => writeTextMock(text) },
+    configurable: true,
+  });
+  render(<RequestDropdown request={request} onRename={vi.fn()} />);
+
+  await user.click(screen.getByRole('button', { name: /more/i }));
+  await user.click(await screen.findByText('Copy as cURL'));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  writeTextMock.mockResolvedValue(undefined);
+});
+
+describe('RequestDropdown copy as cURL', () => {
+  it('copies the command with the body read from the body file', async () => {
+    openMock.mockResolvedValue({ readAll: () => Promise.resolve('{"user":"trufos"}') });
+
+    await clickCopyAsCurl(makeRequest());
+
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledTimes(1));
+    const command = writeTextMock.mock.calls[0][0] as string;
+    expect(command).toContain("curl -X POST 'https://example.com/login'");
+    expect(command).toContain("-H 'Accept: application/json'");
+    expect(command).toContain(`--data-raw '{"user":"trufos"}'`);
+    expect(toastSuccessMock).toHaveBeenCalled();
+    expect(showErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('copies without a body when the body file does not exist', async () => {
+    openMock.mockRejectedValue(new Error('file not found'));
+
+    await clickCopyAsCurl(makeRequest());
+
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledTimes(1));
+    const command = writeTextMock.mock.calls[0][0] as string;
+    expect(command).toContain('curl -X POST');
+    expect(command).not.toContain('--data-raw');
+    expect(toastSuccessMock).toHaveBeenCalled();
+  });
+
+  it('shows an error when writing to the clipboard fails', async () => {
+    openMock.mockResolvedValue({ readAll: () => Promise.resolve('') });
+    writeTextMock.mockRejectedValue(new Error('denied'));
+
+    await clickCopyAsCurl(makeRequest());
+
+    await waitFor(() => expect(showErrorMock).toHaveBeenCalled());
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/RequestDropdown.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/RequestDropdown.tsx
@@ -7,9 +7,13 @@ import {
 import { SidebarMenuAction } from '@/components/ui/sidebar';
 import { handleMouseEvent } from '@/util/callback-util';
 import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
-import { TrufosRequest } from 'shim/objects/request';
+import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { cn } from '@/lib/utils';
 import { MoreIcon } from '@/components/icons';
+import { buildCurlCommand } from '@/util/curl-util';
+import { IpcPushStream } from '@/lib/ipc-stream';
+import { toast } from '@/components/ui/sonner';
+import { showError } from '@/error/errorHandler';
 
 export interface RequestDropdownProps {
   request: TrufosRequest;
@@ -19,6 +23,25 @@ export interface RequestDropdownProps {
 export const RequestDropdown = ({ request, onRename }: RequestDropdownProps) => {
   const { copyRequest, deleteRequest } = useCollectionActions();
   const selectedRequestId = useCollectionStore((state) => state.selectedRequestId);
+
+  const copyAsCurl = async () => {
+    try {
+      let textBody: string | undefined;
+      if (request.body?.type === RequestBodyType.TEXT) {
+        textBody = request.body.text;
+        if (textBody == null) {
+          // The body lives in a file that may not exist for never-opened requests.
+          textBody = await IpcPushStream.open(request, 'utf-8')
+            .then((stream) => stream.readAll())
+            .catch(() => undefined);
+        }
+      }
+      await navigator.clipboard.writeText(buildCurlCommand(request, textBody));
+      toast.success('cURL command copied to clipboard');
+    } catch (error) {
+      showError('Failed to copy cURL command', error);
+    }
+  };
 
   return (
     <div>
@@ -41,6 +64,10 @@ export const RequestDropdown = ({ request, onRename }: RequestDropdownProps) => 
 
           <DropdownMenuItem onClick={handleMouseEvent(() => copyRequest(request.id))}>
             Copy Request
+          </DropdownMenuItem>
+
+          <DropdownMenuItem onClick={handleMouseEvent(() => void copyAsCurl())}>
+            Copy as cURL
           </DropdownMenuItem>
 
           <DropdownMenuItem

--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/RequestDropdown.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/RequestDropdown.tsx
@@ -24,7 +24,7 @@ export const RequestDropdown = ({ request, onRename }: RequestDropdownProps) => 
   const { copyRequest, deleteRequest } = useCollectionActions();
   const selectedRequestId = useCollectionStore((state) => state.selectedRequestId);
 
-  const copyAsCurl = async () => {
+  const copyAsCurl = async (): Promise<void> => {
     try {
       let textBody: string | undefined;
       if (request.body?.type === RequestBodyType.TEXT) {

--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/RequestDropdown.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/Dropdown/RequestDropdown.tsx
@@ -10,10 +10,13 @@ import { useCollectionActions, useCollectionStore } from '@/state/collectionStor
 import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { cn } from '@/lib/utils';
 import { MoreIcon } from '@/components/icons';
-import { buildCurlCommand } from '@/util/curl-util';
+import { buildCurlCommand, resolveCurlCommandVariables } from '@/util/curl-util';
 import { IpcPushStream } from '@/lib/ipc-stream';
 import { toast } from '@/components/ui/sonner';
 import { showError } from '@/error/errorHandler';
+import { RendererEventService } from '@/services/event/renderer-event-service';
+
+const eventService = RendererEventService.instance;
 
 export interface RequestDropdownProps {
   request: TrufosRequest;
@@ -36,7 +39,12 @@ export const RequestDropdown = ({ request, onRename }: RequestDropdownProps) => 
             .catch(() => undefined);
         }
       }
-      await navigator.clipboard.writeText(buildCurlCommand(request, textBody));
+      const resolved = await resolveCurlCommandVariables(
+        request,
+        textBody,
+        eventService.setVariablesInString
+      );
+      await navigator.clipboard.writeText(buildCurlCommand(resolved.request, resolved.textBody));
       toast.success('cURL command copied to clipboard');
     } catch (error) {
       showError('Failed to copy cURL command', error);

--- a/src/renderer/services/event/renderer-event-service.ts
+++ b/src/renderer/services/event/renderer-event-service.ts
@@ -58,6 +58,7 @@ export class RendererEventService implements IEventService {
   getActiveEnvironmentVariables = createEventMethod('getActiveEnvironmentVariables');
   getVariable = createEventMethod('getVariable');
   setCollectionVariables = createEventMethod('setCollectionVariables');
+  setVariablesInString = createEventMethod('setVariablesInString');
   setEnvironmentVariables = createEventMethod('setEnvironmentVariables');
   saveFolder = createEventMethod('saveFolder');
   copyFolder = createEventMethod('copyFolder');

--- a/src/renderer/util/curl-util.test.ts
+++ b/src/renderer/util/curl-util.test.ts
@@ -157,6 +157,19 @@ describe('buildCurlCommand', () => {
     expect(command).not.toContain("with-value '!!'");
   });
 
+  it('percent-encodes reserved characters in query keys', () => {
+    const request = makeRequest({
+      url: {
+        base: 'https://example.com/api',
+        query: [{ key: "some key '!!'", value: 'value', isActive: true }],
+      },
+    });
+
+    const command = buildCurlCommand(request);
+    expect(command).toContain("'https://example.com/api?some%20key%20%27%21%21%27=value'");
+    expect(command).not.toContain("some key '!!'");
+  });
+
   it('keeps template variables in query values unresolved and unencoded', () => {
     const request = makeRequest({
       url: {

--- a/src/renderer/util/curl-util.test.ts
+++ b/src/renderer/util/curl-util.test.ts
@@ -151,7 +151,9 @@ describe('buildCurlCommand', () => {
     });
 
     const command = buildCurlCommand(request);
-    expect(command).toContain('some-query=with-value%20');
+    expect(command).toContain(
+      "'https://echo.free.beeceptor.com?some-query=with-value%20%27%21%21%27'"
+    );
     expect(command).not.toContain("with-value '!!'");
   });
 
@@ -172,6 +174,14 @@ describe('buildCurlCommand', () => {
     });
 
     expect(buildCurlCommand(request)).toContain("-H 'Authorization: Bearer {{token}}'");
+  });
+
+  it('skips empty bearer auth tokens', () => {
+    const request = makeRequest({
+      auth: { type: AuthorizationType.BEARER, token: '' },
+    });
+
+    expect(buildCurlCommand(request)).not.toContain('Authorization');
   });
 
   it('adds a resolved Authorization header for basic auth', () => {

--- a/src/renderer/util/curl-util.test.ts
+++ b/src/renderer/util/curl-util.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { buildCurlCommand } from './curl-util';
 import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { RequestMethod } from 'shim/objects/request-method';
+import { AuthorizationType } from 'shim/objects/auth';
 
 function makeRequest(overrides: Partial<TrufosRequest> = {}): TrufosRequest {
   return {
@@ -139,5 +140,68 @@ describe('buildCurlCommand', () => {
     expect(buildCurlCommand(request)).toBe(
       "curl -X GET 'https://example.com/api' \\\n  -H 'Accept: application/json'"
     );
+  });
+
+  it('percent-encodes reserved characters in query values', () => {
+    const request = makeRequest({
+      url: {
+        base: 'https://echo.free.beeceptor.com',
+        query: [{ key: 'some-query', value: "with-value '!!'", isActive: true }],
+      },
+    });
+
+    const command = buildCurlCommand(request);
+    expect(command).toContain('some-query=with-value%20');
+    expect(command).not.toContain("with-value '!!'");
+  });
+
+  it('keeps template variables in query values unresolved and unencoded', () => {
+    const request = makeRequest({
+      url: {
+        base: 'https://example.com/api',
+        query: [{ key: 'token', value: '{{authToken}}', isActive: true }],
+      },
+    });
+
+    expect(buildCurlCommand(request)).toContain('token={{authToken}}');
+  });
+
+  it('adds a resolved Authorization header for bearer auth', () => {
+    const request = makeRequest({
+      auth: { type: AuthorizationType.BEARER, token: '{{token}}' },
+    });
+
+    expect(buildCurlCommand(request)).toContain("-H 'Authorization: Bearer {{token}}'");
+  });
+
+  it('adds a resolved Authorization header for basic auth', () => {
+    const request = makeRequest({
+      auth: { type: AuthorizationType.BASIC, username: 'user', password: 'pass' },
+    });
+
+    expect(buildCurlCommand(request)).toContain(`-H 'Authorization: Basic ${btoa('user:pass')}'`);
+  });
+
+  it('does not override an explicitly set Authorization header with auth config', () => {
+    const request = makeRequest({
+      headers: [{ key: 'Authorization', value: 'Bearer explicit', isActive: true }],
+      auth: { type: AuthorizationType.BEARER, token: 'from-auth-tab' },
+    });
+
+    const command = buildCurlCommand(request);
+    expect(command).toContain("-H 'Authorization: Bearer explicit'");
+    expect(command).not.toContain('from-auth-tab');
+  });
+
+  it('skips form-data file fields without a path or file name', () => {
+    const request = makeRequest({
+      method: RequestMethod.POST,
+      body: {
+        type: RequestBodyType.FORM_DATA,
+        fields: [{ key: 'empty-file', isActive: true, value: { type: RequestBodyType.FILE } }],
+      },
+    });
+
+    expect(buildCurlCommand(request)).not.toContain('-F');
   });
 });

--- a/src/renderer/util/curl-util.test.ts
+++ b/src/renderer/util/curl-util.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { buildCurlCommand } from './curl-util';
+import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
+import { RequestMethod } from 'shim/objects/request-method';
+
+function makeRequest(overrides: Partial<TrufosRequest> = {}): TrufosRequest {
+  return {
+    id: 'req-1',
+    parentId: 'col-1',
+    type: 'request',
+    lastModified: 0,
+    title: 'Test',
+    url: { base: 'https://example.com/api', query: [] },
+    method: RequestMethod.GET,
+    headers: [],
+    body: null,
+    ...overrides,
+  } as TrufosRequest;
+}
+
+describe('buildCurlCommand', () => {
+  it('builds a plain GET request', () => {
+    expect(buildCurlCommand(makeRequest())).toBe("curl -X GET 'https://example.com/api'");
+  });
+
+  it('includes query parameters in the URL', () => {
+    const request = makeRequest({
+      url: {
+        base: 'https://example.com/api',
+        query: [
+          { key: 'page', value: '2', isActive: true },
+          { key: 'ignored', value: 'x', isActive: false },
+        ],
+      },
+    });
+
+    expect(buildCurlCommand(request)).toContain('page=2');
+    expect(buildCurlCommand(request)).not.toContain('ignored');
+  });
+
+  it('adds active headers only', () => {
+    const request = makeRequest({
+      headers: [
+        { key: 'Authorization', value: 'Bearer {{token}}', isActive: true },
+        { key: 'X-Disabled', value: 'nope', isActive: false },
+      ],
+    });
+
+    const command = buildCurlCommand(request);
+    expect(command).toContain("-H 'Authorization: Bearer {{token}}'");
+    expect(command).not.toContain('X-Disabled');
+  });
+
+  it('escapes single quotes in values', () => {
+    const request = makeRequest({
+      url: { base: "https://example.com/it's", query: [] },
+    });
+
+    expect(buildCurlCommand(request)).toContain("'https://example.com/it'\\''s'");
+  });
+
+  it('adds a text body with content type from the mime type', () => {
+    const request = makeRequest({
+      method: RequestMethod.POST,
+      body: { type: RequestBodyType.TEXT, mimeType: 'application/json' },
+    });
+
+    const command = buildCurlCommand(request, '{"a":1}');
+    expect(command).toContain("-H 'Content-Type: application/json'");
+    expect(command).toContain(`--data-raw '{"a":1}'`);
+  });
+
+  it('does not duplicate an explicitly set content type header', () => {
+    const request = makeRequest({
+      method: RequestMethod.POST,
+      headers: [{ key: 'content-type', value: 'text/plain', isActive: true }],
+      body: { type: RequestBodyType.TEXT, mimeType: 'application/json' },
+    });
+
+    const command = buildCurlCommand(request, 'hello');
+    expect(command).not.toContain('application/json');
+    expect(command).toContain("-H 'content-type: text/plain'");
+  });
+
+  it('omits the data flag when the text body is empty', () => {
+    const request = makeRequest({
+      method: RequestMethod.POST,
+      body: { type: RequestBodyType.TEXT, mimeType: 'application/json' },
+    });
+
+    expect(buildCurlCommand(request)).not.toContain('--data-raw');
+  });
+
+  it('references a file body by path', () => {
+    const request = makeRequest({
+      method: RequestMethod.PUT,
+      body: { type: RequestBodyType.FILE, filePath: '/tmp/payload.bin' },
+    });
+
+    expect(buildCurlCommand(request)).toContain("--data-binary '@/tmp/payload.bin'");
+  });
+
+  it('adds active form-data fields', () => {
+    const request = makeRequest({
+      method: RequestMethod.POST,
+      body: {
+        type: RequestBodyType.FORM_DATA,
+        fields: [
+          {
+            key: 'name',
+            isActive: true,
+            value: { type: RequestBodyType.TEXT, text: 'trufos', mimeType: 'text/plain' },
+          },
+          {
+            key: 'file',
+            isActive: true,
+            value: { type: RequestBodyType.FILE, filePath: '/tmp/a.png' },
+          },
+          {
+            key: 'disabled',
+            isActive: false,
+            value: { type: RequestBodyType.TEXT, text: 'x', mimeType: 'text/plain' },
+          },
+        ],
+      },
+    });
+
+    const command = buildCurlCommand(request);
+    expect(command).toContain("-F 'name=trufos'");
+    expect(command).toContain("-F 'file=@/tmp/a.png'");
+    expect(command).not.toContain('disabled');
+  });
+
+  it('joins parts with line continuations', () => {
+    const request = makeRequest({
+      headers: [{ key: 'Accept', value: 'application/json', isActive: true }],
+    });
+
+    expect(buildCurlCommand(request)).toBe(
+      "curl -X GET 'https://example.com/api' \\\n  -H 'Accept: application/json'"
+    );
+  });
+});

--- a/src/renderer/util/curl-util.test.ts
+++ b/src/renderer/util/curl-util.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildCurlCommand } from './curl-util';
+import { buildCurlCommand, resolveCurlCommandVariables } from './curl-util';
 import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { RequestMethod } from 'shim/objects/request-method';
 import { AuthorizationType } from 'shim/objects/auth';
@@ -179,6 +179,39 @@ describe('buildCurlCommand', () => {
     });
 
     expect(buildCurlCommand(request)).toContain('token={{authToken}}');
+  });
+
+  it('resolves template variables before building a command', async () => {
+    const request = makeRequest({
+      method: RequestMethod.POST,
+      url: {
+        base: 'https://pokeapi.co/api/v2/pokemon/{{pokemon_name}}',
+        query: [{ key: 'limit', value: '{{limit}}', isActive: true }],
+      },
+      headers: [{ key: 'X-Pokemon', value: '{{pokemon_name}}', isActive: true }],
+      auth: { type: AuthorizationType.BEARER, token: '{{token}}' },
+      body: { type: RequestBodyType.TEXT, mimeType: 'application/json' },
+    });
+    const variables = new Map([
+      ['pokemon_name', 'pikachu'],
+      ['limit', '10'],
+      ['token', 'secret-token'],
+    ]);
+
+    const resolved = await resolveCurlCommandVariables(
+      request,
+      '{"name":"{{pokemon_name}}"}',
+      (value) =>
+        Promise.resolve(
+          value.replace(/\{\{([^}]+)}}/g, (_match, key: string) => variables.get(key) ?? '')
+        )
+    );
+
+    const command = buildCurlCommand(resolved.request, resolved.textBody);
+    expect(command).toContain("'https://pokeapi.co/api/v2/pokemon/pikachu?limit=10'");
+    expect(command).toContain("-H 'X-Pokemon: pikachu'");
+    expect(command).toContain("-H 'Authorization: Bearer secret-token'");
+    expect(command).toContain(`--data-raw '{"name":"pikachu"}'`);
   });
 
   it('adds a resolved Authorization header for bearer auth', () => {

--- a/src/renderer/util/curl-util.ts
+++ b/src/renderer/util/curl-util.ts
@@ -1,6 +1,13 @@
-import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
+import { FormDataBody, RequestBody, RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { AuthorizationType } from 'shim/objects/auth';
 import { TrufosURL } from 'shim/objects/url';
+
+type VariableResolver = (value: string) => Promise<string>;
+
+export interface ResolvedCurlRequest {
+  request: TrufosRequest;
+  textBody?: string;
+}
 
 /**
  * Quotes a value for a POSIX shell using single quotes (`'` becomes `'\''`).
@@ -41,6 +48,134 @@ function buildCurlUrl({ base, query }: TrufosURL): string {
   return `${base}?${params}`;
 }
 
+async function resolveOptional(
+  value: string | undefined,
+  resolveVariables: VariableResolver
+): Promise<string | undefined> {
+  return value == null ? undefined : await resolveVariables(value);
+}
+
+async function resolveCurlUrl(
+  { base, query }: TrufosURL,
+  resolveVariables: VariableResolver
+): Promise<TrufosURL> {
+  return {
+    base: await resolveVariables(base),
+    query: await Promise.all(
+      query.map(async (queryParam) => ({
+        ...queryParam,
+        key: await resolveVariables(queryParam.key),
+        value: await resolveOptional(queryParam.value, resolveVariables),
+      }))
+    ),
+  };
+}
+
+async function resolveCurlBody(
+  body: RequestBody | null | undefined,
+  resolveVariables: VariableResolver
+): Promise<RequestBody | null | undefined> {
+  if (body == null) return body;
+
+  switch (body.type) {
+    case RequestBodyType.TEXT:
+      return {
+        ...body,
+        text: await resolveOptional(body.text, resolveVariables),
+        mimeType: await resolveVariables(body.mimeType),
+      };
+    case RequestBodyType.FILE:
+      return {
+        ...body,
+        filePath: await resolveOptional(body.filePath, resolveVariables),
+        fileName: await resolveOptional(body.fileName, resolveVariables),
+        mimeType: await resolveOptional(body.mimeType, resolveVariables),
+      };
+    case RequestBodyType.FORM_DATA:
+      return {
+        ...body,
+        fields: await Promise.all(
+          body.fields.map(async (field) => {
+            return {
+              ...field,
+              key: await resolveVariables(field.key),
+              value: await resolveFormDataValue(field.value, resolveVariables),
+            };
+          })
+        ),
+      };
+  }
+}
+
+async function resolveFormDataValue(
+  value: FormDataBody['fields'][number]['value'],
+  resolveVariables: VariableResolver
+): Promise<FormDataBody['fields'][number]['value']> {
+  switch (value.type) {
+    case RequestBodyType.TEXT:
+      return {
+        ...value,
+        text: await resolveOptional(value.text, resolveVariables),
+        mimeType: await resolveVariables(value.mimeType),
+      };
+    case RequestBodyType.FILE:
+      return {
+        ...value,
+        filePath: await resolveOptional(value.filePath, resolveVariables),
+        fileName: await resolveOptional(value.fileName, resolveVariables),
+        mimeType: await resolveOptional(value.mimeType, resolveVariables),
+      };
+  }
+}
+
+async function resolveCurlAuth(
+  auth: TrufosRequest['auth'],
+  resolveVariables: VariableResolver
+): Promise<TrufosRequest['auth']> {
+  switch (auth?.type) {
+    case AuthorizationType.BEARER:
+      return { ...auth, token: await resolveVariables(auth.token) };
+    case AuthorizationType.BASIC:
+      return {
+        ...auth,
+        username: await resolveVariables(auth.username),
+        password: await resolveVariables(auth.password),
+      };
+    default:
+      return auth;
+  }
+}
+
+/**
+ * Resolves template variables in request fields before building a cURL command.
+ * Resolution is provided by the main process so it uses the selected environment,
+ * collection variables, and system variables in the same precedence as sending.
+ */
+export async function resolveCurlCommandVariables(
+  request: TrufosRequest,
+  textBody: string | undefined,
+  resolveVariables: VariableResolver
+): Promise<ResolvedCurlRequest> {
+  const body = await resolveCurlBody(request.body, resolveVariables);
+
+  return {
+    request: {
+      ...request,
+      url: await resolveCurlUrl(request.url, resolveVariables),
+      headers: await Promise.all(
+        request.headers.map(async (header) => ({
+          ...header,
+          key: await resolveVariables(header.key),
+          value: await resolveVariables(header.value),
+        }))
+      ),
+      body: body as TrufosRequest['body'],
+      auth: await resolveCurlAuth(request.auth, resolveVariables),
+    },
+    textBody: await resolveOptional(textBody, resolveVariables),
+  };
+}
+
 /**
  * Builds the `Authorization` header value for auth types that can be resolved
  * synchronously without any network I/O. OAuth1/OAuth2/inherited auth need a
@@ -59,8 +194,7 @@ function buildAuthHeader(auth: TrufosRequest['auth']): string | undefined {
 }
 
 /**
- * Builds a cURL command for the given request. Template variables (`{{...}}`)
- * are kept unresolved so the command stays portable and does not leak secrets.
+ * Builds a cURL command for the given request.
  * @param request The request to convert.
  * @param textBody The content of the request body file, if the request has a
  * text body. Callers load it separately because it is stored on disk.

--- a/src/renderer/util/curl-util.ts
+++ b/src/renderer/util/curl-util.ts
@@ -1,0 +1,60 @@
+import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
+import { buildUrl } from 'shim/objects/url';
+
+/**
+ * Quotes a value for a POSIX shell using single quotes (`'` becomes `'\''`).
+ */
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+/**
+ * Builds a cURL command for the given request. Template variables (`{{...}}`)
+ * are kept unresolved so the command stays portable and does not leak secrets.
+ * @param request The request to convert.
+ * @param textBody The content of the request body file, if the request has a
+ * text body. Callers load it separately because it is stored on disk.
+ * @returns The cURL command, one option per line.
+ */
+export function buildCurlCommand(request: TrufosRequest, textBody?: string): string {
+  const parts = [`curl -X ${request.method} ${shellQuote(buildUrl(request.url))}`];
+
+  const activeHeaders = request.headers.filter((header) => header.isActive);
+  for (const header of activeHeaders) {
+    parts.push(`-H ${shellQuote(`${header.key}: ${header.value}`)}`);
+  }
+  const hasContentType = activeHeaders.some(
+    (header) => header.key.toLowerCase() === 'content-type'
+  );
+
+  const { body } = request;
+  switch (body?.type) {
+    case RequestBodyType.TEXT:
+      if (textBody) {
+        if (!hasContentType && body.mimeType) {
+          parts.push(`-H ${shellQuote(`Content-Type: ${body.mimeType}`)}`);
+        }
+        parts.push(`--data-raw ${shellQuote(textBody)}`);
+      }
+      break;
+    case RequestBodyType.FILE:
+      if (body.filePath) {
+        if (!hasContentType && body.mimeType) {
+          parts.push(`-H ${shellQuote(`Content-Type: ${body.mimeType}`)}`);
+        }
+        parts.push(`--data-binary ${shellQuote(`@${body.filePath}`)}`);
+      }
+      break;
+    case RequestBodyType.FORM_DATA:
+      for (const field of body.fields.filter((field) => field.isActive)) {
+        const value =
+          field.value.type === RequestBodyType.FILE
+            ? `@${field.value.filePath ?? field.value.fileName ?? ''}`
+            : (field.value.text ?? '');
+        parts.push(`-F ${shellQuote(`${field.key}=${value}`)}`);
+      }
+      break;
+  }
+
+  return parts.join(' \\\n  ');
+}

--- a/src/renderer/util/curl-util.ts
+++ b/src/renderer/util/curl-util.ts
@@ -3,9 +3,10 @@ import { AuthorizationType } from 'shim/objects/auth';
 import { TrufosURL } from 'shim/objects/url';
 
 type VariableResolver = (value: string) => Promise<string>;
+type CurlRequest = Omit<TrufosRequest, 'body'> & { body?: RequestBody | null };
 
 export interface ResolvedCurlRequest {
-  request: TrufosRequest;
+  request: CurlRequest;
   textBody?: string;
 }
 
@@ -152,7 +153,7 @@ async function resolveCurlAuth(
  * collection variables, and system variables in the same precedence as sending.
  */
 export async function resolveCurlCommandVariables(
-  request: TrufosRequest,
+  request: CurlRequest,
   textBody: string | undefined,
   resolveVariables: VariableResolver
 ): Promise<ResolvedCurlRequest> {
@@ -169,7 +170,7 @@ export async function resolveCurlCommandVariables(
           value: await resolveVariables(header.value),
         }))
       ),
-      body: body as TrufosRequest['body'],
+      body,
       auth: await resolveCurlAuth(request.auth, resolveVariables),
     },
     textBody: await resolveOptional(textBody, resolveVariables),
@@ -200,7 +201,7 @@ function buildAuthHeader(auth: TrufosRequest['auth']): string | undefined {
  * text body. Callers load it separately because it is stored on disk.
  * @returns The cURL command, one option per line.
  */
-export function buildCurlCommand(request: TrufosRequest, textBody?: string): string {
+export function buildCurlCommand(request: CurlRequest, textBody?: string): string {
   const parts = [`curl -X ${request.method} ${shellQuote(buildCurlUrl(request.url))}`];
 
   const activeHeaders = request.headers.filter((header) => header.isActive);

--- a/src/renderer/util/curl-util.ts
+++ b/src/renderer/util/curl-util.ts
@@ -1,11 +1,57 @@
 import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
-import { buildUrl } from 'shim/objects/url';
+import { AuthorizationType } from 'shim/objects/auth';
+import { TrufosURL } from 'shim/objects/url';
 
 /**
  * Quotes a value for a POSIX shell using single quotes (`'` becomes `'\''`).
  */
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+/**
+ * Percent-encodes a URL component while keeping `{{...}}` template variables
+ * readable, so the generated URL is valid but the placeholders stay
+ * unresolved and recognizable. `{` and `}` are the only characters this needs
+ * to restore after encoding, since `encodeURIComponent` escapes them too.
+ */
+function encodeUrlComponent(value: string): string {
+  return encodeURIComponent(value).replaceAll('%7B', '{').replaceAll('%7D', '}');
+}
+
+/**
+ * Builds a percent-encoded URL for use in a cURL command. Unlike `buildUrl`,
+ * this encodes query keys/values so reserved characters (spaces, `!`, `'`, ...)
+ * don't produce a URL that curl rejects.
+ */
+function buildCurlUrl({ base, query }: TrufosURL): string {
+  const activeQuery = query.filter((q) => q.isActive);
+  if (activeQuery.length === 0) return base;
+
+  const params = activeQuery
+    .map(({ key, value }) =>
+      value == null
+        ? encodeUrlComponent(key)
+        : `${encodeUrlComponent(key)}=${encodeUrlComponent(value)}`
+    )
+    .join('&');
+  return `${base}?${params}`;
+}
+
+/**
+ * Builds the `Authorization` header value for auth types that can be resolved
+ * synchronously without any network I/O. OAuth1/OAuth2/inherited auth need a
+ * token exchange or a parent lookup and are intentionally left unresolved.
+ */
+function buildAuthHeader(auth: TrufosRequest['auth']): string | undefined {
+  switch (auth?.type) {
+    case AuthorizationType.BEARER:
+      return `Bearer ${auth.token}`;
+    case AuthorizationType.BASIC:
+      return `Basic ${btoa(`${auth.username}:${auth.password}`)}`;
+    default:
+      return undefined;
+  }
 }
 
 /**
@@ -17,7 +63,7 @@ function shellQuote(value: string): string {
  * @returns The cURL command, one option per line.
  */
 export function buildCurlCommand(request: TrufosRequest, textBody?: string): string {
-  const parts = [`curl -X ${request.method} ${shellQuote(buildUrl(request.url))}`];
+  const parts = [`curl -X ${request.method} ${shellQuote(buildCurlUrl(request.url))}`];
 
   const activeHeaders = request.headers.filter((header) => header.isActive);
   for (const header of activeHeaders) {
@@ -26,6 +72,16 @@ export function buildCurlCommand(request: TrufosRequest, textBody?: string): str
   const hasContentType = activeHeaders.some(
     (header) => header.key.toLowerCase() === 'content-type'
   );
+  const hasAuthHeader = activeHeaders.some(
+    (header) => header.key.toLowerCase() === 'authorization'
+  );
+
+  if (!hasAuthHeader) {
+    const authHeader = buildAuthHeader(request.auth);
+    if (authHeader) {
+      parts.push(`-H ${shellQuote(`Authorization: ${authHeader}`)}`);
+    }
+  }
 
   const { body } = request;
   switch (body?.type) {
@@ -47,11 +103,13 @@ export function buildCurlCommand(request: TrufosRequest, textBody?: string): str
       break;
     case RequestBodyType.FORM_DATA:
       for (const field of body.fields.filter((field) => field.isActive)) {
-        const value =
-          field.value.type === RequestBodyType.FILE
-            ? `@${field.value.filePath ?? field.value.fileName ?? ''}`
-            : (field.value.text ?? '');
-        parts.push(`-F ${shellQuote(`${field.key}=${value}`)}`);
+        if (field.value.type === RequestBodyType.FILE) {
+          const path = field.value.filePath ?? field.value.fileName;
+          if (!path) continue; // no file selected yet, nothing to attach
+          parts.push(`-F ${shellQuote(`${field.key}=@${path}`)}`);
+        } else {
+          parts.push(`-F ${shellQuote(`${field.key}=${field.value.text ?? ''}`)}`);
+        }
       }
       break;
   }

--- a/src/renderer/util/curl-util.ts
+++ b/src/renderer/util/curl-util.ts
@@ -16,7 +16,10 @@ function shellQuote(value: string): string {
  * to restore after encoding, since `encodeURIComponent` escapes them too.
  */
 function encodeUrlComponent(value: string): string {
-  return encodeURIComponent(value).replaceAll('%7B', '{').replaceAll('%7D', '}');
+  return encodeURIComponent(value)
+    .replace(/[!'()*]/g, (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`)
+    .replaceAll('%7B', '{')
+    .replaceAll('%7D', '}');
 }
 
 /**
@@ -46,8 +49,9 @@ function buildCurlUrl({ base, query }: TrufosURL): string {
 function buildAuthHeader(auth: TrufosRequest['auth']): string | undefined {
   switch (auth?.type) {
     case AuthorizationType.BEARER:
-      return `Bearer ${auth.token}`;
+      return auth.token ? `Bearer ${auth.token}` : undefined;
     case AuthorizationType.BASIC:
+      if (auth.username == null || auth.password == null) return undefined;
       return `Basic ${btoa(`${auth.username}:${auth.password}`)}`;
     default:
       return undefined;

--- a/src/shim/event-service.ts
+++ b/src/shim/event-service.ts
@@ -108,6 +108,12 @@ export interface IEventService {
   getVariable(key: string): Promise<VariableObject>;
 
   /**
+   * Replace template variables in the given string using the selected environment.
+   * @param value The string to resolve.
+   */
+  setVariablesInString(value: string): Promise<string>;
+
+  /**
    * Replace all existing collection variables with the given ones.
    * @param variables The variables of the Collection to set.
    */


### PR DESCRIPTION
### **User description**
## Changes

Implements #941 — a lightweight "Copy as cURL" in the request context menu (Rename / Copy / **Copy as cURL** / Delete).

- **`src/renderer/util/curl-util.ts`** — pure command builder:
  - `curl -X <METHOD> '<url>'` with the URL built via the existing `buildUrl` (active query params only).
  - One `-H 'Key: value'` per **active** header.
  - Text body → `--data-raw`, plus `Content-Type` from the body mime type when no explicit header is set; file body → `--data-binary @path`; form-data → `-F` per active field.
  - POSIX single-quote escaping (`'` → `'\''`), parts joined with ` \` line continuations.
  - Template variables (`{{...}}`) stay **unresolved** — portable command, no leaked secrets.
- **`RequestDropdown`** — new menu item; text bodies are read from the request body file via the existing `IpcPushStream` (requests that were never opened have no body file — the read failure is swallowed and the command is copied without a data flag). Success shows a toast, failures go through the shared error handler.
- Related: #775 (full code generator) stays open for the multi-language modal; this is the minimal context-menu shortcut and can later delegate to the generator's curl target.

Closes #941

## Testing

- `yarn test`: 444 passed — 10 new unit tests for the command builder (escaping, active-only headers/query params, all three body types, content-type handling) and 3 component tests for the menu action (body from file, missing body file, clipboard failure).
- `yarn lint` / `yarn prettier-check`: clean.
- Note for reviewers: `userEvent.setup()` installs its own clipboard stub, so the component tests override `navigator.clipboard` after setup.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [ ] Manual testing has been performed
- [ ] Documentation has been updated, if necessary (not applicable)
- [x] Changes have been reviewed by second person

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds "Copy as cURL" context menu item for quick command export

- Builds cURL commands with method, URL, active headers, and body

- Resolves template variables and auth configuration into commands

- Handles text, file, and form-data body types with proper escaping

- Includes comprehensive unit tests for command builder and UI integration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Request in Sidebar"] -->|Right-click| B["RequestDropdown Menu"]
  B -->|Click 'Copy as cURL'| C["copyAsCurl Handler"]
  C -->|Read body file| D["IpcPushStream"]
  C -->|Resolve variables| E["RendererEventService"]
  C -->|Build command| F["buildCurlCommand"]
  F -->|Shell escape & format| G["cURL Command"]
  G -->|Copy to clipboard| H["navigator.clipboard"]
  H -->|Success| I["Toast Notification"]
  H -->|Failure| J["Error Handler"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>curl-util.ts</strong><dd><code>Core cURL command builder with variable resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/942/files#diff-f7a26494e554947a43b1cb36d924dbeb62eae89c31f443a684b8b9984dabcb6b">+257/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RequestDropdown.tsx</strong><dd><code>Add "Copy as cURL" menu item and handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/942/files#diff-3c023ea458a5c38f276a4bf241ef9693759efb8ad1117b45b18f36f5051365c7">+36/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>renderer-event-service.ts</strong><dd><code>Expose setVariablesInString method for variable resolution</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/942/files#diff-6446e2be18634b05193826bf484b2b8bc0a1c252f5207f424de9e77b82f4444f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main-event-service.ts</strong><dd><code>Implement setVariablesInString delegation to environment service</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/942/files#diff-88f162ee0fb07a5f96655c4e842df6fb5072f17b7c130b8099cfb16c16e65588">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>event-service.ts</strong><dd><code>Add setVariablesInString interface definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/942/files#diff-9ca4fa37785e3ce6722e2ccb9049e915895c3efc6be7030ad0d8abf3e2933de3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>curl-util.test.ts</strong><dd><code>Comprehensive tests for cURL command generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/942/files#diff-d1ac5c08503eb7009ac50919f125d4589ebf198d0fb6303bf489aab9aa1ceb4e">+263/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RequestDropdown.test.tsx</strong><dd><code>Tests for cURL copy menu action and clipboard integration</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/942/files#diff-05e2e08e7d81f4b9b3248b792ba317df8a1ba783084b6db7b9979fb7ce0604ca">+132/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main-event-service.test.ts</strong><dd><code>Test setVariablesInString method delegation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/942/files#diff-bf14319b9cd04db995a57fd7fa8d2c755249179873dd3725b845f875667c0e89">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

