### PR TITLE
refactor: consolidate Zustand stores

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,7 +10,7 @@ import { ResizablePanel, ResizablePanelGroup, ResizableHandle } from '@/componen
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { CollectionStoreProvider } from '@/state/CollectionStoreProvider';
 import { RendererEventService } from '@/services/event/renderer-event-service';
-import { useAppSettingsStore } from '@/state/appSettingsStore';
+import { useAppStore } from '@/state/collectionStore';
 import {
   selectIsCollectionRunnerOpen,
   selectIsCollectionSettingsOpen,
@@ -22,16 +22,22 @@ import { showError } from '@/error/errorHandler';
 const MIN_SIDEBAR_PIXELS = 300;
 const MIN_REQUEST_WINDOW_PIXELS = 500;
 
-export const App = () => {
+const AppContent = () => {
   const isCollectionRunnerOpen = useViewStore(selectIsCollectionRunnerOpen);
   const isCollectionSettingsOpen = useViewStore(selectIsCollectionSettingsOpen);
-  const { closeCollectionRunner, closeCollectionSettings } = useViewActions();
+  const {
+    closeCollectionRunner,
+    closeCollectionSettings,
+    openCollectionRunner,
+    openCollectionSettings,
+  } = useViewActions();
+  const initializeAppSettings = useAppStore((state) => state.initializeAppSettings);
 
   useEffect(() => {
     // Entry points of the native application menu (Collection > ...).
     RendererEventService.instance
-      .on('show-collection-runner', () => useViewStore.getState().openCollectionRunner())
-      .on('show-collection-settings', () => useViewStore.getState().openCollectionSettings());
+      .on('show-collection-runner', openCollectionRunner)
+      .on('show-collection-settings', openCollectionSettings);
 
     RendererEventService.instance
       .getAppSettings()
@@ -39,40 +45,46 @@ export const App = () => {
         showError('Failed to load app settings', err);
       })
       .then((settings) => {
-        if (settings) {
-          useAppSettingsStore.getState().initialize(settings);
+        if (settings != null) {
+          initializeAppSettings(settings);
+        } else {
+          initializeAppSettings(undefined);
         }
         window.electron.ipcRenderer.send('renderer-ready');
       });
-  }, []);
+  }, [initializeAppSettings, openCollectionRunner, openCollectionSettings]);
 
   return (
-    <CollectionStoreProvider>
-      <ThemeProvider>
-        <TooltipProvider delayDuration={750}>
-          <SidebarProvider className="grid">
-            {/* The runner replaces the whole layout as an alternative full-width view;
-                its own request checklist makes the sidebar redundant. */}
-            {isCollectionRunnerOpen ? (
-              <CollectionRunner open onClose={closeCollectionRunner} />
-            ) : (
-              <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
-                <ResizablePanel defaultSize="25%" minSize={MIN_SIDEBAR_PIXELS}>
-                  <Menubar />
-                </ResizablePanel>
-                <ResizableHandle />
-                <ResizablePanel defaultSize="75%" minSize={MIN_REQUEST_WINDOW_PIXELS}>
-                  <RequestWindow />
-                </ResizablePanel>
-              </ResizablePanelGroup>
-            )}
-            <CollectionSettingsModal
-              isOpen={isCollectionSettingsOpen}
-              onClose={closeCollectionSettings}
-            />
-          </SidebarProvider>
-        </TooltipProvider>
-      </ThemeProvider>
-    </CollectionStoreProvider>
+    <ThemeProvider>
+      <TooltipProvider delayDuration={750}>
+        <SidebarProvider className="grid">
+          {/* The runner replaces the whole layout as an alternative full-width view;
+              its own request checklist makes the sidebar redundant. */}
+          {isCollectionRunnerOpen ? (
+            <CollectionRunner open onClose={closeCollectionRunner} />
+          ) : (
+            <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
+              <ResizablePanel defaultSize="25%" minSize={MIN_SIDEBAR_PIXELS}>
+                <Menubar />
+              </ResizablePanel>
+              <ResizableHandle />
+              <ResizablePanel defaultSize="75%" minSize={MIN_REQUEST_WINDOW_PIXELS}>
+                <RequestWindow />
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          )}
+          <CollectionSettingsModal
+            isOpen={isCollectionSettingsOpen}
+            onClose={closeCollectionSettings}
+          />
+        </SidebarProvider>
+      </TooltipProvider>
+    </ThemeProvider>
   );
 };
+
+export const App = () => (
+  <CollectionStoreProvider>
+    <AppContent />
+  </CollectionStoreProvider>
+);

--- a/src/renderer/components/shared/settings/CollectionSettingsModal.tsx
+++ b/src/renderer/components/shared/settings/CollectionSettingsModal.tsx
@@ -15,15 +15,14 @@ import { CertificateEditor } from '@/components/shared/settings/TlsTab/Certifica
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { useEffect, useState } from 'react';
-import { selectVariables, useVariableActions, useVariableStore } from '@/state/variableStore';
+import { selectVariables, useVariableStore } from '@/state/variableStore';
 import {
   selectEnvironments,
   selectSelectedEnvironment,
-  useEnvironmentActions,
   useEnvironmentStore,
 } from '@/state/environmentStore';
 import { variableArrayToMap, variableMapToArray } from '@/state/helper/variableMappers';
-import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
+import { useAppStore, useCollectionStore } from '@/state/collectionStore';
 import { deepEqual } from '@/util/object-util';
 import { ClientCertificate } from 'shim/objects/collection';
 import { VariableObjectWithKey } from 'shim/objects/variables';
