### PR TITLE
feat: support building DMG locally

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -7,7 +7,7 @@ import { AutoUnpackNativesPlugin } from '@electron-forge/plugin-auto-unpack-nati
 import { FusesPlugin } from '@electron-forge/plugin-fuses';
 import { VitePlugin } from '@electron-forge/plugin-vite';
 import { FuseV1Options, FuseVersion } from '@electron/fuses';
-import ts from 'typescript';
+import { createProgram, forEachChild, isInterfaceDeclaration, TypeFormatFlags } from 'typescript';
 import { resolve } from 'node:path';
 import { writeFile } from 'node:fs/promises';
 import { name as packageName } from './package.json';
@@ -21,27 +21,38 @@ if (process.env.APPLE_API_KEY && process.env.APPLE_API_KEY_ID && process.env.APP
     appleApiIssuer: process.env.APPLE_API_ISSUER,
   };
   osxSign = true;
+} else {
+  console.warn(
+    'Apple API key not found.',
+    'macOS notarization and code signing will be disabled.',
+    'Set APPLE_API_KEY, APPLE_API_KEY_ID, and APPLE_API_ISSUER environment variables to enable.'
+  );
+  osxSign = {
+    identity: '-',
+    identityValidation: false,
+    optionsForFile: () => ({ hardenedRuntime: false }),
+  };
 }
 
 const config: ForgeConfig = {
   hooks: {
     generateAssets: async () => {
       const shimPath = resolve('src/shim/scripting.ts');
-      const program = ts.createProgram([shimPath], { strict: true });
+      const program = createProgram([shimPath], { strict: true });
       const checker = program.getTypeChecker();
       const sourceFile = program.getSourceFile(shimPath);
       if (!sourceFile) throw new Error('scripting.ts not found');
 
       const declarations: string[] = [];
-      ts.forEachChild(sourceFile, (node) => {
-        if (ts.isInterfaceDeclaration(node) && node.name.text === 'GlobalScriptingApi') {
+      forEachChild(sourceFile, (node) => {
+        if (isInterfaceDeclaration(node) && node.name.text === 'GlobalScriptingApi') {
           const type = checker.getTypeAtLocation(node);
           for (const symbol of checker.getPropertiesOfType(type)) {
             const propType = checker.getTypeOfSymbolAtLocation(symbol, node);
             const propTypeStr = checker.typeToString(
               propType,
               undefined,
-              ts.TypeFormatFlags.NoTruncation
+              TypeFormatFlags.NoTruncation
             );
             declarations.push(`declare const ${symbol.name}: ${propTypeStr};`);
           }


### PR DESCRIPTION
### **User description**
## Changes

- support building DMG locally

## Testing

- ran `yarn run make` and installed it

## Checklist

- [ ] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person


___

### **PR Type**
Enhancement


___

### **Description**
- Add DMG build support for local macOS development

- Improve TypeScript imports with specific named exports

- Add fallback code signing configuration when API keys unavailable

- Display warning message for missing Apple notarization credentials


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["forge.config.ts"] -->|"Refactor TypeScript imports"| B["Named exports from typescript"]
  A -->|"Add conditional logic"| C["Check Apple API credentials"]
  C -->|"If missing"| D["Use fallback code signing config"]
  C -->|"If present"| E["Enable notarization and signing"]
  D -->|"Display warning"| F["Console message to user"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>forge.config.ts</strong><dd><code>Add DMG build support with fallback signing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forge.config.ts

<ul><li>Refactored TypeScript imports to use named exports (<code>createProgram</code>, <br><code>forEachChild</code>, <code>isInterfaceDeclaration</code>, <code>TypeFormatFlags</code>) instead of <br>importing the entire module<br> <li> Added else block to handle missing Apple API credentials with fallback <br>code signing configuration<br> <li> Added console warning message when Apple API key environment variables <br>are not set<br> <li> Updated TypeScript API calls to use imported named functions directly</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/943/files#diff-d5a3befed25d202aaa4e1d96ef7bf6f5428fadb1ac5a65038dc8183d3a1cbda4">+16/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

