### PR TITLE
fix(957): reordering sidebar items

### DIFF
--- a/src/main/persistence/service/persistence-service.test.ts
+++ b/src/main/persistence/service/persistence-service.test.ts
@@ -13,7 +13,7 @@ import { generateDefaultCollection } from './default-collection';
 import { sanitizeTitle } from 'shim/fs';
 import { CollectionInfoFile, RequestInfoFile, GIT_IGNORE_FILE_NAME } from './info-files/latest';
 import { PersistenceService } from './persistence-service';
-import { DRAFT_DIR_NAME, SECRETS_FILE_NAME } from 'main/persistence/constants';
+import { DRAFT_DIR_NAME, ORDER_FILE_NAME, SECRETS_FILE_NAME } from 'main/persistence/constants';
 
 const persistenceService = PersistenceService.instance;
 
@@ -1080,5 +1080,76 @@ describe('PersistenceService', () => {
 
     // Assert
     expect(folder.children.map((c) => c.title)).toEqual(['Request1', 'Request3', 'Request2']);
+  });
+
+  it('reorderItem() should persist reordering to a non-zero position in a 3+ item list (#957)', async () => {
+    // Arrange - mixed folders and requests, no order.json exists yet
+    const folder1 = getExampleFolder(collection.id);
+    folder1.title = 'Folder1';
+    const folder2 = getExampleFolder(collection.id);
+    folder2.title = 'Folder2';
+    const request1 = getExampleRequest(collection.id);
+    request1.title = 'Req1';
+    const request2 = getExampleRequest(collection.id);
+    request2.title = 'Req2';
+    collection.children.push(folder1, folder2, request1, request2);
+    await persistenceService.saveCollection(collection, true);
+
+    // Act - move Folder1 to a middle position (index 2)
+    await persistenceService.reorderItem(collection, folder1.id, 2);
+
+    // Assert - in-memory order updated
+    expect(collection.children.map((c) => c.title)).toEqual(['Folder2', 'Req1', 'Folder1', 'Req2']);
+
+    // Verify the manual order round-trips across a reload
+    const loaded = await persistenceService.loadCollection(collection.dirPath);
+    expect(loaded.children.map((c) => c.title)).toEqual(['Folder2', 'Req1', 'Folder1', 'Req2']);
+  });
+
+  it('reorderItem() should write a complete order.json containing every sibling (#957)', async () => {
+    // Arrange - three items, no order.json exists yet
+    const request1 = getExampleRequest(collection.id);
+    request1.title = 'Req1';
+    const request2 = getExampleRequest(collection.id);
+    request2.title = 'Req2';
+    const request3 = getExampleRequest(collection.id);
+    request3.title = 'Req3';
+    collection.children.push(request1, request2, request3);
+    await persistenceService.saveCollection(collection, true);
+
+    // Act - move Req3 to the middle
+    await persistenceService.reorderItem(collection, request3.id, 1);
+
+    // Assert - order.json lists all three siblings in the new order
+    const order = JSON.parse(
+      await readFile(path.join(collection.dirPath, ORDER_FILE_NAME), 'utf-8')
+    );
+    expect(order).toEqual([request1.id, request3.id, request2.id]);
+  });
+
+  it('moveChild() to a middle position keeps both parents complete after reload (#957)', async () => {
+    // Arrange
+    const folder = getExampleFolder(collection.id);
+    folder.title = 'Folder';
+    const request1 = getExampleRequest(folder.id);
+    request1.title = 'Req1';
+    const request2 = getExampleRequest(folder.id);
+    request2.title = 'Req2';
+    folder.children.push(request1, request2);
+    const request3 = getExampleRequest(collection.id);
+    request3.title = 'Req3';
+    const request4 = getExampleRequest(collection.id);
+    request4.title = 'Req4';
+    collection.children.push(folder, request3, request4);
+    await persistenceService.saveCollection(collection, true);
+
+    // Act - move Req3 from the collection into the folder between Req1 and Req2
+    await persistenceService.moveChild(request3, collection, folder, 1);
+
+    // Verify both parents keep their full, correct order across a reload
+    const loaded = await persistenceService.loadCollection(collection.dirPath);
+    expect(loaded.children.map((c) => c.title)).toEqual(['Folder', 'Req4']);
+    const loadedFolder = loaded.children.find((c) => c.title === 'Folder') as Folder;
+    expect(loadedFolder.children.map((c) => c.title)).toEqual(['Req1', 'Req3', 'Req2']);
   });
 });

