### PR TITLE
feat: add assertions tab for no-code response tests (#841)

### DIFF
--- a/examples/collection/collection.json
+++ b/examples/collection/collection.json
@@ -1,7 +1,7 @@
 {
   "id": "dbba497e-b5a1-47f3-86d4-5461c01e034f",
   "title": "New Collection",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "variables": {
     "test": {
       "value": "I contain text",

--- a/examples/collection/echo/request.json
+++ b/examples/collection/echo/request.json
@@ -1,7 +1,7 @@
 {
   "id": "35efb7a3-84ab-4d28-a91c-2945c0591c6e",
   "title": "Echo",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "url": {
     "base": "https://echo.free.beeceptor.com",
     "query": []

--- a/src/main/persistence/service/info-files/latest.ts
+++ b/src/main/persistence/service/info-files/latest.ts
@@ -4,11 +4,11 @@ import { Collection } from 'shim/objects/collection';
 import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
 import { VariableMap } from 'shim/objects/variables';
-import { InfoFile, VERSION, RequestInfoFile, FolderInfoFile, CollectionInfoFile } from './v2-4-0';
+import { InfoFile, VERSION, RequestInfoFile, FolderInfoFile, CollectionInfoFile } from './v2-5-0';
 import { SettingsService } from '../settings-service';
 
 export { createGitIgnore, GIT_IGNORE_FILE_NAME } from './v2-0-0';
-export { VERSION, InfoFile, CollectionInfoFile, FolderInfoFile, RequestInfoFile } from './v2-4-0';
+export { VERSION, InfoFile, CollectionInfoFile, FolderInfoFile, RequestInfoFile } from './v2-5-0';
 
 /**
  * Deep clones the given object and removes any properties that are not allowed in an info file.

--- a/src/main/persistence/service/info-files/migrators.ts
+++ b/src/main/persistence/service/info-files/migrators.ts
@@ -11,6 +11,7 @@ import { InfoFileMigrator as V2_1_0 } from './v2-1-0';
 import { InfoFileMigrator as V2_2_0 } from './v2-2-0';
 import { InfoFileMigrator as V2_3_0 } from './v2-3-0';
 import { InfoFileMigrator as V2_4_0 } from './v2-4-0';
+import { InfoFileMigrator as V2_5_0 } from './v2-5-0';
 import { SemVer } from 'main/util/semver';
 
 // add new migrators here
@@ -25,6 +26,7 @@ const MIGRATOR_ARRAY = [
   new V2_2_0(),
   new V2_3_0(),
   new V2_4_0(),
+  new V2_5_0(),
 ];
 
 const MIGRATORS = new Map<string, AbstractInfoFileMigrator<VersionedObject, VersionedObject>>(

--- a/src/main/persistence/service/info-files/v2-4-0.ts
+++ b/src/main/persistence/service/info-files/v2-4-0.ts
@@ -8,6 +8,7 @@ import {
   TrufosObjectType,
   AuthorizationInformation,
   AuthorizationInformationNoInherit,
+  Assertion,
 } from 'shim/objects';
 import { ClientCertificate } from 'shim/objects/collection';
 import { SemVer } from 'main/util/semver';
@@ -30,6 +31,7 @@ export const RequestInfoFile = InfoFileBase.extend({
   headers: TrufosHeader.array(),
   body: RequestBody,
   auth: AuthorizationInformation.optional(),
+  assertions: Assertion.array().optional(),
 });
 export type RequestInfoFile = z.infer<typeof RequestInfoFile>;
 
@@ -56,7 +58,9 @@ export type InfoFile = z.infer<typeof InfoFile>;
 export class InfoFileMigrator extends AbstractInfoFileMigrator<OldInfoFile, InfoFile> {
   public readonly fromVersion = OLD_VERSION.toString();
 
-  async migrate(old: OldInfoFile, type: TrufosObjectType, filePath: string): Promise<InfoFile> {
+  async migrate(old: OldInfoFile, _type: TrufosObjectType, _filePath: string): Promise<InfoFile> {
+    void _type;
+    void _filePath;
     return Object.assign(old, { version: VERSION.toString() });
   }
 }

--- a/src/main/persistence/service/info-files/v2-5-0.ts
+++ b/src/main/persistence/service/info-files/v2-5-0.ts
@@ -5,17 +5,17 @@ import {
   EnvironmentMap,
   RequestMethod,
   TrufosHeader,
-  TrufosObjectType,
   AuthorizationInformation,
   AuthorizationInformationNoInherit,
+  Assertion,
 } from 'shim/objects';
 import { ClientCertificate } from 'shim/objects/collection';
 import { SemVer } from 'main/util/semver';
 import { AbstractInfoFileMigrator } from './migrator';
-import { InfoFile as OldInfoFile, VERSION as OLD_VERSION } from './v2-3-0';
+import { InfoFile as OldInfoFile, VERSION as OLD_VERSION } from './v2-4-0';
 import z from 'zod';
 
-export const VERSION = new SemVer(2, 4, 0);
+export const VERSION = new SemVer(2, 5, 0);
 
 export const InfoFileBase = z.object({
   id: z.string(),
@@ -30,6 +30,7 @@ export const RequestInfoFile = InfoFileBase.extend({
   headers: TrufosHeader.array(),
   body: RequestBody,
   auth: AuthorizationInformation.optional(),
+  assertions: Assertion.array().optional(),
 });
 export type RequestInfoFile = z.infer<typeof RequestInfoFile>;
 
@@ -48,15 +49,15 @@ export const InfoFile = z.union([RequestInfoFile, FolderInfoFile, CollectionInfo
 export type InfoFile = z.infer<typeof InfoFile>;
 
 /**
- * Migrates schema `v2.3.0` to `v2.4.0`.
+ * Migrates schema `v2.4.0` to `v2.5.0`.
  *
  * Changes:
- * - Adds optional `clientCertificate` field to CollectionInfoFile for mTLS support.
+ * - Adds optional `assertions` field to RequestInfoFile for no-code response assertions.
  */
 export class InfoFileMigrator extends AbstractInfoFileMigrator<OldInfoFile, InfoFile> {
   public readonly fromVersion = OLD_VERSION.toString();
 
-  async migrate(old: OldInfoFile, type: TrufosObjectType, filePath: string): Promise<InfoFile> {
+  async migrate(old: OldInfoFile): Promise<InfoFile> {
     return Object.assign(old, { version: VERSION.toString() });
   }
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -50,7 +50,7 @@ export const App = () => {
     <CollectionStoreProvider>
       <ThemeProvider>
         <TooltipProvider delayDuration={750}>
-          <SidebarProvider className="grid">
+          <SidebarProvider className="grid h-svh overflow-hidden">
             {/* The runner replaces the whole layout as an alternative full-width view;
                 its own request checklist makes the sidebar redundant. */}
             {isCollectionRunnerOpen ? (

--- a/src/renderer/components/mainWindow/MainTopBar.tsx
+++ b/src/renderer/components/mainWindow/MainTopBar.tsx
@@ -15,6 +15,7 @@ import { saveModelContent } from '@/lib/monaco/models';
 import { TrufosURL } from 'shim/objects/url';
 import { IconButton } from '@/components/ui/icon-button';
 import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
+import { evaluateAssertions } from '@/services/assertions/assertion-service';
 
 const httpService = HttpService.instance;
 const eventService = RendererEventService.instance;
@@ -23,7 +24,7 @@ export function MainTopBar() {
   const [isLoading, setIsLoading] = useState(false);
 
   const { updateRequest, discardChanges } = useCollectionActions();
-  const { addResponse } = useResponseActions();
+  const { addResponse, setAssertionResults } = useResponseActions();
   const request = useCollectionStore(selectRequest)!;
   const { url, method } = request;
 
@@ -38,13 +39,14 @@ export function MainTopBar() {
 
         const response = await httpService.sendRequest(request);
         addResponse(request.id, response);
+        setAssertionResults(request.id, await evaluateAssertions(request.assertions, response));
       } catch (error) {
         showError(error);
       } finally {
         setIsLoading(false);
       }
     }),
-    [request, addResponse]
+    [request, addResponse, setAssertionResults]
   );
 
   const saveRequest = useCallback(

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/InputTabs.test.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/InputTabs.test.tsx
@@ -3,10 +3,24 @@ import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect } from 'vitest';
 import { TrufosHeader } from 'shim/objects/headers';
 import { TrufosQueryParam } from 'shim/objects/query-param';
+import { Assertion } from 'shim/objects/assertion';
 import { InputTabs } from './InputTabs';
 
 let mockHeaders: TrufosHeader[] = [];
-let mockQueryParams: TrufosQueryParam[] = [];
+const mockQueryParams: TrufosQueryParam[] = [];
+const mockAssertions: Assertion[] = [];
+
+interface MockRequest {
+  id: string;
+  headers: TrufosHeader[];
+  url: { query: TrufosQueryParam[] };
+  assertions: Assertion[];
+}
+
+interface MockCollectionState {
+  selectedRequestId: string;
+  requests: Map<string, MockRequest>;
+}
 
 // Mock child components to avoid their store dependencies
 vi.mock('@/components/mainWindow/bodyTabs/InputTabs/tabs/HeaderTab/HeaderTab', () => ({
@@ -32,15 +46,29 @@ vi.mock('@/components/mainWindow/bodyTabs/InputTabs/tabs/ScriptTab', () => ({
   ScriptTab: () => <div>ScriptTab Content</div>,
 }));
 
+vi.mock('@/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab', () => ({
+  AssertionsTab: () => <div>AssertionsTab Content</div>,
+}));
+
 vi.mock('@/state/collectionStore', () => ({
-  useCollectionStore: (selector: any) =>
+  useCollectionStore: <T,>(selector: (state: MockCollectionState) => T): T =>
     selector({
       selectedRequestId: 'req-1',
       requests: new Map([
-        ['req-1', { id: 'req-1', headers: mockHeaders, url: { query: mockQueryParams } }],
+        [
+          'req-1',
+          {
+            id: 'req-1',
+            headers: mockHeaders,
+            url: { query: mockQueryParams },
+            assertions: mockAssertions,
+          },
+        ],
       ]),
     }),
-  selectRequest: (state: any) => state.requests.get(state.selectedRequestId),
+  selectRequest: (state: MockCollectionState) => state.requests.get(state.selectedRequestId),
+  selectAssertions: (state: MockCollectionState) =>
+    state.requests.get(state.selectedRequestId)!.assertions,
 }));
 
 describe('InputTabs', () => {
@@ -56,6 +84,7 @@ describe('InputTabs', () => {
     expect(getByText('Parameters')).toBeTruthy();
     expect(getByText('Headers')).toBeTruthy();
     expect(getByText('Auth')).toBeTruthy();
+    expect(getByText('Assertions')).toBeTruthy();
   });
 
   it('should show Body tab content by default', () => {

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/InputTabs.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/InputTabs.tsx
@@ -1,18 +1,20 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useMemo, useState } from 'react';
-import { selectRequest, useCollectionStore } from '@/state/collectionStore';
+import { selectAssertions, selectRequest, useCollectionStore } from '@/state/collectionStore';
 import { HeaderTab } from '@/components/mainWindow/bodyTabs/InputTabs/tabs/HeaderTab/HeaderTab';
 import { BodyTab } from '@/components/mainWindow/bodyTabs/InputTabs/tabs/BodyTab';
 import { ParamsTab } from '@/components/mainWindow/bodyTabs/InputTabs/tabs/ParamsTab';
 import { AuthorizationTab } from '@/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationTab';
 import { ScriptTab } from '@/components/mainWindow/bodyTabs/InputTabs/tabs/ScriptTab';
 import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
+import { AssertionsTab } from '@/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab';
 
 interface InputTabsProps {
   className: string;
 }
 
-type InputTabValue = 'body' | 'queryParams' | 'headers' | 'authorization' | 'scripts';
+type InputTabValue =
+  'body' | 'queryParams' | 'headers' | 'authorization' | 'scripts' | 'assertions';
 
 export function InputTabs(props: Readonly<InputTabsProps>) {
   const { className } = props;
@@ -21,6 +23,7 @@ export function InputTabs(props: Readonly<InputTabsProps>) {
 
   const headers = useCollectionStore((state) => selectRequest(state)!.headers);
   const queryParams = useCollectionStore((state) => selectRequest(state)!.url.query);
+  const assertions = useCollectionStore(selectAssertions);
 
   const activeHeaderCount = useMemo(
     () => headers.filter((header) => header.isActive).length,
@@ -30,6 +33,11 @@ export function InputTabs(props: Readonly<InputTabsProps>) {
   const activeParamsCount = useMemo(
     () => queryParams.filter((param) => param.isActive).length,
     [queryParams]
+  );
+
+  const activeAssertionCount = useMemo(
+    () => assertions.filter((assertion) => assertion.isActive).length,
+    [assertions]
   );
 
   useHotkeys([
@@ -53,6 +61,10 @@ export function InputTabs(props: Readonly<InputTabsProps>) {
       keys: 'mod+5',
       handler: () => setSelectedTab('scripts'),
     },
+    {
+      keys: 'mod+8',
+      handler: () => setSelectedTab('assertions'),
+    },
   ]);
 
   return (
@@ -73,6 +85,9 @@ export function InputTabs(props: Readonly<InputTabsProps>) {
         </TabsTrigger>
         <TabsTrigger value="authorization">Auth</TabsTrigger>
         <TabsTrigger value="scripts">Scripts</TabsTrigger>
+        <TabsTrigger value="assertions">
+          {activeAssertionCount === 0 ? 'Assertions' : `Assertions (${activeAssertionCount})`}
+        </TabsTrigger>
       </TabsList>
 
       <TabsContent value="body">
@@ -93,6 +108,10 @@ export function InputTabs(props: Readonly<InputTabsProps>) {
 
       <TabsContent value="scripts">
         <ScriptTab />
+      </TabsContent>
+
+      <TabsContent value="assertions">
+        <AssertionsTab />
       </TabsContent>
     </Tabs>
   );

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { AddIcon, DeleteIcon } from '@/components/icons';
 import { ActiveCheckbox } from '@/components/shared/ActiveCheckbox';
+import { Divider } from '@/components/shared/Divider';
 import {
   Select,
   SelectContent,
@@ -70,12 +71,17 @@ export const AssertionsTab = (): React.ReactNode => {
   return (
     <div className="relative h-full p-4">
       <div className="absolute top-4 right-4 left-4 z-10">
-        <Button className="h-fit gap-1" size="sm" variant="ghost" onClick={addAssertion}>
+        <Button
+          className="h-fit gap-1 hover:bg-transparent"
+          size="sm"
+          variant="ghost"
+          onClick={addAssertion}
+        >
           <AddIcon />
           Add Assertion
         </Button>
 
-        <div className="bg-divider mt-2 h-px" />
+        <Divider className="mt-2" />
       </div>
 
       <div className="absolute top-[68px] right-4 bottom-4 left-4 overflow-auto">

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab.tsx
@@ -62,7 +62,7 @@ const defaultOperatorByType: Record<AssertionType, AssertionOperator> = {
   [AssertionType.JSON_PATH]: AssertionOperator.EXISTS,
 };
 
-export const AssertionsTab = (): React.ReactNode => {
+export const AssertionsTab = () => {
   const { addAssertion, deleteAssertion, updateAssertion, setAssertionActive } =
     useCollectionActions();
   const assertions = useCollectionStore(selectAssertions);
@@ -128,7 +128,7 @@ function AssertionRow({
   onDelete,
   onUpdate,
   onActiveChange,
-}: Readonly<AssertionRowProps>): React.ReactNode {
+}: Readonly<AssertionRowProps>) {
   const handleTypeChange = (type: AssertionType): void => {
     onUpdate(index, {
       type,

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab.tsx
@@ -184,23 +184,25 @@ function AssertionRow({
       </TableCell>
 
       <TableCell>
-        <input
-          className="w-full bg-transparent outline-hidden disabled:opacity-40"
-          disabled={!usesTarget(assertion.type)}
-          placeholder={getTargetPlaceholder(assertion.type)}
-          value={assertion.target ?? ''}
-          onChange={(event) => onUpdate(index, { target: event.target.value })}
-        />
+        {usesTarget(assertion.type) && (
+          <input
+            className="w-full bg-transparent outline-hidden"
+            placeholder={getTargetPlaceholder(assertion.type)}
+            value={assertion.target ?? ''}
+            onChange={(event) => onUpdate(index, { target: event.target.value })}
+          />
+        )}
       </TableCell>
 
       <TableCell>
-        <input
-          className="w-full bg-transparent outline-hidden disabled:opacity-40"
-          disabled={!usesExpected(assertion.operator)}
-          placeholder={getExpectedPlaceholder(assertion)}
-          value={assertion.expected ?? ''}
-          onChange={(event) => onUpdate(index, { expected: event.target.value })}
-        />
+        {usesExpected(assertion.operator) && (
+          <input
+            className="w-full bg-transparent outline-hidden"
+            placeholder={getExpectedPlaceholder(assertion)}
+            value={assertion.expected ?? ''}
+            onChange={(event) => onUpdate(index, { expected: event.target.value })}
+          />
+        )}
       </TableCell>
 
       <TableCell className="text-right">

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab.tsx
@@ -22,7 +22,6 @@ import {
   useCollectionActions,
   useCollectionStore,
 } from '@/state/collectionStore';
-import { withUpdatedAssertionName } from '@/services/assertions/assertion-name';
 import { Assertion, AssertionOperator, AssertionType } from 'shim/objects/assertion';
 
 const typeLabels: Record<AssertionType, string> = {
@@ -89,11 +88,10 @@ export const AssertionsTab = (): React.ReactNode => {
           <TableHeader>
             <TableRow>
               <TableHead className="w-12" />
-              <TableHead className="w-1/5">Name</TableHead>
               <TableHead className="w-36">Type</TableHead>
               <TableHead className="w-36">Check</TableHead>
-              <TableHead className="w-1/5">Target</TableHead>
-              <TableHead className="w-1/5">Expected</TableHead>
+              <TableHead className="w-1/3">Target</TableHead>
+              <TableHead className="w-1/3">Expected</TableHead>
               <TableHead className="w-16">Actions</TableHead>
             </TableRow>
           </TableHeader>
@@ -131,12 +129,8 @@ function AssertionRow({
   onUpdate,
   onActiveChange,
 }: Readonly<AssertionRowProps>): React.ReactNode {
-  const updateGeneratedFields = (updatedAssertion: Partial<Assertion>): void => {
-    onUpdate(index, withUpdatedAssertionName(assertion, updatedAssertion));
-  };
-
   const handleTypeChange = (type: AssertionType): void => {
-    updateGeneratedFields({
+    onUpdate(index, {
       type,
       operator: defaultOperatorByType[type],
       target: getDefaultTarget(type, assertion.target),
@@ -150,16 +144,6 @@ function AssertionRow({
         <ActiveCheckbox
           checked={assertion.isActive}
           onChange={(active) => onActiveChange(index, active)}
-        />
-      </TableCell>
-
-      <TableCell>
-        <input
-          className="w-full bg-transparent outline-hidden"
-          value={assertion.name}
-          onChange={(event) =>
-            onUpdate(index, { name: event.target.value, nameManuallyEdited: true })
-          }
         />
       </TableCell>
 
@@ -184,7 +168,7 @@ function AssertionRow({
       <TableCell>
         <Select
           value={assertion.operator}
-          onValueChange={(value) => updateGeneratedFields({ operator: value as AssertionOperator })}
+          onValueChange={(value) => onUpdate(index, { operator: value as AssertionOperator })}
         >
           <SelectTrigger className="w-full">
             <SelectValue />
@@ -205,7 +189,7 @@ function AssertionRow({
           disabled={!usesTarget(assertion.type)}
           placeholder={getTargetPlaceholder(assertion.type)}
           value={assertion.target ?? ''}
-          onChange={(event) => updateGeneratedFields({ target: event.target.value })}
+          onChange={(event) => onUpdate(index, { target: event.target.value })}
         />
       </TableCell>
 
@@ -215,7 +199,7 @@ function AssertionRow({
           disabled={!usesExpected(assertion.operator)}
           placeholder={getExpectedPlaceholder(assertion)}
           value={assertion.expected ?? ''}
-          onChange={(event) => updateGeneratedFields({ expected: event.target.value })}
+          onChange={(event) => onUpdate(index, { expected: event.target.value })}
         />
       </TableCell>
 

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab.tsx
@@ -196,12 +196,17 @@ function AssertionRow({
 
       <TableCell>
         {usesExpected(assertion.operator) && (
-          <input
-            className="w-full bg-transparent outline-hidden"
-            placeholder={getExpectedPlaceholder(assertion)}
-            value={assertion.expected ?? ''}
-            onChange={(event) => onUpdate(index, { expected: event.target.value })}
-          />
+          <div className="flex items-center gap-1">
+            <input
+              className="w-full bg-transparent outline-hidden"
+              placeholder={getExpectedPlaceholder(assertion)}
+              value={assertion.expected ?? ''}
+              onChange={(event) => onUpdate(index, { expected: event.target.value })}
+            />
+            {assertion.type === AssertionType.RESPONSE_TIME && (
+              <span className="text-text-secondary shrink-0 text-xs">ms</span>
+            )}
+          </div>
         )}
       </TableCell>
 

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/tabs/AssertionsTab.tsx
@@ -1,0 +1,259 @@
+import { Button } from '@/components/ui/button';
+import { AddIcon, DeleteIcon } from '@/components/icons';
+import { ActiveCheckbox } from '@/components/shared/ActiveCheckbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  selectAssertions,
+  useCollectionActions,
+  useCollectionStore,
+} from '@/state/collectionStore';
+import { withUpdatedAssertionName } from '@/services/assertions/assertion-name';
+import { Assertion, AssertionOperator, AssertionType } from 'shim/objects/assertion';
+
+const typeLabels: Record<AssertionType, string> = {
+  [AssertionType.STATUS_CODE]: 'Status',
+  [AssertionType.RESPONSE_TIME]: 'Time',
+  [AssertionType.HEADER]: 'Header',
+  [AssertionType.JSON_PATH]: 'JSON Path',
+};
+
+const operatorLabels: Record<AssertionOperator, string> = {
+  [AssertionOperator.EQUALS]: 'Equals',
+  [AssertionOperator.IN_RANGE]: 'In range',
+  [AssertionOperator.BELOW]: 'Below',
+  [AssertionOperator.PRESENT]: 'Present',
+  [AssertionOperator.CONTAINS]: 'Contains',
+  [AssertionOperator.EXISTS]: 'Exists',
+};
+
+const operatorsByType: Record<AssertionType, AssertionOperator[]> = {
+  [AssertionType.STATUS_CODE]: [AssertionOperator.EQUALS, AssertionOperator.IN_RANGE],
+  [AssertionType.RESPONSE_TIME]: [AssertionOperator.BELOW],
+  [AssertionType.HEADER]: [
+    AssertionOperator.PRESENT,
+    AssertionOperator.EQUALS,
+    AssertionOperator.CONTAINS,
+  ],
+  [AssertionType.JSON_PATH]: [
+    AssertionOperator.EXISTS,
+    AssertionOperator.EQUALS,
+    AssertionOperator.CONTAINS,
+  ],
+};
+
+const defaultOperatorByType: Record<AssertionType, AssertionOperator> = {
+  [AssertionType.STATUS_CODE]: AssertionOperator.EQUALS,
+  [AssertionType.RESPONSE_TIME]: AssertionOperator.BELOW,
+  [AssertionType.HEADER]: AssertionOperator.PRESENT,
+  [AssertionType.JSON_PATH]: AssertionOperator.EXISTS,
+};
+
+export const AssertionsTab = (): React.ReactNode => {
+  const { addAssertion, deleteAssertion, updateAssertion, setAssertionActive } =
+    useCollectionActions();
+  const assertions = useCollectionStore(selectAssertions);
+
+  return (
+    <div className="relative h-full p-4">
+      <div className="absolute top-4 right-4 left-4 z-10">
+        <Button className="h-fit gap-1" size="sm" variant="ghost" onClick={addAssertion}>
+          <AddIcon />
+          Add Assertion
+        </Button>
+
+        <div className="bg-divider mt-2 h-px" />
+      </div>
+
+      <div className="absolute top-[68px] right-4 bottom-4 left-4 overflow-auto">
+        <Table className="w-full table-fixed">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-12" />
+              <TableHead className="w-1/5">Name</TableHead>
+              <TableHead className="w-36">Type</TableHead>
+              <TableHead className="w-36">Check</TableHead>
+              <TableHead className="w-1/5">Target</TableHead>
+              <TableHead className="w-1/5">Expected</TableHead>
+              <TableHead className="w-16">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+
+          <TableBody>
+            {assertions.map((assertion, index) => (
+              <AssertionRow
+                key={assertion.id}
+                assertion={assertion}
+                index={index}
+                onDelete={deleteAssertion}
+                onUpdate={updateAssertion}
+                onActiveChange={setAssertionActive}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+};
+
+interface AssertionRowProps {
+  assertion: Assertion;
+  index: number;
+  onDelete(index: number): void;
+  onUpdate(index: number, assertion: Partial<Assertion>): void;
+  onActiveChange(index: number, active?: boolean): void;
+}
+
+function AssertionRow({
+  assertion,
+  index,
+  onDelete,
+  onUpdate,
+  onActiveChange,
+}: Readonly<AssertionRowProps>): React.ReactNode {
+  const updateGeneratedFields = (updatedAssertion: Partial<Assertion>): void => {
+    onUpdate(index, withUpdatedAssertionName(assertion, updatedAssertion));
+  };
+
+  const handleTypeChange = (type: AssertionType): void => {
+    updateGeneratedFields({
+      type,
+      operator: defaultOperatorByType[type],
+      target: getDefaultTarget(type, assertion.target),
+      expected: getDefaultExpected(type, assertion.expected),
+    });
+  };
+
+  return (
+    <TableRow>
+      <TableCell>
+        <ActiveCheckbox
+          checked={assertion.isActive}
+          onChange={(active) => onActiveChange(index, active)}
+        />
+      </TableCell>
+
+      <TableCell>
+        <input
+          className="w-full bg-transparent outline-hidden"
+          value={assertion.name}
+          onChange={(event) =>
+            onUpdate(index, { name: event.target.value, nameManuallyEdited: true })
+          }
+        />
+      </TableCell>
+
+      <TableCell>
+        <Select
+          value={assertion.type}
+          onValueChange={(value) => handleTypeChange(value as AssertionType)}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {Object.values(AssertionType).map((type) => (
+              <SelectItem key={type} value={type}>
+                {typeLabels[type]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </TableCell>
+
+      <TableCell>
+        <Select
+          value={assertion.operator}
+          onValueChange={(value) => updateGeneratedFields({ operator: value as AssertionOperator })}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {operatorsByType[assertion.type].map((operator) => (
+              <SelectItem key={operator} value={operator}>
+                {operatorLabels[operator]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </TableCell>
+
+      <TableCell>
+        <input
+          className="w-full bg-transparent outline-hidden disabled:opacity-40"
+          disabled={!usesTarget(assertion.type)}
+          placeholder={getTargetPlaceholder(assertion.type)}
+          value={assertion.target ?? ''}
+          onChange={(event) => updateGeneratedFields({ target: event.target.value })}
+        />
+      </TableCell>
+
+      <TableCell>
+        <input
+          className="w-full bg-transparent outline-hidden disabled:opacity-40"
+          disabled={!usesExpected(assertion.operator)}
+          placeholder={getExpectedPlaceholder(assertion)}
+          value={assertion.expected ?? ''}
+          onChange={(event) => updateGeneratedFields({ expected: event.target.value })}
+        />
+      </TableCell>
+
+      <TableCell className="text-right">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="hover:text-accent-primary active:text-accent-secondary h-6 w-6 hover:bg-transparent"
+          onClick={() => onDelete(index)}
+        >
+          <DeleteIcon />
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function usesTarget(type: AssertionType): boolean {
+  return type === AssertionType.HEADER || type === AssertionType.JSON_PATH;
+}
+
+function usesExpected(operator: AssertionOperator): boolean {
+  return operator !== AssertionOperator.PRESENT && operator !== AssertionOperator.EXISTS;
+}
+
+function getDefaultTarget(type: AssertionType, current: string | undefined): string | undefined {
+  if (!usesTarget(type)) return undefined;
+  return current ?? (type === AssertionType.JSON_PATH ? '$.' : '');
+}
+
+function getDefaultExpected(type: AssertionType, current: string | undefined): string | undefined {
+  if (type === AssertionType.STATUS_CODE) return current ?? '200';
+  if (type === AssertionType.RESPONSE_TIME) return current ?? '500';
+  return current;
+}
+
+function getTargetPlaceholder(type: AssertionType): string {
+  if (type === AssertionType.HEADER) return 'content-type';
+  if (type === AssertionType.JSON_PATH) return '$.data.id';
+  return '';
+}
+
+function getExpectedPlaceholder(assertion: Assertion): string {
+  if (assertion.type === AssertionType.STATUS_CODE) return '200 or 200-299';
+  if (assertion.type === AssertionType.RESPONSE_TIME) return '500';
+  return 'Expected value';
+}

--- a/src/renderer/components/mainWindow/bodyTabs/OutputTabs.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/OutputTabs.tsx
@@ -97,7 +97,7 @@ export function OutputTabs({ className }: OutputTabsProps) {
       </TabsContent>
 
       <TabsContent value="assertions" className="p-4">
-        <div className="h-0">
+        <div>
           <Table className="w-full table-auto">
             <TableHeader>
               <TableRow>

--- a/src/renderer/components/mainWindow/bodyTabs/OutputTabs.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/OutputTabs.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { CheckCircle2, XCircle } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Table,
@@ -9,7 +10,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { ResponseStatus } from '@/components/mainWindow/responseStatus/ResponseStatus';
-import { selectResponse, useResponseStore } from '@/state/responseStore';
+import { selectAssertionResults, selectResponse, useResponseStore } from '@/state/responseStore';
 import { selectRequest, useCollectionStore } from '@/state/collectionStore';
 import { BodyTab } from './OutputTabs/BodyTab';
 import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
@@ -18,13 +19,14 @@ interface OutputTabsProps {
   className: string;
 }
 
-type OutputTabValue = 'body' | 'header';
+type OutputTabValue = 'body' | 'header' | 'assertions';
 
 export function OutputTabs({ className }: OutputTabsProps) {
   const [selectedTab, setSelectedTab] = useState<OutputTabValue>('body');
 
   const requestId = useCollectionStore((state) => selectRequest(state)?.id);
   const response = useResponseStore((state) => selectResponse(state, requestId));
+  const assertionResults = useResponseStore((state) => selectAssertionResults(state, requestId));
 
   useHotkeys([
     {
@@ -34,6 +36,10 @@ export function OutputTabs({ className }: OutputTabsProps) {
     {
       keys: 'mod+7',
       handler: () => setSelectedTab('header'),
+    },
+    {
+      keys: 'mod+9',
+      handler: () => setSelectedTab('assertions'),
     },
   ]);
 
@@ -56,6 +62,11 @@ export function OutputTabs({ className }: OutputTabsProps) {
         <div className="flex">
           <TabsTrigger value="body">Response Body</TabsTrigger>
           <TabsTrigger value="header">Headers</TabsTrigger>
+          <TabsTrigger value="assertions">
+            {assertionResults == null || assertionResults.length === 0
+              ? 'Assertions'
+              : `Assertions (${assertionResults.filter((result) => result.passed).length}/${assertionResults.length})`}
+          </TabsTrigger>
         </div>
         <ResponseStatus />
       </TabsList>
@@ -78,6 +89,38 @@ export function OutputTabs({ className }: OutputTabsProps) {
                 <TableRow key={key}>
                   <TableCell className="w-1/3">{key}</TableCell>
                   <TableCell>{Array.isArray(value) ? value.join(', ') : value}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </TabsContent>
+
+      <TabsContent value="assertions" className="p-4">
+        <div className="h-0">
+          <Table className="w-full table-auto">
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-20">Result</TableHead>
+                <TableHead className="w-1/3">Assertion</TableHead>
+                <TableHead className="w-full">Details</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {(assertionResults ?? []).map((result) => (
+                <TableRow key={result.assertionId}>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      {result.passed ? (
+                        <CheckCircle2 className="text-accent-primary h-4 w-4" />
+                      ) : (
+                        <XCircle className="text-destructive h-4 w-4" />
+                      )}
+                      {result.passed ? 'Pass' : 'Fail'}
+                    </div>
+                  </TableCell>
+                  <TableCell>{result.name}</TableCell>
+                  <TableCell>{result.message}</TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/src/renderer/components/mainWindow/bodyTabs/OutputTabs.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/OutputTabs.tsx
@@ -110,11 +110,11 @@ export function OutputTabs({ className }: OutputTabsProps) {
               {(assertionResults ?? []).map((result) => (
                 <TableRow key={result.assertionId}>
                   <TableCell>
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 whitespace-nowrap">
                       {result.passed ? (
-                        <CheckCircle2 className="text-accent-primary h-4 w-4" />
+                        <CheckCircle2 className="text-state-success h-4 w-4 shrink-0" />
                       ) : (
-                        <XCircle className="text-destructive h-4 w-4" />
+                        <XCircle className="text-danger h-4 w-4 shrink-0" />
                       )}
                       {result.passed ? 'Pass' : 'Fail'}
                     </div>

--- a/src/renderer/components/ui/tabs.tsx
+++ b/src/renderer/components/ui/tabs.tsx
@@ -57,7 +57,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      `tabs-scrollbar bg-card ring-offset-background focus-visible:ring-ring mt-2 flex-1 overflow-y-auto rounded-[24px] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden`,
+      `tabs-scrollbar bg-card ring-offset-background focus-visible:ring-ring mt-2 min-h-0 flex-1 overflow-y-auto rounded-[24px] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden`,
       className
     )}
     {...props}

--- a/src/renderer/services/assertions/assertion-name.test.ts
+++ b/src/renderer/services/assertions/assertion-name.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { Assertion, AssertionOperator, AssertionType } from 'shim/objects/assertion';
+import { buildAssertionName, withUpdatedAssertionName } from './assertion-name';
+
+const assertion: Assertion = {
+  id: 'assertion-id',
+  name: 'Status code equals 200',
+  isActive: true,
+  type: AssertionType.STATUS_CODE,
+  operator: AssertionOperator.EQUALS,
+  expected: '200',
+};
+
+describe('assertion names', () => {
+  it('builds names from assertion values', () => {
+    expect(buildAssertionName(assertion)).toBe('Status code equals 200');
+    expect(
+      buildAssertionName({
+        type: AssertionType.HEADER,
+        operator: AssertionOperator.PRESENT,
+        target: 'content-type',
+      })
+    ).toBe('Header content-type exists');
+  });
+
+  it('updates generated names when assertion fields change', () => {
+    expect(withUpdatedAssertionName(assertion, { expected: '201' })).toEqual({
+      expected: '201',
+      name: 'Status code equals 201',
+    });
+  });
+
+  it('keeps manual names when assertion fields change', () => {
+    expect(
+      withUpdatedAssertionName(
+        {
+          ...assertion,
+          name: 'My check',
+          nameManuallyEdited: true,
+        },
+        { expected: '201' }
+      )
+    ).toEqual({ expected: '201' });
+  });
+});

--- a/src/renderer/services/assertions/assertion-name.test.ts
+++ b/src/renderer/services/assertions/assertion-name.test.ts
@@ -1,19 +1,30 @@
 import { describe, expect, it } from 'vitest';
-import { Assertion, AssertionOperator, AssertionType } from 'shim/objects/assertion';
-import { buildAssertionName, withUpdatedAssertionName } from './assertion-name';
+import { AssertionOperator, AssertionType } from 'shim/objects/assertion';
+import { buildAssertionName } from './assertion-name';
 
-const assertion: Assertion = {
-  id: 'assertion-id',
-  name: 'Status code equals 200',
-  isActive: true,
-  type: AssertionType.STATUS_CODE,
-  operator: AssertionOperator.EQUALS,
-  expected: '200',
-};
-
-describe('assertion names', () => {
+describe('buildAssertionName', () => {
   it('builds names from assertion values', () => {
-    expect(buildAssertionName(assertion)).toBe('Status code equals 200');
+    expect(
+      buildAssertionName({
+        type: AssertionType.STATUS_CODE,
+        operator: AssertionOperator.EQUALS,
+        expected: '200',
+      })
+    ).toBe('Status code equals 200');
+    expect(
+      buildAssertionName({
+        type: AssertionType.STATUS_CODE,
+        operator: AssertionOperator.IN_RANGE,
+        expected: '200-299',
+      })
+    ).toBe('Status code is in 200-299');
+    expect(
+      buildAssertionName({
+        type: AssertionType.RESPONSE_TIME,
+        operator: AssertionOperator.BELOW,
+        expected: '500',
+      })
+    ).toBe('Response time below 500 ms');
     expect(
       buildAssertionName({
         type: AssertionType.HEADER,
@@ -21,25 +32,13 @@ describe('assertion names', () => {
         target: 'content-type',
       })
     ).toBe('Header content-type exists');
-  });
-
-  it('updates generated names when assertion fields change', () => {
-    expect(withUpdatedAssertionName(assertion, { expected: '201' })).toEqual({
-      expected: '201',
-      name: 'Status code equals 201',
-    });
-  });
-
-  it('keeps manual names when assertion fields change', () => {
     expect(
-      withUpdatedAssertionName(
-        {
-          ...assertion,
-          name: 'My check',
-          nameManuallyEdited: true,
-        },
-        { expected: '201' }
-      )
-    ).toEqual({ expected: '201' });
+      buildAssertionName({
+        type: AssertionType.JSON_PATH,
+        operator: AssertionOperator.EQUALS,
+        target: '$.data.id',
+        expected: '42',
+      })
+    ).toBe('JSON path $.data.id equals 42');
   });
 });

--- a/src/renderer/services/assertions/assertion-name.ts
+++ b/src/renderer/services/assertions/assertion-name.ts
@@ -1,0 +1,50 @@
+import { Assertion, AssertionOperator, AssertionType } from 'shim/objects/assertion';
+
+export function buildAssertionName(
+  assertion: Pick<Assertion, 'type' | 'operator'> & Partial<Assertion>
+): string {
+  switch (assertion.type) {
+    case AssertionType.STATUS_CODE:
+      return assertion.operator === AssertionOperator.IN_RANGE
+        ? `Status code is in ${assertion.expected ?? ''}`
+        : `Status code equals ${assertion.expected ?? ''}`;
+    case AssertionType.RESPONSE_TIME:
+      return `Response time below ${assertion.expected ?? ''} ms`;
+    case AssertionType.HEADER:
+      return buildTargetName('Header', assertion);
+    case AssertionType.JSON_PATH:
+      return buildTargetName('JSON path', assertion);
+  }
+}
+
+export function shouldUpdateAssertionName(assertion: Assertion): boolean {
+  return assertion.nameManuallyEdited !== true && assertion.name === buildAssertionName(assertion);
+}
+
+export function withUpdatedAssertionName(
+  assertion: Assertion,
+  updatedAssertion: Partial<Assertion>
+): Partial<Assertion> {
+  const nextAssertion = { ...assertion, ...updatedAssertion };
+  if (!shouldUpdateAssertionName(assertion)) return updatedAssertion;
+  return {
+    ...updatedAssertion,
+    name: buildAssertionName(nextAssertion),
+  };
+}
+
+function buildTargetName(
+  label: string,
+  assertion: Pick<Assertion, 'operator'> & Partial<Assertion>
+): string {
+  const target = assertion.target ?? '';
+  if (
+    assertion.operator === AssertionOperator.PRESENT ||
+    assertion.operator === AssertionOperator.EXISTS
+  ) {
+    return `${label} ${target} exists`;
+  }
+
+  const expected = assertion.expected ?? '';
+  return `${label} ${target} ${assertion.operator} ${expected}`;
+}

--- a/src/renderer/services/assertions/assertion-name.ts
+++ b/src/renderer/services/assertions/assertion-name.ts
@@ -1,5 +1,6 @@
 import { Assertion, AssertionOperator, AssertionType } from 'shim/objects/assertion';
 
+/** Builds a human-readable label for an assertion from its type, operator, target and expected value. */
 export function buildAssertionName(
   assertion: Pick<Assertion, 'type' | 'operator'> & Partial<Assertion>
 ): string {
@@ -15,22 +16,6 @@ export function buildAssertionName(
     case AssertionType.JSON_PATH:
       return buildTargetName('JSON path', assertion);
   }
-}
-
-export function shouldUpdateAssertionName(assertion: Assertion): boolean {
-  return assertion.nameManuallyEdited !== true && assertion.name === buildAssertionName(assertion);
-}
-
-export function withUpdatedAssertionName(
-  assertion: Assertion,
-  updatedAssertion: Partial<Assertion>
-): Partial<Assertion> {
-  const nextAssertion = { ...assertion, ...updatedAssertion };
-  if (!shouldUpdateAssertionName(assertion)) return updatedAssertion;
-  return {
-    ...updatedAssertion,
-    name: buildAssertionName(nextAssertion),
-  };
 }
 
 function buildTargetName(

--- a/src/renderer/services/assertions/assertion-service.test.ts
+++ b/src/renderer/services/assertions/assertion-service.test.ts
@@ -8,7 +8,7 @@ const open = vi.fn(() => ({ readAll }));
 
 vi.mock('@/lib/ipc-stream', () => ({
   IpcPushStream: {
-    open: (...args: unknown[]) => open(...args),
+    open: () => open(),
   },
 }));
 

--- a/src/renderer/services/assertions/assertion-service.test.ts
+++ b/src/renderer/services/assertions/assertion-service.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Assertion, AssertionOperator, AssertionType } from 'shim/objects/assertion';
+import { TrufosResponse } from 'shim/objects/response';
+import { evaluateAssertions } from './assertion-service';
+
+const readAll = vi.fn<() => Promise<string>>();
+const open = vi.fn(() => ({ readAll }));
+
+vi.mock('@/lib/ipc-stream', () => ({
+  IpcPushStream: {
+    open: (...args: unknown[]) => open(...args),
+  },
+}));
+
+const response: TrufosResponse = {
+  type: 'response',
+  id: 'response-id',
+  headers: {
+    'content-type': 'application/json',
+  },
+  metaInfo: {
+    duration: 120,
+    status: 201,
+    size: {
+      totalSizeInBytes: 100,
+      headersSizeInBytes: 40,
+      bodySizeInBytes: 60,
+    },
+  },
+};
+
+describe('evaluateAssertions', () => {
+  beforeEach(() => {
+    open.mockImplementation(() => ({ readAll }));
+    readAll.mockReset();
+  });
+
+  it('evaluates status code and response time assertions', async () => {
+    const assertions: Assertion[] = [
+      {
+        id: 'status',
+        name: 'Status is 201',
+        isActive: true,
+        type: AssertionType.STATUS_CODE,
+        operator: AssertionOperator.EQUALS,
+        expected: '201',
+      },
+      {
+        id: 'time',
+        name: 'Fast enough',
+        isActive: true,
+        type: AssertionType.RESPONSE_TIME,
+        operator: AssertionOperator.BELOW,
+        expected: '100',
+      },
+    ];
+
+    await expect(evaluateAssertions(assertions, response)).resolves.toEqual([
+      { assertionId: 'status', name: 'Status is 201', passed: true, message: 'Passed' },
+      {
+        assertionId: 'time',
+        name: 'Fast enough',
+        passed: false,
+        message: 'Expected below 100ms, got 120ms',
+      },
+    ]);
+  });
+
+  it('evaluates header assertions case-insensitively', async () => {
+    const assertions: Assertion[] = [
+      {
+        id: 'header',
+        name: 'Content type',
+        isActive: true,
+        type: AssertionType.HEADER,
+        operator: AssertionOperator.CONTAINS,
+        target: 'Content-Type',
+        expected: 'json',
+      },
+    ];
+
+    await expect(evaluateAssertions(assertions, response)).resolves.toEqual([
+      { assertionId: 'header', name: 'Content type', passed: true, message: 'Passed' },
+    ]);
+  });
+
+  it('evaluates JSON path assertions against response body', async () => {
+    readAll.mockResolvedValueOnce('{"data":{"id":42}}');
+    const assertions: Assertion[] = [
+      {
+        id: 'json',
+        name: 'JSON id',
+        isActive: true,
+        type: AssertionType.JSON_PATH,
+        operator: AssertionOperator.EQUALS,
+        target: '$.data.id',
+        expected: '42',
+      },
+    ];
+
+    await expect(evaluateAssertions(assertions, response)).resolves.toEqual([
+      { assertionId: 'json', name: 'JSON id', passed: true, message: 'Passed' },
+    ]);
+  });
+
+  it('reports JSON path assertions as failed when response body is not JSON', async () => {
+    readAll.mockResolvedValueOnce('not json');
+    const assertions: Assertion[] = [
+      {
+        id: 'json',
+        name: 'JSON id',
+        isActive: true,
+        type: AssertionType.JSON_PATH,
+        operator: AssertionOperator.EXISTS,
+        target: '$.data.id',
+      },
+    ];
+
+    await expect(evaluateAssertions(assertions, response)).resolves.toEqual([
+      {
+        assertionId: 'json',
+        name: 'JSON id',
+        passed: false,
+        message: 'Response body is not valid JSON',
+      },
+    ]);
+  });
+
+  it('reports JSON path assertions as failed when response body cannot be read', async () => {
+    open.mockRejectedValueOnce(new Error('stream failed'));
+    const assertions: Assertion[] = [
+      {
+        id: 'json',
+        name: 'JSON id',
+        isActive: true,
+        type: AssertionType.JSON_PATH,
+        operator: AssertionOperator.EXISTS,
+        target: '$.data.id',
+      },
+    ];
+
+    await expect(evaluateAssertions(assertions, response)).resolves.toEqual([
+      {
+        assertionId: 'json',
+        name: 'JSON id',
+        passed: false,
+        message: 'Response body is not valid JSON',
+      },
+    ]);
+  });
+});

--- a/src/renderer/services/assertions/assertion-service.test.ts
+++ b/src/renderer/services/assertions/assertion-service.test.ts
@@ -131,7 +131,7 @@ describe('evaluateAssertions', () => {
     ]);
   });
 
-  it('reports JSON path assertions as failed when response body cannot be read', async () => {
+  it('reports a read failure separately from invalid JSON', async () => {
     open.mockRejectedValueOnce(new Error('stream failed'));
     const assertions: Assertion[] = [
       {
@@ -148,7 +148,7 @@ describe('evaluateAssertions', () => {
         assertionId: 'json',
         name: 'JSON path $.data.id exists',
         passed: false,
-        message: 'Response body is not valid JSON',
+        message: 'Response body could not be read',
       },
     ]);
   });

--- a/src/renderer/services/assertions/assertion-service.test.ts
+++ b/src/renderer/services/assertions/assertion-service.test.ts
@@ -39,7 +39,6 @@ describe('evaluateAssertions', () => {
     const assertions: Assertion[] = [
       {
         id: 'status',
-        name: 'Status is 201',
         isActive: true,
         type: AssertionType.STATUS_CODE,
         operator: AssertionOperator.EQUALS,
@@ -47,7 +46,6 @@ describe('evaluateAssertions', () => {
       },
       {
         id: 'time',
-        name: 'Fast enough',
         isActive: true,
         type: AssertionType.RESPONSE_TIME,
         operator: AssertionOperator.BELOW,
@@ -56,10 +54,10 @@ describe('evaluateAssertions', () => {
     ];
 
     await expect(evaluateAssertions(assertions, response)).resolves.toEqual([
-      { assertionId: 'status', name: 'Status is 201', passed: true, message: 'Passed' },
+      { assertionId: 'status', name: 'Status code equals 201', passed: true, message: 'Passed' },
       {
         assertionId: 'time',
-        name: 'Fast enough',
+        name: 'Response time below 100 ms',
         passed: false,
         message: 'Expected below 100ms, got 120ms',
       },
@@ -70,7 +68,6 @@ describe('evaluateAssertions', () => {
     const assertions: Assertion[] = [
       {
         id: 'header',
-        name: 'Content type',
         isActive: true,
         type: AssertionType.HEADER,
         operator: AssertionOperator.CONTAINS,
@@ -80,7 +77,12 @@ describe('evaluateAssertions', () => {
     ];
 
     await expect(evaluateAssertions(assertions, response)).resolves.toEqual([
-      { assertionId: 'header', name: 'Content type', passed: true, message: 'Passed' },
+      {
+        assertionId: 'header',
+        name: 'Header Content-Type contains json',
+        passed: true,
+        message: 'Passed',
+      },
     ]);
   });
 
@@ -89,7 +91,6 @@ describe('evaluateAssertions', () => {
     const assertions: Assertion[] = [
       {
         id: 'json',
-        name: 'JSON id',
         isActive: true,
         type: AssertionType.JSON_PATH,
         operator: AssertionOperator.EQUALS,
@@ -99,7 +100,12 @@ describe('evaluateAssertions', () => {
     ];
 
     await expect(evaluateAssertions(assertions, response)).resolves.toEqual([
-      { assertionId: 'json', name: 'JSON id', passed: true, message: 'Passed' },
+      {
+        assertionId: 'json',
+        name: 'JSON path $.data.id equals 42',
+        passed: true,
+        message: 'Passed',
+      },
     ]);
   });
 
@@ -108,7 +114,6 @@ describe('evaluateAssertions', () => {
     const assertions: Assertion[] = [
       {
         id: 'json',
-        name: 'JSON id',
         isActive: true,
         type: AssertionType.JSON_PATH,
         operator: AssertionOperator.EXISTS,
@@ -119,7 +124,7 @@ describe('evaluateAssertions', () => {
     await expect(evaluateAssertions(assertions, response)).resolves.toEqual([
       {
         assertionId: 'json',
-        name: 'JSON id',
+        name: 'JSON path $.data.id exists',
         passed: false,
         message: 'Response body is not valid JSON',
       },
@@ -131,7 +136,6 @@ describe('evaluateAssertions', () => {
     const assertions: Assertion[] = [
       {
         id: 'json',
-        name: 'JSON id',
         isActive: true,
         type: AssertionType.JSON_PATH,
         operator: AssertionOperator.EXISTS,
@@ -142,7 +146,7 @@ describe('evaluateAssertions', () => {
     await expect(evaluateAssertions(assertions, response)).resolves.toEqual([
       {
         assertionId: 'json',
-        name: 'JSON id',
+        name: 'JSON path $.data.id exists',
         passed: false,
         message: 'Response body is not valid JSON',
       },

--- a/src/renderer/services/assertions/assertion-service.ts
+++ b/src/renderer/services/assertions/assertion-service.ts
@@ -77,7 +77,7 @@ function evaluateResponseTimeAssertion(
   return buildResult(
     assertion,
     duration < expected,
-    `Expected below ${expected}ms, got ${duration}ms`
+    `Expected below ${expected}ms, got ${Math.round(duration)}ms`
   );
 }
 

--- a/src/renderer/services/assertions/assertion-service.ts
+++ b/src/renderer/services/assertions/assertion-service.ts
@@ -1,4 +1,5 @@
 import { IpcPushStream } from '@/lib/ipc-stream';
+import { buildAssertionName } from '@/services/assertions/assertion-name';
 import {
   Assertion,
   AssertionOperator,
@@ -42,7 +43,7 @@ function evaluateAssertion(
   } catch (error) {
     return {
       assertionId: assertion.id,
-      name: assertion.name,
+      name: buildAssertionName(assertion),
       passed: false,
       message: error instanceof Error ? error.message : 'Assertion failed',
     };
@@ -215,7 +216,7 @@ function formatJsonValue(value: unknown): string {
 function buildResult(assertion: Assertion, passed: boolean, message: string): AssertionResult {
   return {
     assertionId: assertion.id,
-    name: assertion.name,
+    name: buildAssertionName(assertion),
     passed,
     message: passed ? 'Passed' : message,
   };

--- a/src/renderer/services/assertions/assertion-service.ts
+++ b/src/renderer/services/assertions/assertion-service.ts
@@ -1,0 +1,222 @@
+import { IpcPushStream } from '@/lib/ipc-stream';
+import {
+  Assertion,
+  AssertionOperator,
+  AssertionResult,
+  AssertionType,
+} from 'shim/objects/assertion';
+import { TrufosResponse } from 'shim/objects/response';
+
+const MAX_RESPONSE_BODY_BYTES = 1024 * 1024;
+
+export async function evaluateAssertions(
+  assertions: Assertion[] | undefined,
+  response: TrufosResponse
+): Promise<AssertionResult[]> {
+  const activeAssertions = assertions?.filter((assertion) => assertion.isActive) ?? [];
+  const needsBody = activeAssertions.some(
+    (assertion) => assertion.type === AssertionType.JSON_PATH
+  );
+  const body = needsBody ? await readResponseBodySafely(response) : undefined;
+  const jsonBody = body == null ? undefined : parseJson(body);
+
+  return activeAssertions.map((assertion) => evaluateAssertion(assertion, response, jsonBody));
+}
+
+function evaluateAssertion(
+  assertion: Assertion,
+  response: TrufosResponse,
+  jsonBody: unknown
+): AssertionResult {
+  try {
+    switch (assertion.type) {
+      case AssertionType.STATUS_CODE:
+        return evaluateStatusCodeAssertion(assertion, response);
+      case AssertionType.RESPONSE_TIME:
+        return evaluateResponseTimeAssertion(assertion, response);
+      case AssertionType.HEADER:
+        return evaluateHeaderAssertion(assertion, response);
+      case AssertionType.JSON_PATH:
+        return evaluateJsonPathAssertion(assertion, jsonBody);
+    }
+  } catch (error) {
+    return {
+      assertionId: assertion.id,
+      name: assertion.name,
+      passed: false,
+      message: error instanceof Error ? error.message : 'Assertion failed',
+    };
+  }
+}
+
+function evaluateStatusCodeAssertion(
+  assertion: Assertion,
+  response: TrufosResponse
+): AssertionResult {
+  const status = response.metaInfo.status;
+
+  if (assertion.operator === AssertionOperator.IN_RANGE) {
+    const [min, max] = parseRange(assertion.expected);
+    return buildResult(
+      assertion,
+      status >= min && status <= max,
+      `Expected ${min}-${max}, got ${status}`
+    );
+  }
+
+  const expected = parseNumber(assertion.expected, 'Expected status code');
+  return buildResult(assertion, status === expected, `Expected ${expected}, got ${status}`);
+}
+
+function evaluateResponseTimeAssertion(
+  assertion: Assertion,
+  response: TrufosResponse
+): AssertionResult {
+  const expected = parseNumber(assertion.expected, 'Expected response time');
+  const duration = response.metaInfo.duration;
+  return buildResult(
+    assertion,
+    duration < expected,
+    `Expected below ${expected}ms, got ${duration}ms`
+  );
+}
+
+function evaluateHeaderAssertion(assertion: Assertion, response: TrufosResponse): AssertionResult {
+  const headerName = assertion.target?.trim();
+  if (!headerName) throw new Error('Header name missing');
+
+  const value = findHeaderValue(response, headerName);
+  if (assertion.operator === AssertionOperator.PRESENT) {
+    return buildResult(assertion, value != null, `Expected header "${headerName}" to be present`);
+  }
+
+  const actual = value == null ? undefined : headerToString(value);
+  const expected = assertion.expected ?? '';
+  const passed =
+    assertion.operator === AssertionOperator.CONTAINS
+      ? actual?.includes(expected) === true
+      : actual === expected;
+
+  return buildResult(
+    assertion,
+    passed,
+    `Expected header "${headerName}" ${assertion.operator} "${expected}", got "${actual ?? ''}"`
+  );
+}
+
+function evaluateJsonPathAssertion(assertion: Assertion, jsonBody: unknown): AssertionResult {
+  if (jsonBody == null) throw new Error('Response body is not valid JSON');
+
+  const path = assertion.target?.trim();
+  if (!path) throw new Error('JSON path missing');
+
+  const resolved = resolveJsonPath(jsonBody, path);
+  if (assertion.operator === AssertionOperator.EXISTS) {
+    return buildResult(assertion, resolved.exists, `Expected JSON path "${path}" to exist`);
+  }
+
+  const actual = formatJsonValue(resolved.value);
+  const expected = assertion.expected ?? '';
+  const passed =
+    assertion.operator === AssertionOperator.CONTAINS
+      ? actual.includes(expected)
+      : actual === expected;
+
+  return buildResult(
+    assertion,
+    passed,
+    `Expected JSON path "${path}" ${assertion.operator} "${expected}", got "${actual}"`
+  );
+}
+
+async function readResponseBody(response: TrufosResponse): Promise<string | undefined> {
+  if (!response.id) return undefined;
+  const stream = await IpcPushStream.open(response, 'utf-8', MAX_RESPONSE_BODY_BYTES);
+  return await stream.readAll();
+}
+
+async function readResponseBodySafely(response: TrufosResponse): Promise<string | undefined> {
+  try {
+    return await readResponseBody(response);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseJson(body: string | undefined): unknown {
+  if (body == null || body.trim() === '') return undefined;
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseNumber(value: string | undefined, fieldName: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) throw new Error(`${fieldName} must be a number`);
+  return parsed;
+}
+
+function parseRange(value: string | undefined): [number, number] {
+  const [min, max] = value?.split('-').map((part) => Number(part.trim())) ?? [];
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    throw new Error('Expected status range must use min-max format');
+  }
+  return [min, max];
+}
+
+function findHeaderValue(response: TrufosResponse, name: string): string | string[] | undefined {
+  const lowerName = name.toLowerCase();
+  const entry = Object.entries(response.headers).find(([key]) => key.toLowerCase() === lowerName);
+  return entry?.[1];
+}
+
+function headerToString(value: string | string[]): string {
+  return Array.isArray(value) ? value.join(', ') : value;
+}
+
+function resolveJsonPath(root: unknown, path: string): { exists: boolean; value: unknown } {
+  const segments =
+    path
+      .replace(/^\$\./, '')
+      .replace(/^\$/, '')
+      .match(/[^.[\]]+/g) ?? [];
+  let current = root;
+
+  for (const segment of segments) {
+    if (Array.isArray(current)) {
+      const index = Number(segment);
+      if (!Number.isInteger(index) || index < 0 || index >= current.length) {
+        return { exists: false, value: undefined };
+      }
+      current = current[index];
+    } else if (isRecord(current) && segment in current) {
+      current = current[segment];
+    } else {
+      return { exists: false, value: undefined };
+    }
+  }
+
+  return { exists: true, value: current };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function formatJsonValue(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return '[complex value]';
+}
+
+function buildResult(assertion: Assertion, passed: boolean, message: string): AssertionResult {
+  return {
+    assertionId: assertion.id,
+    name: assertion.name,
+    passed,
+    message: passed ? 'Passed' : message,
+  };
+}

--- a/src/renderer/services/assertions/assertion-service.ts
+++ b/src/renderer/services/assertions/assertion-service.ts
@@ -18,16 +18,28 @@ export async function evaluateAssertions(
   const needsBody = activeAssertions.some(
     (assertion) => assertion.type === AssertionType.JSON_PATH
   );
-  const body = needsBody ? await readResponseBodySafely(response) : undefined;
-  const jsonBody = body == null ? undefined : parseJson(body);
 
-  return activeAssertions.map((assertion) => evaluateAssertion(assertion, response, jsonBody));
+  let jsonBody: unknown;
+  let jsonBodyError = 'Response body is not valid JSON';
+  if (needsBody) {
+    const body = await readResponseBodySafely(response);
+    if (body == null) {
+      jsonBodyError = 'Response body could not be read';
+    } else {
+      jsonBody = parseJson(body);
+    }
+  }
+
+  return activeAssertions.map((assertion) =>
+    evaluateAssertion(assertion, response, jsonBody, jsonBodyError)
+  );
 }
 
 function evaluateAssertion(
   assertion: Assertion,
   response: TrufosResponse,
-  jsonBody: unknown
+  jsonBody: unknown,
+  jsonBodyError: string
 ): AssertionResult {
   try {
     switch (assertion.type) {
@@ -38,7 +50,7 @@ function evaluateAssertion(
       case AssertionType.HEADER:
         return evaluateHeaderAssertion(assertion, response);
       case AssertionType.JSON_PATH:
-        return evaluateJsonPathAssertion(assertion, jsonBody);
+        return evaluateJsonPathAssertion(assertion, jsonBody, jsonBodyError);
     }
   } catch (error) {
     return {
@@ -105,8 +117,12 @@ function evaluateHeaderAssertion(assertion: Assertion, response: TrufosResponse)
   );
 }
 
-function evaluateJsonPathAssertion(assertion: Assertion, jsonBody: unknown): AssertionResult {
-  if (jsonBody == null) throw new Error('Response body is not valid JSON');
+function evaluateJsonPathAssertion(
+  assertion: Assertion,
+  jsonBody: unknown,
+  jsonBodyError: string
+): AssertionResult {
+  if (jsonBody == null) throw new Error(jsonBodyError);
 
   const path = assertion.target?.trim();
   if (!path) throw new Error('JSON path missing');

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -21,8 +21,11 @@ import { immer } from 'zustand/middleware/immer';
 import { parseUrl } from 'shim/objects/url';
 import { ScriptType } from 'shim/scripting';
 import { SortMode } from '@/components/sidebar/SidebarRequestList/treeUtilities';
+import { Assertion, AssertionOperator, AssertionType } from 'shim/objects/assertion';
+import { buildAssertionName } from '@/services/assertions/assertion-name';
 
 const eventService = RendererEventService.instance;
+const EMPTY_ASSERTIONS: Assertion[] = [];
 
 interface CollectionState {
   /** The currently selected collection */
@@ -376,6 +379,47 @@ export const createCollectionStore = (collection: Collection) => {
           request.draft = true;
         }),
 
+      addAssertion: () =>
+        set((state) => {
+          const request = selectRequest(state)!;
+          request.assertions ??= [];
+          const assertion = {
+            id: crypto.randomUUID(),
+            isActive: true,
+            type: AssertionType.STATUS_CODE,
+            operator: AssertionOperator.EQUALS,
+            expected: '200',
+          };
+          request.assertions.push({
+            ...assertion,
+            name: buildAssertionName(assertion),
+            nameManuallyEdited: false,
+          });
+          markDraft(state);
+        }),
+
+      updateAssertion: (index, updatedAssertion) =>
+        set((state) => {
+          const assertions = ensureAssertions(state);
+          if (assertions[index] == null) return;
+          assertions[index] = { ...assertions[index], ...updatedAssertion };
+          markDraft(state);
+        }),
+
+      deleteAssertion: (index) =>
+        set((state) => {
+          ensureAssertions(state).splice(index, 1);
+          markDraft(state);
+        }),
+
+      setAssertionActive: (index, active) =>
+        set((state) => {
+          const assertion = ensureAssertions(state)[index];
+          if (assertion == null) return;
+          assertion.isActive = active ?? !assertion.isActive;
+          markDraft(state);
+        }),
+
       setDraftFlag: () => set(markDraft),
 
       addNewFolder: async (title?, parentId?) => {
@@ -608,6 +652,16 @@ const markDraft = (state: CollectionState) => {
 
 export const selectHeaders = (state: CollectionState) => selectRequest(state)!.headers;
 export const selectQueryParams = (state: CollectionState) => selectRequest(state)!.url.query;
+export const selectAssertions = (state: CollectionState) => {
+  const request = selectRequest(state)!;
+  return request.assertions ?? EMPTY_ASSERTIONS;
+};
+
+const ensureAssertions = (state: CollectionState) => {
+  const request = selectRequest(state)!;
+  request.assertions ??= [];
+  return request.assertions;
+};
 
 const selectQueryParam = (state: CollectionState, index: number) =>
   selectQueryParams(state)?.[index];

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -22,7 +22,6 @@ import { parseUrl } from 'shim/objects/url';
 import { ScriptType } from 'shim/scripting';
 import { SortMode } from '@/components/sidebar/SidebarRequestList/treeUtilities';
 import { Assertion, AssertionOperator, AssertionType } from 'shim/objects/assertion';
-import { buildAssertionName } from '@/services/assertions/assertion-name';
 
 const eventService = RendererEventService.instance;
 const EMPTY_ASSERTIONS: Assertion[] = [];
@@ -383,17 +382,12 @@ export const createCollectionStore = (collection: Collection) => {
         set((state) => {
           const request = selectRequest(state)!;
           request.assertions ??= [];
-          const assertion = {
+          request.assertions.push({
             id: crypto.randomUUID(),
             isActive: true,
             type: AssertionType.STATUS_CODE,
             operator: AssertionOperator.EQUALS,
             expected: '200',
-          };
-          request.assertions.push({
-            ...assertion,
-            name: buildAssertionName(assertion),
-            nameManuallyEdited: false,
           });
           markDraft(state);
         }),

--- a/src/renderer/state/interface/CollectionStateActions.ts
+++ b/src/renderer/state/interface/CollectionStateActions.ts
@@ -1,4 +1,5 @@
 import { ClientCertificate, Collection } from 'shim/objects/collection';
+import { Assertion } from 'shim/objects/assertion';
 import { Folder } from 'shim/objects/folder';
 import { TrufosHeader } from 'shim/objects/headers';
 import { TrufosQueryParam } from 'shim/objects/query-param';
@@ -129,6 +130,11 @@ export interface CollectionStateActions {
   addFormDataField(): void;
   updateFormDataField(index: number, updatedField: Partial<FormDataField>): void;
   deleteFormDataField(index: number): void;
+
+  addAssertion(): void;
+  updateAssertion(index: number, updatedAssertion: Partial<Assertion>): void;
+  deleteAssertion(index: number): void;
+  setAssertionActive(index: number, active?: boolean): void;
 
   /**
    * Set the draft flag on the currently selected request

--- a/src/renderer/state/responseStore.ts
+++ b/src/renderer/state/responseStore.ts
@@ -1,11 +1,13 @@
 import { useActions } from '@/state/helper/util';
 import { editor } from 'monaco-editor';
+import { AssertionResult } from 'shim/objects/assertion';
 import { TrufosResponse } from 'shim/objects/response';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 
 /** A map of requestId => response */
 type ResponseInfoMap = Record<string, TrufosResponse>;
+type AssertionResultMap = Record<string, AssertionResult[]>;
 
 // Stored outside immer state to prevent immer from deep-cloning the Monaco
 // editor instance (which has circular references and would overflow the stack).
@@ -13,7 +15,9 @@ let responseEditorRef: editor.ICodeEditor | undefined;
 
 interface ResponseState {
   responseInfoMap: ResponseInfoMap;
+  assertionResultMap: AssertionResultMap;
   addResponse: (requestId: string, response: TrufosResponse) => void;
+  setAssertionResults: (requestId: string, results: AssertionResult[]) => void;
   removeResponse: (requestId: string) => void;
   setResponseEditor: (editor: editor.ICodeEditor | undefined) => void;
 
@@ -27,13 +31,19 @@ interface ResponseState {
 export const useResponseStore = create<ResponseState>()(
   immer((set) => ({
     responseInfoMap: {},
+    assertionResultMap: {},
     addResponse: (requestId, response) =>
       set((state) => {
         state.responseInfoMap[requestId] = response;
       }),
+    setAssertionResults: (requestId, results) =>
+      set((state) => {
+        state.assertionResultMap[requestId] = results;
+      }),
     removeResponse: (requestId) =>
       set((state) => {
         delete state.responseInfoMap[requestId];
+        delete state.assertionResultMap[requestId];
       }),
     setResponseEditor: (responseEditor) => {
       responseEditorRef = responseEditor;
@@ -53,4 +63,6 @@ export const useResponseStore = create<ResponseState>()(
 
 export const selectResponse = (state: ResponseState, requestId: string | undefined) =>
   requestId != null ? state.responseInfoMap[requestId] : undefined;
+export const selectAssertionResults = (state: ResponseState, requestId: string | undefined) =>
+  requestId != null ? state.assertionResultMap[requestId] : undefined;
 export const useResponseActions = () => useResponseStore(useActions());

--- a/src/renderer/view/CollectionRunner.test.tsx
+++ b/src/renderer/view/CollectionRunner.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { CollectionRunner } from './CollectionRunner';
+import { AssertionOperator, AssertionType } from 'shim/objects/assertion';
 import { RequestMethod } from 'shim/objects/request-method';
 import type { Folder } from 'shim/objects/folder';
 import { RequestBodyType, type TrufosRequest } from 'shim/objects/request';
@@ -11,6 +12,7 @@ const sendRequestMock =
   vi.fn<(request: TrufosRequest, abortKey?: string) => Promise<TrufosResponse>>();
 const abortRequestMock = vi.fn().mockResolvedValue(undefined);
 const addResponseMock = vi.fn();
+const setAssertionResultsMock = vi.fn();
 const showErrorMock = vi.fn();
 
 vi.mock('@/services/http/http-service', () => ({
@@ -24,7 +26,10 @@ vi.mock('@/services/http/http-service', () => ({
 }));
 
 vi.mock('@/state/responseStore', () => ({
-  useResponseActions: () => ({ addResponse: addResponseMock }),
+  useResponseActions: () => ({
+    addResponse: addResponseMock,
+    setAssertionResults: setAssertionResultsMock,
+  }),
 }));
 
 vi.mock('@/lib/monaco/models', () => ({
@@ -46,6 +51,35 @@ vi.mock('@/components/ui/resizable', () => ({
   ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   ResizablePanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   ResizableHandle: () => null,
+}));
+
+vi.mock('@/services/assertions/assertion-service', () => ({
+  evaluateAssertions: (
+    assertions:
+      | Array<{
+          id: string;
+          name: string;
+          isActive: boolean;
+          expected?: string;
+        }>
+      | undefined,
+    response: TrufosResponse
+  ) =>
+    Promise.resolve(
+      (assertions ?? [])
+        .filter((assertion) => assertion.isActive)
+        .map((assertion) => {
+          const passed = String(response.metaInfo.status) === assertion.expected;
+          return {
+            assertionId: assertion.id,
+            name: assertion.name,
+            passed,
+            message: passed
+              ? 'Passed'
+              : `Expected ${assertion.expected}, got ${response.metaInfo.status}`,
+          };
+        })
+    ),
 }));
 
 vi.mock('@/error/errorHandler', () => ({
@@ -151,6 +185,7 @@ beforeEach(() => {
   sendRequestMock.mockReset();
   abortRequestMock.mockClear();
   addResponseMock.mockClear();
+  setAssertionResultsMock.mockClear();
   showErrorMock.mockClear();
   selectEnvironmentMock.mockClear();
   mockEnvironmentState = {
@@ -315,6 +350,36 @@ describe('CollectionRunner execution', () => {
     ]);
   });
 
+  it('stores assertion results in the response store', async () => {
+    const user = userEvent.setup();
+    const request = makeRequest('req-1', 'Login', RequestMethod.POST);
+    request.assertions = [
+      {
+        id: 'assertion-1',
+        name: 'Status code equals 200',
+        isActive: true,
+        type: AssertionType.STATUS_CODE,
+        operator: AssertionOperator.EQUALS,
+        expected: '200',
+      },
+    ];
+    setupCollection([request]);
+    sendRequestMock.mockResolvedValue(makeResponse(200));
+    renderRunner();
+
+    await user.click(screen.getByRole('button', { name: /run 1 request$/i }));
+
+    await waitFor(() => expect(setAssertionResultsMock).toHaveBeenCalledTimes(1));
+    expect(setAssertionResultsMock).toHaveBeenCalledWith('req-1', [
+      {
+        assertionId: 'assertion-1',
+        name: 'Status code equals 200',
+        passed: true,
+        message: 'Passed',
+      },
+    ]);
+  });
+
   it('marks non-successful status codes as failed and shows the summary', async () => {
     const user = userEvent.setup();
     sendRequestMock
@@ -384,6 +449,54 @@ describe('CollectionRunner execution', () => {
 
     await waitFor(() => expect(sendRequestMock).toHaveBeenCalledTimes(4));
     await waitFor(() => expect(screen.getAllByText('Failed')).toHaveLength(4));
+  });
+
+  it('marks a successful response as failed when an assertion fails', async () => {
+    const user = userEvent.setup();
+    const request = makeRequest('req-1', 'Login', RequestMethod.POST);
+    request.assertions = [
+      {
+        id: 'assertion-1',
+        name: 'Status code equals 201',
+        isActive: true,
+        type: AssertionType.STATUS_CODE,
+        operator: AssertionOperator.EQUALS,
+        expected: '201',
+      },
+    ];
+    setupCollection([request]);
+    sendRequestMock.mockResolvedValue(makeResponse(200));
+    renderRunner();
+
+    await user.click(screen.getByRole('button', { name: /run 1 request$/i }));
+
+    await waitFor(() => expect(screen.getAllByText('Failed')).toHaveLength(1));
+    expect(screen.queryAllByText('Passed')).toHaveLength(0);
+  });
+
+  it('ignores assertions when include assertions is disabled', async () => {
+    const user = userEvent.setup();
+    const request = makeRequest('req-1', 'Login', RequestMethod.POST);
+    request.assertions = [
+      {
+        id: 'assertion-1',
+        name: 'Status code equals 201',
+        isActive: true,
+        type: AssertionType.STATUS_CODE,
+        operator: AssertionOperator.EQUALS,
+        expected: '201',
+      },
+    ];
+    setupCollection([request]);
+    sendRequestMock.mockResolvedValue(makeResponse(200));
+    renderRunner();
+
+    await user.click(screen.getByText('Include assertions'));
+    await user.click(screen.getByRole('button', { name: /run 1 request$/i }));
+
+    await waitFor(() => expect(screen.getAllByText('Passed')).toHaveLength(1));
+    expect(screen.queryAllByText('Failed')).toHaveLength(0);
+    expect(setAssertionResultsMock).toHaveBeenCalledWith('req-1', []);
   });
 
   it('shows the running state and disables controls during a run', async () => {
@@ -490,6 +603,36 @@ describe('CollectionRunner result details', () => {
 
     await user.click(screen.getByRole('tab', { name: 'Headers' }));
     expect(screen.getByText(/content-type/)).toBeDefined();
+  });
+
+  it('shows assertion details when a row is expanded', async () => {
+    const user = userEvent.setup();
+    const request = makeRequest('req-1', 'Login', RequestMethod.POST);
+    request.assertions = [
+      {
+        id: 'assertion-1',
+        name: 'Status code equals 201',
+        isActive: true,
+        type: AssertionType.STATUS_CODE,
+        operator: AssertionOperator.EQUALS,
+        expected: '201',
+      },
+    ];
+    setupCollection([request]);
+    sendRequestMock.mockResolvedValue(makeResponse(200));
+    renderRunner();
+
+    await user.click(screen.getByRole('button', { name: /run 1 request$/i }));
+    await waitFor(() => expect(screen.getAllByText('Failed')).toHaveLength(1));
+
+    const row = screen
+      .getAllByRole('button')
+      .find((button) => button.textContent?.includes('Login'))!;
+    await user.click(row);
+    await user.click(screen.getByRole('tab', { name: 'Assertions' }));
+
+    expect(screen.getByText('Status code equals 201')).toBeDefined();
+    expect(screen.getByText('Expected 201, got 200')).toBeDefined();
   });
 
   it('shows the total duration in the summary after a run', async () => {

--- a/src/renderer/view/CollectionRunner.test.tsx
+++ b/src/renderer/view/CollectionRunner.test.tsx
@@ -58,7 +58,6 @@ vi.mock('@/services/assertions/assertion-service', () => ({
     assertions:
       | Array<{
           id: string;
-          name: string;
           isActive: boolean;
           expected?: string;
         }>
@@ -72,7 +71,7 @@ vi.mock('@/services/assertions/assertion-service', () => ({
           const passed = String(response.metaInfo.status) === assertion.expected;
           return {
             assertionId: assertion.id,
-            name: assertion.name,
+            name: `Status code equals ${assertion.expected}`,
             passed,
             message: passed
               ? 'Passed'
@@ -356,7 +355,6 @@ describe('CollectionRunner execution', () => {
     request.assertions = [
       {
         id: 'assertion-1',
-        name: 'Status code equals 200',
         isActive: true,
         type: AssertionType.STATUS_CODE,
         operator: AssertionOperator.EQUALS,
@@ -457,7 +455,6 @@ describe('CollectionRunner execution', () => {
     request.assertions = [
       {
         id: 'assertion-1',
-        name: 'Status code equals 201',
         isActive: true,
         type: AssertionType.STATUS_CODE,
         operator: AssertionOperator.EQUALS,
@@ -480,7 +477,6 @@ describe('CollectionRunner execution', () => {
     request.assertions = [
       {
         id: 'assertion-1',
-        name: 'Status code equals 201',
         isActive: true,
         type: AssertionType.STATUS_CODE,
         operator: AssertionOperator.EQUALS,
@@ -611,7 +607,6 @@ describe('CollectionRunner result details', () => {
     request.assertions = [
       {
         id: 'assertion-1',
-        name: 'Status code equals 201',
         isActive: true,
         type: AssertionType.STATUS_CODE,
         operator: AssertionOperator.EQUALS,

--- a/src/renderer/view/CollectionRunner.tsx
+++ b/src/renderer/view/CollectionRunner.tsx
@@ -15,6 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ResizablePanel, ResizablePanelGroup, ResizableHandle } from '@/components/ui/resizable';
 import { useResponseData } from '@/components/mainWindow/bodyTabs/OutputTabs/PrettyRenderer';
 import { FolderIcon, SmallArrow } from '@/components/icons';
+import { evaluateAssertions } from '@/services/assertions/assertion-service';
 import { HttpService } from '@/services/http/http-service';
 import { httpMethodColor } from '@/services/StyleHelper';
 import { getIndentation } from '@/components/sidebar/SidebarRequestList/Nav/indentation';
@@ -29,6 +30,7 @@ import {
 } from '@/state/environmentStore';
 import { useResponseActions } from '@/state/responseStore';
 import { showError } from '@/error/errorHandler';
+import type { AssertionResult } from 'shim/objects/assertion';
 import type { Folder } from 'shim/objects/folder';
 import type { TrufosRequest } from 'shim/objects/request';
 import type { TrufosResponse } from 'shim/objects/response';
@@ -64,7 +66,7 @@ type RunnerItem =
 
 type RunnerResult =
   | { state: 'running' }
-  | { state: 'passed' | 'failed'; response: TrufosResponse }
+  | { state: 'passed' | 'failed'; response: TrufosResponse; assertionResults: AssertionResult[] }
   | { state: 'error'; error: string; duration: number };
 
 function isFailure(result?: RunnerResult) {
@@ -142,7 +144,13 @@ function ResponseBodyPreview({ response }: { response: TrufosResponse }) {
   return <pre className="text-xs break-words whitespace-pre-wrap">{body}</pre>;
 }
 
-function ResponseDetail({ response }: { response: TrufosResponse }) {
+function ResponseDetail({
+  assertionResults,
+  response,
+}: {
+  assertionResults: AssertionResult[];
+  response: TrufosResponse;
+}) {
   // Overrides the shadcn defaults to match the compact tab style from the runner design.
   const tabTriggerClassName = cn(
     'h-auto rounded-md px-3 py-1 text-xs font-semibold',
@@ -172,6 +180,9 @@ function ResponseDetail({ response }: { response: TrufosResponse }) {
           <TabsTrigger className={tabTriggerClassName} value="headers">
             Headers
           </TabsTrigger>
+          <TabsTrigger className={tabTriggerClassName} value="assertions">
+            Assertions
+          </TabsTrigger>
         </TabsList>
         <TabsContent className={tabContentClassName} value="body">
           <ResponseBodyPreview response={response} />
@@ -180,6 +191,31 @@ function ResponseDetail({ response }: { response: TrufosResponse }) {
           <pre className="text-xs break-words whitespace-pre-wrap">
             {formatHeaders(response.headers)}
           </pre>
+        </TabsContent>
+        <TabsContent className={tabContentClassName} value="assertions">
+          {assertionResults.length === 0 ? (
+            <p className="text-text-secondary text-xs">No assertions configured.</p>
+          ) : (
+            <div className="space-y-2">
+              {assertionResults.map((result) => (
+                <div
+                  key={result.assertionId}
+                  className="grid grid-cols-[70px_minmax(140px,1fr)_2fr] gap-3 text-xs"
+                >
+                  <span
+                    className={cn(
+                      'font-bold',
+                      result.passed ? 'text-state-success' : 'text-danger'
+                    )}
+                  >
+                    {result.passed ? 'Pass' : 'Fail'}
+                  </span>
+                  <span className="text-text-primary truncate">{result.name}</span>
+                  <span className="text-text-secondary break-words">{result.message}</span>
+                </div>
+              ))}
+            </div>
+          )}
         </TabsContent>
       </Tabs>
     </div>
@@ -225,7 +261,7 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
   const collection = useCollectionStore((state) => state.collection);
   const requests = useCollectionStore((state) => state.requests);
   const folders = useCollectionStore((state) => state.folders);
-  const { addResponse } = useResponseActions();
+  const { addResponse, setAssertionResults } = useResponseActions();
   const environments = useEnvironmentStore(selectEnvironments);
   const selectedEnvironment = useEnvironmentStore(selectSelectedEnvironment);
   const { selectEnvironment } = useEnvironmentActions();
@@ -234,6 +270,7 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
     () => new Set(requests.keys())
   );
   const [stopOnFirstFailure, setStopOnFirstFailure] = useState(false);
+  const [includeAssertions, setIncludeAssertions] = useState(true);
   const [isRunning, setIsRunning] = useState(false);
   const [results, setResults] = useState<Record<string, RunnerResult>>({});
   const [runOrder, setRunOrder] = useState<string[]>([]);
@@ -426,8 +463,19 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
             return;
           }
           addResponse(request.id, response);
-          const state = isSuccessfulStatus(response.metaInfo.status) ? 'passed' : 'failed';
-          setResults((current) => ({ ...current, [request.id]: { state, response } }));
+          const assertionResults = includeAssertions
+            ? await evaluateAssertions(request.assertions, response)
+            : [];
+          setAssertionResults(request.id, assertionResults);
+          const hasAssertionFailure = assertionResults.some((result) => !result.passed);
+          const state =
+            isSuccessfulStatus(response.metaInfo.status) && !hasAssertionFailure
+              ? 'passed'
+              : 'failed';
+          setResults((current) => ({
+            ...current,
+            [request.id]: { state, response, assertionResults },
+          }));
 
           if (stopOnFirstFailure && state === 'failed') break;
         } catch (error) {
@@ -634,6 +682,15 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
               Stop on first failure
             </label>
 
+            <label className="flex cursor-pointer items-center gap-2 text-sm">
+              <Checkbox
+                checked={includeAssertions}
+                disabled={isRunning}
+                onCheckedChange={(value) => setIncludeAssertions(value === true)}
+              />
+              Include assertions
+            </label>
+
             {isRunning ? (
               <Button className="text-danger w-full gap-2" onClick={stopRun} variant="secondary">
                 <Square className="h-3.5 w-3.5" />
@@ -763,7 +820,10 @@ export function CollectionRunner({ open, onClose }: CollectionRunnerProps) {
                       ) : result.state === 'running' ? (
                         <p className="text-text-secondary text-sm">Request is running.</p>
                       ) : (
-                        <ResponseDetail response={result.response} />
+                        <ResponseDetail
+                          assertionResults={result.assertionResults}
+                          response={result.response}
+                        />
                       )}
                     </CollapsibleContent>
                   </Collapsible>

--- a/src/renderer/view/RequestWindow.tsx
+++ b/src/renderer/view/RequestWindow.tsx
@@ -57,7 +57,7 @@ export function RequestWindow() {
   }
 
   return (
-    <div className="grid h-full grid-rows-[auto_1fr] p-6">
+    <div className="grid h-full grid-rows-[auto_minmax(0,1fr)] p-6">
       <MainTopBar />
       <MainBody />
     </div>

--- a/src/shim/objects/assertion.ts
+++ b/src/shim/objects/assertion.ts
@@ -18,8 +18,6 @@ export enum AssertionOperator {
 
 export const Assertion = z.object({
   id: z.string(),
-  name: z.string(),
-  nameManuallyEdited: z.boolean().optional(),
   isActive: z.boolean(),
   type: z.enum(AssertionType),
   operator: z.enum(AssertionOperator),

--- a/src/shim/objects/assertion.ts
+++ b/src/shim/objects/assertion.ts
@@ -1,0 +1,37 @@
+import z from 'zod';
+
+export enum AssertionType {
+  STATUS_CODE = 'status-code',
+  RESPONSE_TIME = 'response-time',
+  HEADER = 'header',
+  JSON_PATH = 'json-path',
+}
+
+export enum AssertionOperator {
+  EQUALS = 'equals',
+  IN_RANGE = 'in-range',
+  BELOW = 'below',
+  PRESENT = 'present',
+  CONTAINS = 'contains',
+  EXISTS = 'exists',
+}
+
+export const Assertion = z.object({
+  id: z.string(),
+  name: z.string(),
+  nameManuallyEdited: z.boolean().optional(),
+  isActive: z.boolean(),
+  type: z.enum(AssertionType),
+  operator: z.enum(AssertionOperator),
+  target: z.string().optional(),
+  expected: z.string().optional(),
+});
+export type Assertion = z.infer<typeof Assertion>;
+
+export const AssertionResult = z.object({
+  assertionId: z.string(),
+  name: z.string(),
+  passed: z.boolean(),
+  message: z.string(),
+});
+export type AssertionResult = z.infer<typeof AssertionResult>;

--- a/src/shim/objects/index.ts
+++ b/src/shim/objects/index.ts
@@ -2,6 +2,7 @@ export * from './request';
 export * from './folder';
 export * from './collection';
 export * from './auth';
+export * from './assertion';
 export * from './url';
 export * from './variables';
 export * from './environment';

--- a/src/shim/objects/request.ts
+++ b/src/shim/objects/request.ts
@@ -2,6 +2,7 @@ import { AuthorizationInformation } from './auth';
 import { RequestMethod } from './request-method';
 import { TrufosURL } from './url';
 import { TrufosHeader } from './headers';
+import { Assertion } from './assertion';
 import z from 'zod';
 
 export const TEXT_BODY_FILE_NAME = 'request-body.txt';
@@ -62,5 +63,6 @@ export const TrufosRequest = z.object({
   body: RequestBody,
   draft: z.boolean().optional(),
   auth: AuthorizationInformation.optional(),
+  assertions: z.array(Assertion).optional(),
 });
 export type TrufosRequest = z.infer<typeof TrufosRequest>;


### PR DESCRIPTION
### **User description**
Closes #841

## Summary

Adds a no-code **Assertions** tab to the request editor. Assertions run automatically after every response (single send and Collection Runner) and show pass/fail results inline.

### Supported checks
| Type | Operators |
|---|---|
| Status code | equals, in range (`200-299`) |
| Response time | below threshold (ms) |
| Header | present, equals, contains |
| JSON path | exists, equals, contains |

### Details
- New `Assertions` input tab (`mod+8`); the active-assertion count is shown in the tab label. Assertions have no stored name — a readable label (e.g. `Status code equals 200`) is derived from type, operator, target and expected value whenever results are displayed, so it always matches the configuration.
- New `Assertions` output tab (`mod+9`) showing per-assertion pass/fail with details, plus a `passed/total` counter in the tab label.
- Collection Runner: assertions are evaluated per request (opt-out via *Include assertions*), failures mark the run result as failed, and results appear in a new Assertions section of the run detail view.
- Assertions are persisted on the request via a new info-file schema **v2.5.0** (optional `assertions` field) with a migrator from v2.4.0, following the existing versioning convention.
- JSON-path assertions read the response body lazily (capped at 1 MiB) and only when needed.
- Scripting (#710) stays available for advanced cases.

## Verification
- `yarn test` — 444 tests pass (new unit tests for the assertion service, name generation, input tabs, and Collection Runner integration)
- `yarn lint` / `yarn prettier-check` clean on touched files
- Manually verified in the dev app: created status/response-time assertions, sent a delayed request, and confirmed pass/fail rendering in both the response tab and the Collection Runner, including the v2.4.0 → v2.5.0 migration of existing collections on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds no-code Assertions tab for response testing without scripting

- Supports status code, response time, header, and JSON path checks

- Assertions run automatically after requests and show pass/fail results

- Integrates with Collection Runner to aggregate assertion results

- Persists assertions via new info-file schema v2.5.0 with migration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Request Editor"] -->|"mod+8"| B["Assertions Input Tab"]
  B -->|"Add/Edit/Delete"| C["Assertion Config"]
  C -->|"Status/Time/Header/JSON"| D["Assertion Service"]
  E["Send Request"] -->|"Evaluate"| D
  D -->|"Results"| F["Assertions Output Tab"]
  F -->|"Pass/Fail"| G["Response View"]
  H["Collection Runner"] -->|"Per Request"| D
  D -->|"Aggregate"| I["Run Results"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>assertion.ts</strong><dd><code>Define assertion types and schemas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-ddc433a31cc20b47579a4ebddc9fc280b16679ba153110638432ad46e285db1a">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>request.ts</strong><dd><code>Add optional assertions array to requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-522609b8e9d371c032b4d4a69f14be76702f7fbb1bdbdf1185140d9e0a982390">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export assertion types from objects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-a169c1780e1607bbba45a1f69e35919fb5f814c8dc408bb1dd638af4b3632db9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>v2-5-0.ts</strong><dd><code>Create new info-file schema v2.5.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-3c004cccfba9058634bfde87b43cb83f4c8248dcbde8c15f8df3b90eb3a7479b">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>latest.ts</strong><dd><code>Update to use v2.5.0 schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-b9534eb7fcd6ccab9d7646c4554d787b8e5a96104dd57c99d8c712133c01a9bc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>migrators.ts</strong><dd><code>Register v2.5.0 migrator for v2.4.0 upgrade</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-06661b893a812c4d43776fa10bd32dfe5b51211aa0e93a459d51fd2b97676729">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assertion-service.ts</strong><dd><code>Implement assertion evaluation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-100d2bda19853b9d3952e3166253c82b1dc02111c9d6539a794662fd745e1f53">+239/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>assertion-name.ts</strong><dd><code>Generate human-readable assertion labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-c873193de542bd1338bb9051f12e165bd241197f6d325dd5489b5d478d7c5139">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AssertionsTab.tsx</strong><dd><code>Create assertions editor UI with table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-576dffedc4f1f8cfa8cdfee2fae995108e1355cd0f7cfb241efaf60a4bf21d9f">+256/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>InputTabs.tsx</strong><dd><code>Add Assertions tab to input tabs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-34facf6841ac77dbf09ad93791508a9173c180c0700c20440831fc20f6003de3">+21/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OutputTabs.tsx</strong><dd><code>Add Assertions output tab with results table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-cdb6c46d76626456f074c8fc26e606d739a237d79847a45ca361bc184a0a7be2">+45/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>collectionStore.ts</strong><dd><code>Add assertion CRUD actions to collection store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-9bd66bf13fd7c115c613572a46b343298648618f8245cf60b86b6e420d738a32">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CollectionStateActions.ts</strong><dd><code>Define assertion action interfaces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-5530e0a088d677d5ae46949013418ce02554e1d724096fc7624ce8dbbb15801b">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>responseStore.ts</strong><dd><code>Store and manage assertion results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-1b00291a68480c1806b55700e7510bd92ba6943d678df43113d77daa886a6bb9">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MainTopBar.tsx</strong><dd><code>Evaluate assertions after sending requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-2ffcaea3cb541bf2a319c21f4b364fa5b0d29c36c183908d44c7f05d4053f9f0">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CollectionRunner.tsx</strong><dd><code>Integrate assertions into Collection Runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-b5655adbcdeb3e9d56d181fea9fee71c069b86945b14efccfeea13a887231c91">+66/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>assertion-service.test.ts</strong><dd><code>Test assertion evaluation for all types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-19ab46e79fb904da196794eaa3d96632b75207ca410c6f13f1da8c1d3a8a757a">+155/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>assertion-name.test.ts</strong><dd><code>Test assertion name generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-d953a7babbe0e1bf56e8a815396c458c18cf57131ee0a68bc8a6c0ad281bc70b">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>InputTabs.test.tsx</strong><dd><code>Test Assertions tab rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-dd6d7a094bce104749d2f19764f3bf36462baa53cd38fae7e9fe115d3cb11497">+33/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CollectionRunner.test.tsx</strong><dd><code>Test assertions in Collection Runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-527ca15e097a654362cf7b9295fda5065079c047484750b44f645f4a27a8a7c0">+139/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug_fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>tabs.tsx</strong><dd><code>Fix tab content scrolling with min-h-0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-2078b9c42084fbef8bb7422fff5864f185a4c22ea86b75a3df7b4798d4f61cde">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RequestWindow.tsx</strong><dd><code>Fix grid layout with minmax constraint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-a90c423eafea8410a44edb4f591fc68bdd2cb40470ffef7e0681863229b3630a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong><dd><code>Add height and overflow constraints to layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-72348b6b222462c023d009b90544f2799da3cf5b1eafc2d280f8a19041271230">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>collection.json</strong><dd><code>Update example collection to v2.5.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-4b55cb2cc639381381fd311433ddb8d260672c99f6c5f9a3037e64d3444ec3ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>request.json</strong><dd><code>Update example request to v2.5.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/945/files#diff-ddb350d411053e2691bfb609837ea016adadabcbf9af17d1262ae6f2c4c1a39d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