@@ -35,10 +34,8 @@ export interface CollectionSettingsModalProps {
 }
 
 /**
- * A single working copy of the editable collection state. The underlying data lives across three
- * stores (collection / variables / environments), but the modal edits one composed draft and commits
- * it back on save. Variables are kept in array form so in-progress/empty/duplicate keys are preserved
- * while editing; they are converted to a map only at commit time.
+ * A single working copy of editable collection state. Variables stay in array form so
+ * in-progress/empty/duplicate keys survive editing; they are converted to a map only on save.
  */
 type CollectionDraft = {
   title: string;
@@ -49,9 +46,7 @@ type CollectionDraft = {
 };
 
 export const CollectionSettingsModal = ({ isOpen, onClose }: CollectionSettingsModalProps) => {
-  const { setVariables } = useVariableActions();
-  const { setEnvironments, selectEnvironment } = useEnvironmentActions();
-  const { setClientCertificate, renameCollection } = useCollectionActions();
+  const saveCollectionSettings = useAppStore((state) => state.saveCollectionSettings);
 
   const variables = useVariableStore(selectVariables);
   const environments = useEnvironmentStore(selectEnvironments);
@@ -94,17 +89,13 @@ export const CollectionSettingsModal = ({ isOpen, onClose }: CollectionSettingsM
   }, [isOpen]);
 
   const save = async () => {
-    // overwrite the generic slices wholesale through their existing store setters.
-    await setVariables(variableArrayToMap(draft.variables));
-    await setEnvironments(draft.environments);
-    await selectEnvironment(draft.selectedEnvironment);
-    await setClientCertificate(draft.clientCertificate);
-
-    // rename must run last
-    const newTitle = draft.title.trim();
-    if (newTitle.length > 0 && newTitle !== collectionTitle) {
-      await renameCollection(newTitle);
-    }
+    await saveCollectionSettings({
+      title: draft.title,
+      variables: variableArrayToMap(draft.variables),
+      environments: draft.environments,
+      selectedEnvironment: draft.selectedEnvironment,
+      clientCertificate: draft.clientCertificate,
+    });
 
     onClose();
   };

--- a/src/renderer/components/sidebar/SidebarHeaderBar.test.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.test.tsx
@@ -21,6 +21,15 @@ interface MockCollectionState {
   sortMode: SortMode;
 }
 
+interface MockAppState extends MockCollectionState {
+  isCollectionRunnerOpen: boolean;
+  isCollectionSettingsOpen: boolean;
+  openCollectionRunner(): void;
+  closeCollectionRunner(): void;
+  openCollectionSettings(): void;
+  closeCollectionSettings(): void;
+}
+
 vi.mock('@/state/collectionStore', () => ({
   useCollectionStore: <T,>(selector: (state: MockCollectionState) => T) =>
     selector({
@@ -32,6 +41,17 @@ vi.mock('@/state/collectionStore', () => ({
     addNewRequest: vi.fn(),
     addNewFolder: vi.fn(),
   }),
+  useAppStore: <T,>(selector: (state: MockAppState) => T) =>
+    selector({
+      collection: { id: 'col-1', title: 'Test Collection', type: 'collection', children: [] },
+      sortMode: currentSortMode,
+      isCollectionRunnerOpen: false,
+      isCollectionSettingsOpen: false,
+      openCollectionRunner: vi.fn(),
+      closeCollectionRunner: vi.fn(),
+      openCollectionSettings: vi.fn(),
+      closeCollectionSettings: vi.fn(),
+    }),
 }));
 
 vi.mock('@/components/sidebar/CollectionDropdown', () => ({

--- a/src/renderer/state/CollectionStoreProvider.test.tsx
+++ b/src/renderer/state/CollectionStoreProvider.test.tsx
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, act, waitFor } from '@testing-library/react';
 import { CollectionStoreProvider } from './CollectionStoreProvider';
-import { useVariableStore } from '@/state/variableStore';
-import { useEnvironmentStore } from '@/state/environmentStore';
+import { AppStoreState, useAppStore } from './collectionStore';
 
 const listeners: Record<string, (...args: unknown[]) => void> = {};
 
@@ -46,16 +45,22 @@ vi.mock('@/state/helper/collectionUtil', () => ({
   isRequestInAParentFolder: vi.fn(() => false),
 }));
 
+let appState: AppStoreState | undefined;
+
+const StoreProbe = () => {
+  appState = useAppStore((state) => state);
+  return null;
+};
+
 beforeEach(() => {
-  useVariableStore.getState().initialize({});
-  useEnvironmentStore.getState().initialize({});
+  appState = undefined;
 });
 
 describe('CollectionStoreProvider', () => {
-  it('updates variableStore and environmentStore when collection-variables-updated is received', async () => {
+  it('updates root store variables and environments when collection-variables-updated is received', async () => {
     render(
       <CollectionStoreProvider>
-        <div />
+        <StoreProbe />
       </CollectionStoreProvider>
     );
 
@@ -71,20 +76,20 @@ describe('CollectionStoreProvider', () => {
       );
     });
 
-    expect(useVariableStore.getState().variables).toEqual(testVariables);
-    expect(useEnvironmentStore.getState().environments).toEqual(testEnvironments);
+    expect(appState?.variables).toEqual(testVariables);
+    expect(appState?.environments).toEqual(testEnvironments);
   });
 
   it('does not update stores when event is not fired', async () => {
     render(
       <CollectionStoreProvider>
-        <div />
+        <StoreProbe />
       </CollectionStoreProvider>
     );
 
     await waitFor(() => expect(listeners['collection-variables-updated']).toBeDefined());
 
-    expect(useVariableStore.getState().variables).toEqual({});
-    expect(useEnvironmentStore.getState().environments).toEqual({});
+    expect(appState?.variables).toEqual({});
+    expect(appState?.environments).toEqual({});
   });
 });

--- a/src/renderer/state/CollectionStoreProvider.tsx
+++ b/src/renderer/state/CollectionStoreProvider.tsx
@@ -1,20 +1,22 @@
 import { useEffect, useRef, useState, FC, PropsWithChildren } from 'react';
 import { Loader2 } from 'lucide-react';
 import { RendererEventService } from '@/services/event/renderer-event-service';
-import {
-  createCollectionStore,
-  CollectionStoreProvider as StoreProvider,
-} from '@/state/collectionStore';
+import { createAppStore, CollectionStoreProvider as StoreProvider } from '@/state/collectionStore';
 import { saveModelContent } from '@/lib/monaco/models';
 import { editor } from 'monaco-editor';
 import { showError } from '@/error/errorHandler';
-import { useVariableStore } from '@/state/variableStore';
-import { useEnvironmentStore } from '@/state/environmentStore';
+import { EnvironmentMap } from 'shim/objects/environment';
+import { VariableMap } from 'shim/objects/variables';
+import { z } from 'zod';
 
 const rendererEventService = RendererEventService.instance;
+const CollectionVariablesUpdated = z.object({
+  variables: VariableMap,
+  environments: EnvironmentMap,
+});
 
 export const CollectionStoreProvider: FC<PropsWithChildren> = ({ children }) => {
-  const storeRef = useRef<ReturnType<typeof createCollectionStore> | null>(null);
+  const storeRef = useRef<ReturnType<typeof createAppStore> | null>(null);
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
@@ -23,17 +25,19 @@ export const CollectionStoreProvider: FC<PropsWithChildren> = ({ children }) => 
         const collection = await rendererEventService.loadCollection();
 
         // Create store with loaded collection
-        storeRef.current = createCollectionStore(collection);
+        storeRef.current = createAppStore(collection);
 
-        // Sync variables changed by scripts back to the frontend stores
-        // @ts-expect-error listener receives ipcEvent + payload but on() only types ...unknown[]
-        rendererEventService.on(
-          'collection-variables-updated',
-          (_ipcEvent, { variables, environments }) => {
-            useVariableStore.getState().initialize(variables);
-            useEnvironmentStore.getState().initialize(environments);
+        // Sync variables changed by scripts back to the root store.
+        rendererEventService.on('collection-variables-updated', (...args: unknown[]) => {
+          const update = CollectionVariablesUpdated.safeParse(args[1]);
+          if (!update.success) {
+            console.error('Received invalid collection variables update:', update.error);
+            return;
           }
-        );
+          storeRef.current
+            ?.getState()
+            .syncCollectionVariables(update.data.variables, update.data.environments);
+        });
 
         // Set up before-close handler: flush all active editor models to disk
         rendererEventService.on('before-close', async () => {

--- a/src/renderer/state/appSettingsStore.ts
+++ b/src/renderer/state/appSettingsStore.ts
@@ -1,37 +1,22 @@
-import { create } from 'zustand';
-import { immer } from 'zustand/middleware/immer';
 import { AppSettings } from 'shim/app-settings';
-import { RendererEventService } from '@/services/event/renderer-event-service';
 import { useActions } from '@/state/helper/util';
-import { showError } from '@/error/errorHandler';
-
-const eventService = RendererEventService.instance;
-
-const DEFAULT_APP_SETTINGS: AppSettings = { theme: 'system' };
+import { useAppStore } from '@/state/collectionStore';
 
 interface AppSettingsActions {
   initialize(settings: AppSettings | undefined): void;
   updateSettings(partial: Partial<AppSettings>): void;
 }
 
-export const useAppSettingsStore = create<AppSettings & AppSettingsActions>()(
-  immer((set, get) => ({
-    ...DEFAULT_APP_SETTINGS,
+type AppSettingsStoreState = AppSettings & AppSettingsActions;
 
-    initialize(settings?: AppSettings) {
-      set(() => settings ?? DEFAULT_APP_SETTINGS);
-    },
-
-    updateSettings(partial: Partial<AppSettings>) {
-      set((state) => {
-        Object.assign(state, partial);
-      });
-      void eventService
-        .saveAppSettings(AppSettings.parse(get()))
-        .catch((err) => showError('Failed to save app settings', err));
-    },
-  }))
-);
+export const useAppSettingsStore = <T>(selector: (state: AppSettingsStoreState) => T): T =>
+  useAppStore((state) =>
+    selector({
+      theme: state.theme,
+      initialize: state.initializeAppSettings,
+      updateSettings: state.updateSettings,
+    })
+  );
 
 export const selectThemePreference = (state: AppSettings & AppSettingsActions) => state.theme;
-export const useAppSettingsActions = () => useAppSettingsStore(useActions());
+export const useAppSettingsActions = (): AppSettingsActions => useAppSettingsStore(useActions());

--- a/src/renderer/state/collectionStore.formData.test.ts
+++ b/src/renderer/state/collectionStore.formData.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createCollectionStore } from './collectionStore';
+import { createAppStore } from './collectionStore';
 import { Collection } from 'shim/objects/collection';
-import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
+import { FormDataBody, RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { RequestMethod } from 'shim/objects/request-method';
 
 vi.mock('@/lib/ipc-stream', () => ({
@@ -14,14 +14,6 @@ vi.mock('@/state/helper/collectionUtil', () => ({
 
 vi.mock('@/services/event/renderer-event-service', () => ({
   RendererEventService: { instance: {} },
-}));
-
-vi.mock('@/state/variableStore', () => ({
-  useVariableStore: { getState: () => ({ initialize: vi.fn() }) },
-}));
-
-vi.mock('@/state/environmentStore', () => ({
-  useEnvironmentStore: { getState: () => ({ initialize: vi.fn() }) },
 }));
 
 const makeRequest = (id: string, parentId: string): TrufosRequest =>
@@ -55,9 +47,17 @@ const COL_ID = 'col-1';
 const buildStore = () => {
   const request = makeRequest(REQ_ID, COL_ID);
   const collection = makeCollection(COL_ID, [request]);
-  const store = createCollectionStore(collection);
+  const store = createAppStore(collection);
   store.getState().setSelectedRequest(REQ_ID);
   return store;
+};
+
+const getFormDataFields = (store: ReturnType<typeof buildStore>): FormDataBody['fields'] => {
+  const body = store.getState().requests.get(REQ_ID)!.body;
+  if (body.type !== RequestBodyType.FORM_DATA) {
+    throw new Error('Expected form data request body');
+  }
+  return body.fields;
 };
 
 describe('FormData store actions', () => {
@@ -71,7 +71,7 @@ describe('FormData store actions', () => {
     it('adds a new text field with empty key, active by default', () => {
       store.getState().addFormDataField();
 
-      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
+      const fields = getFormDataFields(store);
       expect(fields).toHaveLength(1);
       expect(fields[0].key).toBe('');
       expect(fields[0].isActive).toBe(true);
@@ -89,7 +89,7 @@ describe('FormData store actions', () => {
       store.getState().addFormDataField();
       store.getState().addFormDataField();
 
-      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
+      const fields = getFormDataFields(store);
       expect(fields).toHaveLength(3);
     });
   });
@@ -102,7 +102,7 @@ describe('FormData store actions', () => {
     it('updates the key of an existing field', () => {
       store.getState().updateFormDataField(0, { key: 'username' });
 
-      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
+      const fields = getFormDataFields(store);
       expect(fields[0].key).toBe('username');
     });
 
@@ -111,8 +111,11 @@ describe('FormData store actions', () => {
         value: { type: RequestBodyType.FILE, filePath: '/tmp/file.txt', fileName: 'file.txt' },
       });
 
-      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
+      const fields = getFormDataFields(store);
       expect(fields[0].value.type).toBe(RequestBodyType.FILE);
+      if (fields[0].value.type !== RequestBodyType.FILE) {
+        throw new Error('Expected file form data value');
+      }
       expect(fields[0].value.filePath).toBe('/tmp/file.txt');
     });
 
@@ -134,7 +137,7 @@ describe('FormData store actions', () => {
     it('removes the field at the given index', () => {
       store.getState().deleteFormDataField(0);
 
-      const fields = (store.getState().requests.get(REQ_ID)!.body as any).fields;
+      const fields = getFormDataFields(store);
       expect(fields).toHaveLength(1);
       expect(fields[0].key).toBe('second');
     });

--- a/src/renderer/state/collectionStore.test.ts
+++ b/src/renderer/state/collectionStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createCollectionStore } from './collectionStore';
+import { createAppStore, selectPersistableAppState } from './collectionStore';
 import { ClientCertificate, Collection } from 'shim/objects/collection';
 import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { RequestMethod } from 'shim/objects/request-method';
@@ -18,16 +18,11 @@ vi.mock('@/services/event/renderer-event-service', () => ({
     instance: {
       rename: vi.fn(),
       setClientCertificate: vi.fn(),
+      setCollectionVariables: vi.fn(),
+      setEnvironmentVariables: vi.fn(),
+      selectEnvironment: vi.fn().mockResolvedValue(undefined),
     },
   },
-}));
-
-vi.mock('@/state/variableStore', () => ({
-  useVariableStore: { getState: () => ({ initialize: vi.fn() }) },
-}));
-
-vi.mock('@/state/environmentStore', () => ({
-  useEnvironmentStore: { getState: () => ({ initialize: vi.fn() }) },
 }));
 
 const makeRequest = (id: string, parentId: string): TrufosRequest =>
@@ -51,8 +46,8 @@ const makeCollection = (id: string, children: TrufosRequest[] = []): Collection 
     title: 'Test',
     dirPath: '/test',
     children,
-    variables: [],
-    environments: [],
+    variables: {},
+    environments: {},
   }) as unknown as Collection;
 
 const REQ_ID = 'req-1';
@@ -61,7 +56,7 @@ const COL_ID = 'col-1';
 const buildStore = () => {
   const request = makeRequest(REQ_ID, COL_ID);
   const collection = makeCollection(COL_ID, [request]);
-  const store = createCollectionStore(collection);
+  const store = createAppStore(collection);
   store.getState().setSelectedRequest(REQ_ID);
   return store;
 };
@@ -233,7 +228,7 @@ describe('setClientCertificate', () => {
   };
 
   it('sets the client certificate on the collection', () => {
-    const store = createCollectionStore(makeCollection(COL_ID));
+    const store = createAppStore(makeCollection(COL_ID));
 
     store.getState().setClientCertificate(CERT);
 
@@ -241,7 +236,7 @@ describe('setClientCertificate', () => {
   });
 
   it('clears the client certificate when called with null', () => {
-    const store = createCollectionStore(makeCollection(COL_ID));
+    const store = createAppStore(makeCollection(COL_ID));
     store.getState().setClientCertificate(CERT);
 
     store.getState().setClientCertificate(null);
@@ -250,12 +245,58 @@ describe('setClientCertificate', () => {
   });
 
   it('replaces an existing certificate with a new one', () => {
-    const store = createCollectionStore(makeCollection(COL_ID));
+    const store = createAppStore(makeCollection(COL_ID));
     store.getState().setClientCertificate(CERT);
 
     const newCert: ClientCertificate = { certPath: '/new/cert.pem', keyPath: '/new/key.pem' };
     store.getState().setClientCertificate(newCert);
 
     expect(store.getState().collection?.clientCertificate).toEqual(newCert);
+  });
+});
+
+describe('saveCollectionSettings', () => {
+  it('updates all collection settings through one root-store action', async () => {
+    const store = createAppStore(makeCollection(COL_ID));
+    const certificate: ClientCertificate = {
+      certPath: '/path/to/cert.pem',
+      keyPath: '/path/to/key.pem',
+    };
+    const variables = { apiKey: { value: 'test-123' } };
+    const environments = { dev: { variables: { host: { value: 'localhost' } } } };
+
+    await store.getState().saveCollectionSettings({
+      title: 'Renamed collection',
+      variables,
+      environments,
+      selectedEnvironment: 'dev',
+      clientCertificate: certificate,
+    });
+
+    const state = store.getState();
+    expect(state.variables).toEqual(variables);
+    expect(state.environments).toEqual(environments);
+    expect(state.selectedEnvironment).toBe('dev');
+    expect(state.collection?.clientCertificate).toEqual(certificate);
+    expect(state.collection?.title).toBe('Renamed collection');
+  });
+});
+
+describe('selectPersistableAppState', () => {
+  it('includes durable collection data and excludes transient root-store state', () => {
+    const store = createAppStore(makeCollection(COL_ID));
+    store.getState().initializeVariables({ apiKey: { value: 'test-123' } });
+    store.getState().initializeEnvironments({ dev: { variables: {} } });
+    store.getState().openCollectionRunner();
+
+    const persisted = selectPersistableAppState(store.getState());
+
+    expect(persisted.collection?.variables).toEqual({ apiKey: { value: 'test-123' } });
+    expect(persisted.collection?.environments).toEqual({ dev: { variables: {} } });
+    expect(persisted.selectedEnvironment).toBe('dev');
+    expect(persisted.appSettings).toEqual({ theme: 'system' });
+    expect(persisted).not.toHaveProperty('responseInfoMap');
+    expect(persisted).not.toHaveProperty('isCollectionRunnerOpen');
+    expect(persisted).not.toHaveProperty('requests');
   });
 });

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -8,23 +8,27 @@ import {
 } from '@/state/helper/collectionUtil';
 import { useActions } from '@/state/helper/util';
 import { CollectionStateActions } from '@/state/interface/CollectionStateActions';
-import { useVariableStore } from '@/state/variableStore';
-import { useEnvironmentStore } from '@/state/environmentStore';
 import { createModelsForRequest, disposeModelsForRequest } from '@/lib/monaco/models';
 import { isCollection, isRequest, TrufosObject, AuthorizationInformation } from 'shim/objects';
-import { Collection } from 'shim/objects/collection';
+import { ClientCertificate, Collection } from 'shim/objects/collection';
+import { EnvironmentMap } from 'shim/objects/environment';
 import { Folder } from 'shim/objects/folder';
 import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { RequestMethod } from 'shim/objects/request-method';
+import { TrufosResponse } from 'shim/objects/response';
 import { createStore } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { parseUrl } from 'shim/objects/url';
 import { ScriptType } from 'shim/scripting';
 import { SortMode } from '@/components/sidebar/SidebarRequestList/treeUtilities';
+import { VariableMap } from 'shim/objects/variables';
+import { AppSettings } from 'shim/app-settings';
+import { showError } from '@/error/errorHandler';
+import { editor } from 'monaco-editor';
 
 const eventService = RendererEventService.instance;
 
-interface CollectionState {
+export interface CollectionState {
   /** The currently selected collection */
   collection?: Omit<Collection, 'variables' | 'environments'>;
 
@@ -47,22 +51,97 @@ interface CollectionState {
   sortMode: SortMode;
 }
 
-type CollectionStore = StoreApi<CollectionState & CollectionStateActions>;
+export interface VariableState {
+  variables: VariableMap;
+}
 
-// Context for the collection store
-const CollectionStoreContext = createContext<CollectionStore | null>(null);
+interface VariableStateActions {
+  initializeVariables(variables: VariableMap): void;
+  setVariables(variables: VariableMap): Promise<void>;
+}
+
+export interface EnvironmentState {
+  environments: EnvironmentMap;
+  selectedEnvironment?: string;
+}
+
+interface EnvironmentStateActions {
+  initializeEnvironments(environments: EnvironmentMap): void;
+  syncCollectionVariables(variables: VariableMap, environments: EnvironmentMap): void;
+  setEnvironments(environments: EnvironmentMap): Promise<void>;
+  selectEnvironment(environmentKey?: string): Promise<void>;
+  addEnvironment(key: string): void;
+  removeEnvironment(key: string): void;
+}
+
+export interface CollectionSettings {
+  title: string;
+  variables: VariableMap;
+  environments: EnvironmentMap;
+  selectedEnvironment?: string;
+  clientCertificate: ClientCertificate | null;
+}
+
+interface CollectionSettingsActions {
+  saveCollectionSettings(settings: CollectionSettings): Promise<void>;
+}
+
+type ResponseInfoMap = Record<string, TrufosResponse>;
+
+export interface ResponseState {
+  responseInfoMap: ResponseInfoMap;
+}
+
+interface ResponseActions {
+  addResponse(requestId: string, response: TrufosResponse): void;
+  removeResponse(requestId: string): void;
+  setResponseEditor(responseEditor: editor.ICodeEditor | undefined): void;
+  formatResponseEditorText(): Promise<void>;
+}
+
+export interface ViewState {
+  isCollectionRunnerOpen: boolean;
+  isCollectionSettingsOpen: boolean;
+}
+
+interface ViewActions {
+  openCollectionRunner(): void;
+  closeCollectionRunner(): void;
+  openCollectionSettings(): void;
+  closeCollectionSettings(): void;
+}
+
+interface AppSettingsActions {
+  initializeAppSettings(settings: AppSettings | undefined): void;
+  updateSettings(partial: Partial<AppSettings>): void;
+}
+
+export type AppStoreState = CollectionState &
+  CollectionStateActions &
+  VariableState &
+  VariableStateActions &
+  EnvironmentState &
+  EnvironmentStateActions &
+  CollectionSettingsActions &
+  ResponseState &
+  ResponseActions &
+  ViewState &
+  ViewActions &
+  AppSettings &
+  AppSettingsActions;
+
+type AppStore = StoreApi<AppStoreState>;
+
+const CollectionStoreContext = createContext<AppStore | null>(null);
 
 export const CollectionStoreProvider = CollectionStoreContext.Provider;
 
 /**
  * Builds maps of requests and folders from a collection's children tree.
- * Also initializes variable and environment stores.
  */
 const buildCollectionItemMaps = (collection: Collection) => {
   const requests = new Map<TrufosRequest['id'], TrufosRequest>();
   const folders = new Map<Folder['id'], Folder>();
-  const { initialize: initializeVariables } = useVariableStore.getState();
-  const { initialize: initializeEnvironments } = useEnvironmentStore.getState();
 
   const stack = [...collection.children];
   while (stack.length > 0) {
@@ -75,27 +154,39 @@ const buildCollectionItemMaps = (collection: Collection) => {
     }
   }
 
-  initializeVariables(collection.variables);
-  initializeEnvironments(collection.environments);
-
   return { requests, folders };
 };
 
-// Factory function to create a collection store with initial data
-export const createCollectionStore = (collection: Collection) => {
-  console.debug('Creating collection store with collection', collection);
+const DEFAULT_APP_SETTINGS: AppSettings = { theme: 'system' };
 
-  return createStore<CollectionState & CollectionStateActions>()(
+// Stored outside Immer state because Monaco editor instances contain circular references.
+let responseEditorRef: editor.ICodeEditor | undefined;
+
+export const createAppStore = (collection: Collection): AppStore => {
+  console.debug('Creating app store with collection', collection);
+
+  const initialEnvironment = Object.keys(collection.environments)[0];
+
+  const store = createStore<AppStoreState>()(
     immer((set, get) => ({
       collection,
       openFolders: new Set(),
       currentScriptType: ScriptType.PRE_REQUEST,
       sortMode: SortMode.DEFAULT,
       ...buildCollectionItemMaps(collection),
+      variables: collection.variables,
+      environments: collection.environments,
+      selectedEnvironment: initialEnvironment,
+      responseInfoMap: {},
+      isCollectionRunnerOpen: false,
+      isCollectionSettingsOpen: false,
+      ...DEFAULT_APP_SETTINGS,
 
       initialize: (collection) => {
         console.debug('Initializing collection store with collection', collection);
         const { requests, folders } = buildCollectionItemMaps(collection);
+        const previousSelection = get().selectedEnvironment;
+        let nextSelection = previousSelection;
 
         // (re)set initial state
         set((state) => {
@@ -113,8 +204,19 @@ export const createCollectionStore = (collection: Collection) => {
             }
             state.openFolders = state.openFolders.intersection(new Set(folders.keys()));
           }
+          state.variables = collection.variables;
+          state.environments = collection.environments;
+          if (
+            state.selectedEnvironment == null ||
+            collection.environments[state.selectedEnvironment] == null
+          ) {
+            state.selectedEnvironment = Object.keys(collection.environments)[0];
+          }
+          nextSelection = state.selectedEnvironment;
           console.info('Initialized collection:', collection);
         });
+
+        syncSelectedEnvironment(previousSelection, nextSelection);
       },
 
       changeCollection: async (collection: Collection | string) => {
@@ -560,25 +662,213 @@ export const createCollectionStore = (collection: Collection) => {
         });
         await eventService.setClientCertificate(certificate);
       },
+
+      initializeVariables: (variables) => {
+        set((state) => {
+          state.variables = variables;
+        });
+      },
+
+      initializeEnvironments: (environments) => {
+        get().syncCollectionVariables(get().variables, environments);
+      },
+
+      syncCollectionVariables: (variables, environments) => {
+        const previousSelection = get().selectedEnvironment;
+        let nextSelection = previousSelection;
+        set((state) => {
+          state.variables = variables;
+          state.environments = environments;
+          if (
+            state.selectedEnvironment == null ||
+            environments[state.selectedEnvironment] == null
+          ) {
+            state.selectedEnvironment = Object.keys(environments)[0];
+          }
+          nextSelection = state.selectedEnvironment;
+        });
+        syncSelectedEnvironment(previousSelection, nextSelection);
+      },
+
+      setVariables: async (variables) => {
+        console.debug('Saving collection variables');
+        await eventService.setCollectionVariables(variables);
+        set((state) => {
+          state.variables = variables;
+        });
+      },
+
+      setEnvironments: async (environments) => {
+        await eventService.setEnvironmentVariables(environments);
+        set((state) => {
+          state.environments = environments;
+        });
+      },
+
+      selectEnvironment: async (environmentKey) => {
+        await eventService.selectEnvironment(environmentKey);
+        set((state) => {
+          state.selectedEnvironment = environmentKey;
+        });
+      },
+
+      addEnvironment: (key) => {
+        set((state) => {
+          if (!state.environments[key]) {
+            state.environments[key] = { variables: {} };
+          }
+        });
+      },
+
+      removeEnvironment: (key) => {
+        set((state) => {
+          delete state.environments[key];
+          if (state.selectedEnvironment === key) {
+            state.selectedEnvironment = Object.keys(state.environments)[0];
+          }
+        });
+      },
+
+      saveCollectionSettings: async (settings) => {
+        const {
+          setVariables,
+          setEnvironments,
+          selectEnvironment,
+          setClientCertificate,
+          renameCollection,
+        } = get();
+        await setVariables(settings.variables);
+        await setEnvironments(settings.environments);
+        await selectEnvironment(settings.selectedEnvironment);
+        await setClientCertificate(settings.clientCertificate);
+
+        const title = settings.title.trim();
+        if (title.length > 0 && title !== get().collection?.title) {
+          await renameCollection(title);
+        }
+      },
+
+      addResponse: (requestId, response) => {
+        set((state) => {
+          state.responseInfoMap[requestId] = response;
+        });
+      },
+
+      removeResponse: (requestId) => {
+        set((state) => {
+          delete state.responseInfoMap[requestId];
+        });
+      },
+
+      setResponseEditor: (responseEditor) => {
+        responseEditorRef = responseEditor;
+      },
+
+      formatResponseEditorText: async () => {
+        if (!responseEditorRef) return;
+
+        try {
+          responseEditorRef.updateOptions({ readOnly: false });
+          await responseEditorRef.getAction('editor.action.formatDocument')?.run();
+        } finally {
+          responseEditorRef.updateOptions({ readOnly: true });
+        }
+      },
+
+      openCollectionRunner: () => {
+        set((state) => {
+          state.isCollectionRunnerOpen = true;
+        });
+      },
+
+      closeCollectionRunner: () => {
+        set((state) => {
+          state.isCollectionRunnerOpen = false;
+        });
+      },
+
+      openCollectionSettings: () => {
+        set((state) => {
+          state.isCollectionSettingsOpen = true;
+        });
+      },
+
+      closeCollectionSettings: () => {
+        set((state) => {
+          state.isCollectionSettingsOpen = false;
+        });
+      },
+
+      initializeAppSettings: (settings) => {
+        set((state) => {
+          state.theme = (settings ?? DEFAULT_APP_SETTINGS).theme;
+        });
+      },
+
+      updateSettings: (partial) => {
+        set((state) => {
+          Object.assign(state, partial);
+        });
+        void eventService
+          .saveAppSettings(AppSettings.parse({ theme: get().theme }))
+          .catch((error) => showError('Failed to save app settings', error));
+      },
     }))
   );
+
+  syncSelectedEnvironment(undefined, initialEnvironment);
+  return store;
 };
 
-// Hook to access the collection store from context
-export const useCollectionStore = <T>(
-  selector: (state: CollectionState & CollectionStateActions) => T
-): T => {
+export const useAppStore = <T>(selector: (state: AppStoreState) => T): T => {
   const store = useContext(CollectionStoreContext);
   if (!store) {
-    throw new Error('useCollectionStore must be used within CollectionStoreProvider');
+    throw new Error('useAppStore must be used within CollectionStoreProvider');
   }
   return useStore(store, selector);
 };
 
-export const useCollectionActions = () => useCollectionStore(useActions());
+// Feature-specific hook retained for collection consumers. It reads from the single app store.
+export const useCollectionStore = <T>(
+  selector: (state: CollectionState & CollectionStateActions) => T
+): T => useAppStore((state) => selector(state));
+
+export const useCollectionActions = (): CollectionStateActions => useCollectionStore(useActions());
 
 // Export context for the provider to access the raw store
 export { CollectionStoreContext };
+
+export interface PersistableAppState {
+  collection?: Collection;
+  selectedEnvironment?: string;
+  appSettings: AppSettings;
+}
+
+/**
+ * Selects durable application data while excluding UI state, response data, Monaco references,
+ * actions, and Map/Set lookup structures.
+ */
+export const selectPersistableAppState = (state: AppStoreState): PersistableAppState => ({
+  collection:
+    state.collection == null
+      ? undefined
+      : {
+          ...state.collection,
+          variables: state.variables,
+          environments: state.environments,
+        },
+  selectedEnvironment: state.selectedEnvironment,
+  appSettings: { theme: state.theme },
+});
+
+const syncSelectedEnvironment = (
+  previousSelection: string | undefined,
+  nextSelection: string | undefined
+): void => {
+  if (nextSelection !== previousSelection) {
+    eventService.selectEnvironment(nextSelection).catch(console.error);
+  }
+};
 
 const selectParent = (state: CollectionState, parentId: string) => {
   if (state.collection!.id === parentId) return state.collection as Collection;

--- a/src/renderer/state/environmentStore.test.ts
+++ b/src/renderer/state/environmentStore.test.ts
@@ -1,8 +1,13 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { useEnvironmentStore } from './environmentStore';
+import { createAppStore } from './collectionStore';
+import { Collection } from 'shim/objects/collection';
 
 const selectEnvironmentMock = vi.fn().mockResolvedValue(undefined);
 const setEnvironmentVariablesMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/lib/ipc-stream', () => ({
+  IpcPushStream: { open: vi.fn() },
+}));
 
 vi.mock('@/services/event/renderer-event-service', () => ({
   RendererEventService: {
@@ -14,64 +19,73 @@ vi.mock('@/services/event/renderer-event-service', () => ({
 }));
 
 describe('environmentStore', () => {
+  let store: ReturnType<typeof createAppStore>;
+
   beforeEach(() => {
     selectEnvironmentMock.mockClear();
     setEnvironmentVariablesMock.mockClear();
-    useEnvironmentStore.setState({ environments: {}, selectedEnvironment: undefined });
+    store = createAppStore({
+      id: 'col-1',
+      parentId: null,
+      type: 'collection',
+      title: 'Test',
+      dirPath: '/test',
+      children: [],
+      variables: {},
+      environments: {},
+      lastModified: 0,
+      isDefault: false,
+    } as Collection);
   });
 
   describe('initialize', () => {
     it('auto-selects the first environment and propagates it to the main process', () => {
-      useEnvironmentStore
-        .getState()
-        .initialize({ dev: { variables: {} }, prod: { variables: {} } });
+      store.getState().initializeEnvironments({ dev: { variables: {} }, prod: { variables: {} } });
 
-      expect(useEnvironmentStore.getState().selectedEnvironment).toBe('dev');
+      expect(store.getState().selectedEnvironment).toBe('dev');
       expect(selectEnvironmentMock).toHaveBeenCalledWith('dev');
     });
 
     it('keeps an existing selection and does not send redundant IPC calls', () => {
-      useEnvironmentStore.setState({ selectedEnvironment: 'prod' });
+      store.setState({ selectedEnvironment: 'prod' });
 
-      useEnvironmentStore
-        .getState()
-        .initialize({ dev: { variables: {} }, prod: { variables: {} } });
+      store.getState().initializeEnvironments({ dev: { variables: {} }, prod: { variables: {} } });
 
-      expect(useEnvironmentStore.getState().selectedEnvironment).toBe('prod');
+      expect(store.getState().selectedEnvironment).toBe('prod');
       expect(selectEnvironmentMock).not.toHaveBeenCalled();
     });
 
     it('resets an existing selection that is missing in the new environments', () => {
-      useEnvironmentStore.setState({ selectedEnvironment: 'prod' });
+      store.setState({ selectedEnvironment: 'prod' });
 
-      useEnvironmentStore.getState().initialize({ dev: { variables: {} } });
+      store.getState().initializeEnvironments({ dev: { variables: {} } });
 
-      expect(useEnvironmentStore.getState().selectedEnvironment).toBe('dev');
+      expect(store.getState().selectedEnvironment).toBe('dev');
       expect(selectEnvironmentMock).toHaveBeenCalledWith('dev');
     });
 
     it('does not select anything when there are no environments', () => {
-      useEnvironmentStore.getState().initialize({});
+      store.getState().initializeEnvironments({});
 
-      expect(useEnvironmentStore.getState().selectedEnvironment).toBeUndefined();
+      expect(store.getState().selectedEnvironment).toBeUndefined();
       expect(selectEnvironmentMock).not.toHaveBeenCalled();
     });
   });
 
   describe('selectEnvironment', () => {
     it('updates the state and notifies the main process', async () => {
-      await useEnvironmentStore.getState().selectEnvironment('prod');
+      await store.getState().selectEnvironment('prod');
 
-      expect(useEnvironmentStore.getState().selectedEnvironment).toBe('prod');
+      expect(store.getState().selectedEnvironment).toBe('prod');
       expect(selectEnvironmentMock).toHaveBeenCalledWith('prod');
     });
 
     it('clears the selection when called without a key', async () => {
-      useEnvironmentStore.setState({ selectedEnvironment: 'dev' });
+      store.setState({ selectedEnvironment: 'dev' });
 
-      await useEnvironmentStore.getState().selectEnvironment(undefined);
+      await store.getState().selectEnvironment(undefined);
 
-      expect(useEnvironmentStore.getState().selectedEnvironment).toBeUndefined();
+      expect(store.getState().selectedEnvironment).toBeUndefined();
       expect(selectEnvironmentMock).toHaveBeenCalledWith(undefined);
     });
   });

--- a/src/renderer/state/environmentStore.ts
+++ b/src/renderer/state/environmentStore.ts
@@ -1,17 +1,6 @@
-import { create } from 'zustand';
-import { immer } from 'zustand/middleware/immer';
 import { EnvironmentMap } from 'shim/objects/environment';
 import { useActions } from '@/state/helper/util';
-import { RendererEventService } from '@/services/event/renderer-event-service';
-
-const eventService = RendererEventService.instance;
-
-interface EnvironmentState {
-  /** The environments of the current collection */
-  environments: EnvironmentMap;
-  /** Currently selected environment key */
-  selectedEnvironment?: string;
-}
+import { type EnvironmentState, useAppStore } from '@/state/collectionStore';
 
 interface EnvironmentActions {
   initialize(environments: EnvironmentMap): void;
@@ -21,63 +10,21 @@ interface EnvironmentActions {
   removeEnvironment(key: string): void;
 }
 
-export const useEnvironmentStore = create<EnvironmentState & EnvironmentActions>()(
-  immer((set, get) => ({
-    environments: {},
-    selectedEnvironment: undefined,
+type EnvironmentStoreState = EnvironmentState & EnvironmentActions;
 
-    initialize(environments: EnvironmentMap) {
-      const previousSelection = get().selectedEnvironment;
-      const environmentKeys = Object.keys(environments);
-      let nextSelection = previousSelection;
-      set((state) => {
-        state.environments = environments;
-        if (state.selectedEnvironment == null || environments[state.selectedEnvironment] == null) {
-          state.selectedEnvironment = environmentKeys[0] ?? undefined;
-        }
-        nextSelection = state.selectedEnvironment;
-      });
-      // The main process resolves variables based on its own selected environment,
-      // so an auto-selection here must be propagated via IPC.
-      if (nextSelection !== previousSelection) {
-        eventService.selectEnvironment(nextSelection).catch(console.error);
-      }
-    },
-
-    setEnvironments: async (environments) => {
-      await eventService.setEnvironmentVariables(environments);
-      set((state) => {
-        state.environments = environments;
-      });
-    },
-
-    selectEnvironment: async (environmentKey?: string) => {
-      await eventService.selectEnvironment(environmentKey);
-      set((state) => {
-        state.selectedEnvironment = environmentKey;
-      });
-    },
-
-    addEnvironment(key: string) {
-      set((state) => {
-        if (!state.environments[key]) {
-          state.environments[key] = { variables: {} };
-        }
-      });
-    },
-
-    removeEnvironment(key: string) {
-      set((state) => {
-        delete state.environments[key];
-        if (state.selectedEnvironment === key) {
-          const remainingKeys = Object.keys(state.environments);
-          state.selectedEnvironment = remainingKeys.length > 0 ? remainingKeys[0] : undefined;
-        }
-      });
-    },
-  }))
-);
+export const useEnvironmentStore = <T>(selector: (state: EnvironmentStoreState) => T): T =>
+  useAppStore((state) =>
+    selector({
+      environments: state.environments,
+      selectedEnvironment: state.selectedEnvironment,
+      initialize: state.initializeEnvironments,
+      setEnvironments: state.setEnvironments,
+      selectEnvironment: state.selectEnvironment,
+      addEnvironment: state.addEnvironment,
+      removeEnvironment: state.removeEnvironment,
+    })
+  );
 
 export const selectEnvironments = (state: EnvironmentState) => state.environments;
 export const selectSelectedEnvironment = (state: EnvironmentState) => state.selectedEnvironment;
-export const useEnvironmentActions = () => useEnvironmentStore(useActions());
+export const useEnvironmentActions = (): EnvironmentActions => useEnvironmentStore(useActions());

--- a/src/renderer/state/responseStore.ts
+++ b/src/renderer/state/responseStore.ts
@@ -1,18 +1,9 @@
 import { useActions } from '@/state/helper/util';
 import { editor } from 'monaco-editor';
 import { TrufosResponse } from 'shim/objects/response';
-import { create } from 'zustand';
-import { immer } from 'zustand/middleware/immer';
+import { type ResponseState, useAppStore } from '@/state/collectionStore';
 
-/** A map of requestId => response */
-type ResponseInfoMap = Record<string, TrufosResponse>;
-
-// Stored outside immer state to prevent immer from deep-cloning the Monaco
-// editor instance (which has circular references and would overflow the stack).
-let responseEditorRef: editor.ICodeEditor | undefined;
-
-interface ResponseState {
-  responseInfoMap: ResponseInfoMap;
+interface ResponseActions {
   addResponse: (requestId: string, response: TrufosResponse) => void;
   removeResponse: (requestId: string) => void;
   setResponseEditor: (editor: editor.ICodeEditor | undefined) => void;
@@ -24,33 +15,19 @@ interface ResponseState {
   formatResponseEditorText(): Promise<void>;
 }
 
-export const useResponseStore = create<ResponseState>()(
-  immer((set) => ({
-    responseInfoMap: {},
-    addResponse: (requestId, response) =>
-      set((state) => {
-        state.responseInfoMap[requestId] = response;
-      }),
-    removeResponse: (requestId) =>
-      set((state) => {
-        delete state.responseInfoMap[requestId];
-      }),
-    setResponseEditor: (responseEditor) => {
-      responseEditorRef = responseEditor;
-    },
-    formatResponseEditorText: async () => {
-      if (!responseEditorRef) return;
+type ResponseStoreState = ResponseState & ResponseActions;
 
-      try {
-        responseEditorRef.updateOptions({ readOnly: false });
-        await responseEditorRef.getAction('editor.action.formatDocument')?.run();
-      } finally {
-        responseEditorRef.updateOptions({ readOnly: true });
-      }
-    },
-  }))
-);
+export const useResponseStore = <T>(selector: (state: ResponseStoreState) => T): T =>
+  useAppStore((state) =>
+    selector({
+      responseInfoMap: state.responseInfoMap,
+      addResponse: state.addResponse,
+      removeResponse: state.removeResponse,
+      setResponseEditor: state.setResponseEditor,
+      formatResponseEditorText: state.formatResponseEditorText,
+    })
+  );
 
 export const selectResponse = (state: ResponseState, requestId: string | undefined) =>
   requestId != null ? state.responseInfoMap[requestId] : undefined;
-export const useResponseActions = () => useResponseStore(useActions());
+export const useResponseActions = (): ResponseActions => useResponseStore(useActions());

--- a/src/renderer/state/variableStore.ts
+++ b/src/renderer/state/variableStore.ts
@@ -1,36 +1,17 @@
 import { VariableStateActions } from '@/state/interface/VariableStateAction';
-import { create } from 'zustand';
-import { immer } from 'zustand/middleware/immer';
-import { VariableMap } from 'shim/objects/variables';
-import { RendererEventService } from '@/services/event/renderer-event-service';
 import { useActions } from '@/state/helper/util';
+import { type VariableState, useAppStore } from '@/state/collectionStore';
 
-const eventService = RendererEventService.instance;
+type VariableStoreState = VariableState & VariableStateActions;
 
-interface VariableState {
-  /** The variables of the current collection */
-  variables: VariableMap;
-}
-
-export const useVariableStore = create<VariableState & VariableStateActions>()(
-  immer((set, get) => ({
-    variables: {},
-
-    initialize(variables: VariableMap) {
-      set((state) => {
-        state.variables = variables;
-      });
-    },
-
-    setVariables: async (variables) => {
-      console.debug('Saving collection variables');
-      await eventService.setCollectionVariables(variables);
-      set((state) => {
-        state.variables = variables;
-      });
-    },
-  }))
-);
+export const useVariableStore = <T>(selector: (state: VariableStoreState) => T): T =>
+  useAppStore((state) =>
+    selector({
+      variables: state.variables,
+      initialize: state.initializeVariables,
+      setVariables: state.setVariables,
+    })
+  );
 
 export const selectVariables = (state: VariableState) => state.variables;
-export const useVariableActions = () => useVariableStore(useActions());
+export const useVariableActions = (): VariableStateActions => useVariableStore(useActions());

--- a/src/renderer/state/viewStore.ts
+++ b/src/renderer/state/viewStore.ts
@@ -1,13 +1,5 @@
-import { create } from 'zustand';
-import { immer } from 'zustand/middleware/immer';
 import { useActions } from '@/state/helper/util';
-
-interface ViewState {
-  /** Whether the collection runner modal is open */
-  isCollectionRunnerOpen: boolean;
-  /** Whether the collection settings modal is open */
-  isCollectionSettingsOpen: boolean;
-}
+import { type ViewState, useAppStore } from '@/state/collectionStore';
 
 interface ViewActions {
   openCollectionRunner(): void;
@@ -16,36 +8,19 @@ interface ViewActions {
   closeCollectionSettings(): void;
 }
 
-export const useViewStore = create<ViewState & ViewActions>()(
-  immer((set) => ({
-    isCollectionRunnerOpen: false,
-    isCollectionSettingsOpen: false,
+type ViewStoreState = ViewState & ViewActions;
 
-    openCollectionRunner() {
-      set((state) => {
-        state.isCollectionRunnerOpen = true;
-      });
-    },
-
-    closeCollectionRunner() {
-      set((state) => {
-        state.isCollectionRunnerOpen = false;
-      });
-    },
-
-    openCollectionSettings() {
-      set((state) => {
-        state.isCollectionSettingsOpen = true;
-      });
-    },
-
-    closeCollectionSettings() {
-      set((state) => {
-        state.isCollectionSettingsOpen = false;
-      });
-    },
-  }))
-);
+export const useViewStore = <T>(selector: (state: ViewStoreState) => T): T =>
+  useAppStore((state) =>
+    selector({
+      isCollectionRunnerOpen: state.isCollectionRunnerOpen,
+      isCollectionSettingsOpen: state.isCollectionSettingsOpen,
+      openCollectionRunner: state.openCollectionRunner,
+      closeCollectionRunner: state.closeCollectionRunner,
+      openCollectionSettings: state.openCollectionSettings,
+      closeCollectionSettings: state.closeCollectionSettings,
+    })
+  );
 
 export const selectIsCollectionRunnerOpen = (state: ViewState) => state.isCollectionRunnerOpen;
 export const selectIsCollectionSettingsOpen = (state: ViewState) => state.isCollectionSettingsOpen;


### PR DESCRIPTION
### **User description**
## Changes

- Consolidate collection, variables, environments, responses, view state, and app settings behind one renderer Zustand root store.
- Keep feature-specific store hooks as facades over the root store.
- Validate script-driven variable updates at the IPC boundary and handle them in the root store.
- Move collection-settings persistence from the modal into a root-store action.
- Add an explicit persistable-state selector that excludes transient UI state, response data, Monaco references, and Map/Set indexes.

Closes #576

## Testing

- `yarn test`
- `yarn prettier-check`
- `yarn exec eslint <changed files>`
- `yarn tsc --noEmit` remains blocked by existing `src/renderer/lib/monaco/language.ts` Monaco typings error.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [ ] Manual testing has been performed
- [x] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person


___

### **PR Type**
Enhancement


___

### **Description**
- Consolidate three separate Zustand stores into single monolithic root store

- Retain feature-specific store hooks as facades over unified app store

- Add explicit `selectPersistableAppState` selector excluding transient UI state

- Move collection-settings persistence logic into root-store action

- Validate script-driven variable updates at IPC boundary with Zod schema


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Multiple Stores<br/>collection/variables<br/>environments/response<br/>view/appSettings"]
  B["Single Root<br/>App Store"]
  C["Feature Facades<br/>useVariableStore<br/>useEnvironmentStore<br/>useResponseStore<br/>useViewStore<br/>useAppSettingsStore"]
  D["Persistable State<br/>Selector"]
  E["IPC Boundary<br/>Validation"]
  
  A -->|"consolidate"| B
  B -->|"expose via"| C
  B -->|"extract via"| D
  B -->|"validate at"| E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>collectionStore.ts</strong><dd><code>Consolidate all state into single root app store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-9bd66bf13fd7c115c613572a46b343298648618f8245cf60b86b6e420d738a32">+313/-23</a></td>

</tr>

<tr>
  <td><strong>CollectionStoreProvider.tsx</strong><dd><code>Update provider to create unified app store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-d253d97ef56503bec64b1ceea8742417a43d1bc94b1ac3bc9c6c2f497ff609b6">+20/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CollectionSettingsModal.tsx</strong><dd><code>Use new saveCollectionSettings root-store action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-bc8aeb7cf3a9740e0dd14e9ef9e233c0dae5a9df32cd174c4b6bef02d98577b8">+12/-21</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>appSettingsStore.ts</strong><dd><code>Convert to facade over root app store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-8af3598cc18c8f1bbf210435c2b6948597397e26b36e869d7928736e9a6eecce">+11/-26</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>variableStore.ts</strong><dd><code>Convert to facade over root app store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-7004b47fcea0291fa8b18aadee335d2f17f88e5bd99349f01a7480e614efcce3">+11/-30</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>environmentStore.ts</strong><dd><code>Convert to facade over root app store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-d18d7951e0c0b8e8ab5b58716aa20a920d9ee9288df531629d4ee92ebaabcaaf">+16/-69</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>responseStore.ts</strong><dd><code>Convert to facade over root app store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-1b00291a68480c1806b55700e7510bd92ba6943d678df43113d77daa886a6bb9">+14/-37</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>viewStore.ts</strong><dd><code>Convert to facade over root app store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-3f3242036ea07710b3828c5ecae6bcf8ed0bdfa1e31e303b9096f46300677a67">+14/-39</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>App.tsx</strong><dd><code>Update imports and initialization for unified store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-72348b6b222462c023d009b90544f2799da3cf5b1eafc2d280f8a19041271230">+47/-35</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>CollectionStoreProvider.test.tsx</strong><dd><code>Update tests to verify root store integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-76a8050b5cab0c020ead6cf69fa2bad75f211a11af95d4c98b6d7096ff6f5b86">+16/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SidebarHeaderBar.test.tsx</strong><dd><code>Add mock for useAppStore in test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-5531a71800f40921903cccc5d42f32426a1b4e4deef2a98141e42b94a47a1b34">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>collectionStore.test.ts</strong><dd><code>Add tests for saveCollectionSettings and selectPersistableAppState</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-b45e9f937ca04143832f64308b5faebcd085083868ff8c6701890fc6927f3141">+56/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>collectionStore.formData.test.ts</strong><dd><code>Update tests to use createAppStore factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-46c35f921edd6dc79a7ae801a65e249a1cff0e6696e22c03b269a702211d3572">+19/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>environmentStore.test.ts</strong><dd><code>Refactor tests to use root app store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/948/files#diff-9ab9a6026e18316b9062afefe546f88350964583b2b52cffe1a51664a238a6da">+35/-21</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