--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -92,12 +92,10 @@ export class PersistenceService {
 
     const removeFromOldParent = async () => {
       oldParent.children = oldParent.children.filter((c) => c.id !== child.id);
-      const order = await this.loadOrderFile(oldParentDirPath);
-      const index = order.indexOf(child.id);
-      if (index !== -1) {
-        order.splice(index, 1);
-        await this.saveOrderFile(oldParentDirPath, order);
-      }
+      await this.saveOrderFile(
+        oldParentDirPath,
+        oldParent.children.map((c) => c.id)
+      );
     };
 
     const addToNewParent = async () => {
@@ -105,10 +103,11 @@ export class PersistenceService {
         newParent.children.push(child);
       } else {
         newParent.children.splice(position, 0, child);
-        const order = await this.loadOrderFile(newParentDirPath);
-        order.splice(position, 0, child.id);
-        await this.saveOrderFile(newParentDirPath, order);
       }
+      await this.saveOrderFile(
+        newParentDirPath,
+        newParent.children.map((c) => c.id)
+      );
     };
 
     // do in parallel as all are independent operations on the FS
@@ -136,7 +135,7 @@ export class PersistenceService {
   ): Promise<T> {
     logger.info(`Reordering child ${childId} in parent ${parent.id} to position ${newIndex}`);
     const parentDirPath = this.getOrCreateDirPath(parent);
-    const order = await this.loadOrderFile(parentDirPath);
+    const order = parent.children.map((c) => c.id);
     const oldIndex = order.indexOf(childId);
     if (oldIndex !== -1) order.splice(oldIndex, 1);
     order.splice(newIndex, 0, childId);


### PR DESCRIPTION
### **User description**
## Changes

- fix reordering sidebar items not keeping order after reopening app

## Testing

If relevant, mention your manual testing here. If possible, include screenshots.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person


___

### **PR Type**
Bug fix


___

### **Description**
- Fix sidebar item reordering not persisting after app restart

- Ensure order.json contains all siblings when reordering items

- Simplify order file logic to use current children state

- Add comprehensive tests for reordering with mixed item types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Reorder/Move Items"] --> B["Update In-Memory Order"]
  B --> C["Save Complete order.json"]
  C --> D["Reload App"]
  D --> E["Load order.json with All Siblings"]
  E --> F["Restore Correct Order"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>persistence-service.ts</strong><dd><code>Simplify order persistence to use current state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/persistence/service/persistence-service.ts

<ul><li>Simplified <code>moveChild()</code> to always save complete order using current <br>children state instead of loading and modifying existing order<br> <li> Changed <code>reorderItem()</code> to derive order from parent's current children <br>instead of loading from file<br> <li> Ensures order.json always contains all siblings, preventing missing <br>items after reload</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/962/files#diff-a155f0cb611cc8da68af673aff42a673b39cb2c527ace1600936f469cdaeb09a">+9/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>persistence-service.test.ts</strong><dd><code>Add comprehensive reordering persistence tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/persistence/service/persistence-service.test.ts

<ul><li>Added import for <code>ORDER_FILE_NAME</code> constant<br> <li> Added test for reordering item to non-zero position in 3+ item list <br>with round-trip verification<br> <li> Added test verifying order.json contains all siblings after reordering<br> <li> Added test for moveChild() ensuring both parent and child containers <br>maintain complete order after reload</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/962/files#diff-94b3a259a8deab7f7aead7a07142f3c524fac977d47a4be62f1a7b1089ca77c2">+72/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

