### PR TITLE
fix(446): CMD+Enter hotkey triggers newline in monaco

### DIFF
--- a/src/renderer/hooks/hotKeys/useHotkey.test.ts
+++ b/src/renderer/hooks/hotKeys/useHotkey.test.ts
@@ -1,0 +1,87 @@
+import { renderHook } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import { useHotkeys } from './useHotkey';
+
+const dispatchKeyDown = (init: KeyboardEventInit) => {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init });
+  const preventDefault = vi.spyOn(event, 'preventDefault');
+  const stopImmediatePropagation = vi.spyOn(event, 'stopImmediatePropagation');
+  window.dispatchEvent(event);
+  return { event, preventDefault, stopImmediatePropagation };
+};
+
+describe('useHotkeys', () => {
+  it('invokes the handler and suppresses further handling on a matching hotkey', () => {
+    // Arrange
+    const handler = vi.fn();
+    renderHook(() => useHotkeys([{ keys: 'mod+enter', handler }]));
+
+    // Act
+    const { event, preventDefault, stopImmediatePropagation } = dispatchKeyDown({
+      key: 'Enter',
+      metaKey: true,
+    });
+
+    // Assert
+    expect(handler).toHaveBeenCalledWith(event);
+    expect(preventDefault).toHaveBeenCalled();
+    expect(stopImmediatePropagation).toHaveBeenCalled();
+  });
+
+  it('does not touch events that do not match a hotkey', () => {
+    // Arrange
+    const handler = vi.fn();
+    renderHook(() => useHotkeys([{ keys: 'mod+enter', handler }]));
+
+    // Act
+    const { preventDefault, stopImmediatePropagation } = dispatchKeyDown({ key: 'Enter' });
+
+    // Assert
+    expect(handler).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(stopImmediatePropagation).not.toHaveBeenCalled();
+  });
+
+  it('allows opting out of stopping propagation per hotkey', () => {
+    // Arrange
+    const handler = vi.fn();
+    renderHook(() => useHotkeys([{ keys: 'mod+enter', handler, stopPropagation: false }]));
+
+    // Act
+    const { stopImmediatePropagation } = dispatchKeyDown({ key: 'Enter', metaKey: true });
+
+    // Assert
+    expect(handler).toHaveBeenCalled();
+    expect(stopImmediatePropagation).not.toHaveBeenCalled();
+  });
+
+  it('skips form elements by default but still runs when skipFormElements is false', () => {
+    // Arrange
+    const skipping = vi.fn();
+    const notSkipping = vi.fn();
+    renderHook(() => useHotkeys([{ keys: 'mod+enter', handler: skipping }]));
+    renderHook(() =>
+      useHotkeys([{ keys: 'mod+enter', handler: notSkipping }], { skipFormElements: false })
+    );
+
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+
+    // Act
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(event, 'target', { value: textarea });
+    window.dispatchEvent(event);
+
+    // Assert
+    expect(skipping).not.toHaveBeenCalled();
+    expect(notSkipping).toHaveBeenCalled();
+
+    document.body.removeChild(textarea);
+  });
+});

--- a/src/renderer/hooks/hotKeys/useHotkey.ts
+++ b/src/renderer/hooks/hotKeys/useHotkey.ts
@@ -6,6 +6,7 @@ type HotkeyConfig = {
   enabled?: boolean;
   skipFormElements?: boolean;
   preventDefault?: boolean;
+  stopPropagation?: boolean;
 };
 
 type UseHotkeysOptions = {
@@ -13,6 +14,7 @@ type UseHotkeysOptions = {
   capture?: boolean;
   skipFormElements?: boolean;
   preventDefault?: boolean;
+  stopPropagation?: boolean;
 };
 
 const isFormElement = (target: EventTarget | null) => {
@@ -54,6 +56,7 @@ export const useHotkeys = (
     capture = true,
     skipFormElements = true,
     preventDefault = true,
+    stopPropagation = true,
   }: UseHotkeysOptions = {}
 ) => {
   const hotkeysRef = useRef(hotkeys);
@@ -83,9 +86,14 @@ export const useHotkeys = (
       if (!matchedHotkey) return;
 
       const shouldPreventDefault = matchedHotkey.preventDefault ?? preventDefault;
+      const shouldStopPropagation = matchedHotkey.stopPropagation ?? stopPropagation;
 
       if (shouldPreventDefault) {
         event.preventDefault();
+      }
+
+      if (shouldStopPropagation) {
+        event.stopImmediatePropagation();
       }
 
       matchedHotkey.handler(event);


### PR DESCRIPTION
### **User description**
## Changes

- Stop enter keydown event from propagating to monaco editor when matching hotkey

## Testing

If relevant, mention your manual testing here. If possible, include screenshots.

## Checklist

- [ ] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add `stopPropagation` option to prevent hotkey events from propagating

- Implement `stopImmediatePropagation()` call for matched hotkeys by default

- Allow per-hotkey and global opt-out of propagation stopping

- Add comprehensive test coverage for hotkey propagation behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hotkey Match"] --> B["Check stopPropagation Flag"]
  B --> C["Call stopImmediatePropagation"]
  C --> D["Invoke Handler"]
  B --> E["Skip Propagation Stop"]
  E --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useHotkey.ts</strong><dd><code>Add event propagation stopping to hotkey handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/hooks/hotKeys/useHotkey.ts

<ul><li>Add <code>stopPropagation</code> option to <code>HotkeyConfig</code> and <code>UseHotkeysOptions</code> types<br> <li> Implement <code>stopImmediatePropagation()</code> call when hotkey matches and <br><code>stopPropagation</code> is enabled<br> <li> Default <code>stopPropagation</code> to <code>true</code> to prevent event propagation by <br>default<br> <li> Support per-hotkey override of propagation behavior via <br><code>matchedHotkey.stopPropagation</code></ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/955/files#diff-3a6e82627ace060e4872bef9c9cf464ec8dab01675ba1da3541d7e5a69aeb828">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useHotkey.test.ts</strong><dd><code>Add comprehensive hotkey propagation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/hooks/hotKeys/useHotkey.test.ts

<ul><li>Add test verifying handler invocation and propagation suppression on <br>matching hotkey<br> <li> Add test confirming non-matching hotkeys don't trigger propagation <br>methods<br> <li> Add test for per-hotkey opt-out of propagation stopping via <br><code>stopPropagation: false</code><br> <li> Add test for form element skipping behavior with <code>skipFormElements</code> <br>option</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/955/files#diff-715cae778dcc7c6ee5b0522e1281a6b7acb643617975b365e0d6f74b868911e4">+87/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

