### PR TITLE
Feature/867 command palette

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -17,6 +17,7 @@ import {
   useViewActions,
   useViewStore,
 } from '@/state/viewStore';
+import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
 import { showError } from '@/error/errorHandler';
 
 const MIN_SIDEBAR_PIXELS = 300;
@@ -25,7 +26,9 @@ const MIN_REQUEST_WINDOW_PIXELS = 500;
 export const App = () => {
   const isCollectionRunnerOpen = useViewStore(selectIsCollectionRunnerOpen);
   const isCollectionSettingsOpen = useViewStore(selectIsCollectionSettingsOpen);
-  const { closeCollectionRunner, closeCollectionSettings } = useViewActions();
+  const { closeCollectionRunner, closeCollectionSettings, openCommandPalette } = useViewActions();
+
+  useHotkeys([{ keys: 'mod+k', handler: openCommandPalette }]);
 
   useEffect(() => {
     // Entry points of the native application menu (Collection > ...).
@@ -70,6 +73,7 @@ export const App = () => {
               isOpen={isCollectionSettingsOpen}
               onClose={closeCollectionSettings}
             />
+            {/* CommandPalette mounted here in Part 2 */}
           </SidebarProvider>
         </TooltipProvider>
       </ThemeProvider>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4,6 +4,7 @@ import { Menubar } from '@/view/Menubar';
 import { RequestWindow } from '@/view/RequestWindow';
 import { CollectionRunner } from '@/view/CollectionRunner';
 import { CollectionSettingsModal } from '@/components/shared/settings/CollectionSettingsModal';
+import { AppSettingsModal } from '@/components/shared/settings/AppSettingsModal';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { ResizablePanel, ResizablePanelGroup, ResizableHandle } from '@/components/ui/resizable';
@@ -15,6 +16,7 @@ import {
   selectIsCollectionRunnerOpen,
   selectIsCollectionSettingsOpen,
   selectIsCommandPaletteOpen,
+  selectIsAppSettingsOpen,
   useViewActions,
   useViewStore,
 } from '@/state/viewStore';
@@ -29,11 +31,13 @@ export const App = () => {
   const isCollectionRunnerOpen = useViewStore(selectIsCollectionRunnerOpen);
   const isCollectionSettingsOpen = useViewStore(selectIsCollectionSettingsOpen);
   const isCommandPaletteOpen = useViewStore(selectIsCommandPaletteOpen);
+  const isAppSettingsOpen = useViewStore(selectIsAppSettingsOpen);
   const {
     closeCollectionRunner,
     closeCollectionSettings,
     openCommandPalette,
     closeCommandPalette,
+    closeAppSettings,
   } = useViewActions();
 
   useHotkeys([{ keys: 'mod+k', handler: openCommandPalette }]);
@@ -82,6 +86,7 @@ export const App = () => {
               onClose={closeCollectionSettings}
             />
             <CommandPalette open={isCommandPaletteOpen} onClose={closeCommandPalette} />
+            <AppSettingsModal isOpen={isAppSettingsOpen} onClose={closeAppSettings} />
           </SidebarProvider>
         </TooltipProvider>
       </ThemeProvider>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/state/viewStore';
 import { CommandPalette } from '@/components/commandPalette/CommandPalette';
 import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
+import { HOTKEYS } from '@/hooks/hotKeys/hotkeys';
 import { showError } from '@/error/errorHandler';
 
 const MIN_SIDEBAR_PIXELS = 300;
@@ -40,7 +41,7 @@ export const App = () => {
     closeAppSettings,
   } = useViewActions();
 
-  useHotkeys([{ keys: 'mod+k', handler: openCommandPalette }]);
+  useHotkeys([{ keys: HOTKEYS.openCommandPalette, handler: openCommandPalette }]);
 
   useEffect(() => {
     // Entry points of the native application menu (Collection > ...).

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -14,9 +14,11 @@ import { useAppSettingsStore } from '@/state/appSettingsStore';
 import {
   selectIsCollectionRunnerOpen,
   selectIsCollectionSettingsOpen,
+  selectIsCommandPaletteOpen,
   useViewActions,
   useViewStore,
 } from '@/state/viewStore';
+import { CommandPalette } from '@/components/commandPalette/CommandPalette';
 import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
 import { showError } from '@/error/errorHandler';
 
@@ -26,7 +28,9 @@ const MIN_REQUEST_WINDOW_PIXELS = 500;
 export const App = () => {
   const isCollectionRunnerOpen = useViewStore(selectIsCollectionRunnerOpen);
   const isCollectionSettingsOpen = useViewStore(selectIsCollectionSettingsOpen);
-  const { closeCollectionRunner, closeCollectionSettings, openCommandPalette } = useViewActions();
+  const isCommandPaletteOpen = useViewStore(selectIsCommandPaletteOpen);
+  const { closeCollectionRunner, closeCollectionSettings, openCommandPalette, closeCommandPalette } =
+    useViewActions();
 
   useHotkeys([{ keys: 'mod+k', handler: openCommandPalette }]);
 
@@ -73,7 +77,7 @@ export const App = () => {
               isOpen={isCollectionSettingsOpen}
               onClose={closeCollectionSettings}
             />
-            {/* CommandPalette mounted here in Part 2 */}
+            <CommandPalette open={isCommandPaletteOpen} onClose={closeCommandPalette} />
           </SidebarProvider>
         </TooltipProvider>
       </ThemeProvider>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -29,8 +29,12 @@ export const App = () => {
   const isCollectionRunnerOpen = useViewStore(selectIsCollectionRunnerOpen);
   const isCollectionSettingsOpen = useViewStore(selectIsCollectionSettingsOpen);
   const isCommandPaletteOpen = useViewStore(selectIsCommandPaletteOpen);
-  const { closeCollectionRunner, closeCollectionSettings, openCommandPalette, closeCommandPalette } =
-    useViewActions();
+  const {
+    closeCollectionRunner,
+    closeCollectionSettings,
+    openCommandPalette,
+    closeCommandPalette,
+  } = useViewActions();
 
   useHotkeys([{ keys: 'mod+k', handler: openCommandPalette }]);
 

--- a/src/renderer/components/commandPalette/CommandPalette.test.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { CommandPalette } from './CommandPalette';
+import { RequestMethod } from 'shim/objects/request-method';
+import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
+import { Folder } from 'shim/objects/folder';
+
+const setSelectedRequestMock = vi.fn();
+
+const makeRequest = (id: string, parentId: string, title: string, method: RequestMethod) =>
+  ({
+    id,
+    parentId,
+    type: 'request',
+    title,
+    lastModified: 0,
+    url: { base: 'http://localhost', query: [] },
+    method,
+    headers: [],
+    body: { type: RequestBodyType.TEXT, mimeType: 'text/plain' },
+    draft: false,
+  }) as unknown as TrufosRequest;
+
+const makeFolder = (id: string, title: string, children: TrufosRequest[]) =>
+  ({
+    id,
+    parentId: 'col-1',
+    type: 'folder',
+    title,
+    lastModified: 0,
+    children,
+  }) as unknown as Folder;
+
+// Mutable so each describe block can install its own fixture — CommandPalette now reads both
+// `collection` and `folders` from the store (see Task 13's follow-up fix).
+let mockCollection: unknown;
+let mockFolders: Map<string, Folder>;
+
+vi.mock('@/state/collectionStore', () => ({
+  useCollectionStore: <T,>(selector: (state: unknown) => T) =>
+    selector({ collection: mockCollection, folders: mockFolders, selectedRequestId: undefined }),
+  useCollectionActions: () => ({
+    setSelectedRequest: setSelectedRequestMock,
+    addNewRequest: vi.fn(),
+    updateRequest: vi.fn(),
+    discardChanges: vi.fn(),
+    addNewFolder: vi.fn(),
+  }),
+  selectRequest: () => undefined,
+}));
+
+vi.mock('@/state/environmentStore', () => ({
+  useEnvironmentStore: <T,>(selector: (state: unknown) => T) =>
+    selector({ environments: {}, selectedEnvironment: undefined }),
+  useEnvironmentActions: () => ({ selectEnvironment: vi.fn() }),
+  selectEnvironments: (state: { environments: unknown }) => state.environments,
+  selectSelectedEnvironment: (state: { selectedEnvironment: unknown }) => state.selectedEnvironment,
+}));
+
+vi.mock('@/state/responseStore', () => ({
+  useResponseActions: () => ({ addResponse: vi.fn() }),
+}));
+
+vi.mock('@/state/viewStore', () => ({
+  useViewActions: () => ({ openCollectionSettings: vi.fn(), openAppSettings: vi.fn() }),
+}));
+
+describe('CommandPalette nested request title collision (Task 13, cmdk value fix)', () => {
+  // Two requests in different folders share the title "Get" but have different methods —
+  // this is the collision that reproduces the cmdk keyboard-selection mismatch.
+  const requestUsersGet = makeRequest('req-users-get', 'folder-users', 'Get', RequestMethod.GET);
+  const requestPostsGet = makeRequest(
+    'req-posts-get',
+    'folder-posts',
+    'Get',
+    RequestMethod.DELETE
+  );
+  const folderUsers = makeFolder('folder-users', 'Users', [requestUsersGet]);
+  const folderPosts = makeFolder('folder-posts', 'Posts', [requestPostsGet]);
+
+  beforeEach(() => {
+    setSelectedRequestMock.mockClear();
+    mockCollection = {
+      id: 'col-1',
+      title: 'Test Collection',
+      type: 'collection',
+      children: [folderUsers, folderPosts],
+    };
+    mockFolders = new Map([
+      ['folder-users', folderUsers],
+      ['folder-posts', folderPosts],
+    ]);
+  });
+
+  it('selects the correct request when navigating to a nested request whose title collides with another', async () => {
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('tab', { name: /requests/i }));
+
+    // Two rows render, both titled "Get" — one under Users (GET), one under Posts (DELETE).
+    const rows = screen.getAllByRole('option');
+    expect(rows).toHaveLength(2);
+
+    const input = screen.getByPlaceholderText('Search...');
+    // cmdk selects the first item by default; move the highlight to the second "Get" row,
+    // then confirm with Enter — this is the exact sequence that misfired pre-fix.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(setSelectedRequestMock).toHaveBeenCalledWith(requestPostsGet.id);
+  });
+
+  it('still matches nested requests by title when searching, despite the value now being the id', async () => {
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('tab', { name: /requests/i }));
+    await user.type(screen.getByPlaceholderText('Search...'), 'Get');
+
+    expect(screen.queryByText('No requests found.')).toBeNull();
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+  });
+});
+
+describe('CommandPalette nested folder state staleness (Task 13, folders Map fix)', () => {
+  // Simulates the exact post-`updateRequest` divergence confirmed via a real Immer test:
+  // `collection.children`'s embedded tree still holds the OLD child (immer never touches
+  // `state.collection` when a mutation only goes through `state.folders.get(parentId)`), while
+  // the separate `folders` Map holds the NEW, correctly-updated child. A restart resyncs both
+  // from the same source, which is why this only reproduces mid-session.
+  const staleExport = makeRequest('req-export', 'folder-reports', 'Export', RequestMethod.GET);
+  const freshExport = makeRequest('req-export', 'folder-reports', 'Export', RequestMethod.DELETE);
+  const staleFolderInTree = makeFolder('folder-reports', 'Reports', [staleExport]);
+  const freshFolderInMap = makeFolder('folder-reports', 'Reports', [freshExport]);
+
+  beforeEach(() => {
+    setSelectedRequestMock.mockClear();
+    mockCollection = {
+      id: 'col-1',
+      title: 'Test Collection',
+      type: 'collection',
+      children: [staleFolderInTree],
+    };
+    mockFolders = new Map([['folder-reports', freshFolderInMap]]);
+  });
+
+  it('shows the fresh method from the folders Map, not the stale embedded tree', async () => {
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('tab', { name: /requests/i }));
+
+    expect(screen.getByText('DELETE')).toBeDefined();
+    expect(screen.queryByText('GET')).toBeNull();
+  });
+});

--- a/src/renderer/components/commandPalette/CommandPalette.test.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { CommandPalette } from './CommandPalette';
@@ -7,6 +7,10 @@ import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { Folder } from 'shim/objects/folder';
 
 const setSelectedRequestMock = vi.fn();
+const addNewRequestMock = vi.fn();
+const discardChangesMock = vi.fn();
+const sendRequestMock = vi.fn();
+const saveRequestMock = vi.fn();
 
 const makeRequest = (id: string, parentId: string, title: string, method: RequestMethod) =>
   ({
@@ -36,18 +40,21 @@ const makeFolder = (id: string, title: string, children: TrufosRequest[]) =>
 // `collection` and `folders` from the store (see Task 13's follow-up fix).
 let mockCollection: unknown;
 let mockFolders: Map<string, Folder>;
+// Mutable so tests can toggle presence/`draft` state for the I3/I12/I13 hotkey-guard assertions
+// (Task 19) — was a hardcoded `() => undefined` before.
+let mockCurrentRequest: TrufosRequest | undefined;
 
 vi.mock('@/state/collectionStore', () => ({
   useCollectionStore: <T,>(selector: (state: unknown) => T) =>
     selector({ collection: mockCollection, folders: mockFolders, selectedRequestId: undefined }),
   useCollectionActions: () => ({
     setSelectedRequest: setSelectedRequestMock,
-    addNewRequest: vi.fn(),
+    addNewRequest: addNewRequestMock,
     updateRequest: vi.fn(),
-    discardChanges: vi.fn(),
+    discardChanges: discardChangesMock,
     addNewFolder: vi.fn(),
   }),
-  selectRequest: () => undefined,
+  selectRequest: () => mockCurrentRequest,
 }));
 
 vi.mock('@/state/environmentStore', () => ({
@@ -64,6 +71,13 @@ vi.mock('@/state/responseStore', () => ({
 
 vi.mock('@/state/viewStore', () => ({
   useViewActions: () => ({ openCollectionSettings: vi.fn(), openAppSettings: vi.fn() }),
+}));
+
+// Real @/hooks/hotKeys/useHotkey is used (not mocked) so tests exercise the actual window
+// keydown/capture/enabled wiring — only the request-side-effect hooks are stubbed here.
+vi.mock('@/hooks/request/useRequestActions', () => ({
+  useSendRequest: () => ({ sendRequest: sendRequestMock, isSending: false }),
+  useSaveRequest: () => ({ saveRequest: saveRequestMock, isSaving: false }),
 }));
 
 describe('CommandPalette nested request title collision (Task 13, cmdk value fix)', () => {
@@ -149,5 +163,90 @@ describe('CommandPalette nested folder state staleness (Task 13, folders Map fix
 
     expect(screen.getByText('DELETE')).toBeDefined();
     expect(screen.queryByText('GET')).toBeNull();
+  });
+});
+
+describe('CommandPalette owns Send/Save/New-request hotkeys while open (Task 19, I12/I13)', () => {
+  const dispatchKeyDown = (init: KeyboardEventInit) =>
+    window.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+
+  beforeEach(() => {
+    setSelectedRequestMock.mockClear();
+    addNewRequestMock.mockClear();
+    discardChangesMock.mockClear();
+    sendRequestMock.mockClear().mockResolvedValue(undefined);
+    saveRequestMock.mockClear().mockResolvedValue(undefined);
+    mockCollection = { id: 'col-1', title: 'Test Collection', type: 'collection', children: [] };
+    mockFolders = new Map();
+    mockCurrentRequest = undefined;
+  });
+
+  it('mod+enter sends the current request and closes the palette (I12)', async () => {
+    mockCurrentRequest = makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET);
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} />);
+
+    dispatchKeyDown({ key: 'Enter', metaKey: true });
+
+    await waitFor(() => expect(sendRequestMock).toHaveBeenCalled());
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('mod+enter does nothing when there is no current request (I3/I12)', () => {
+    mockCurrentRequest = undefined;
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} />);
+
+    dispatchKeyDown({ key: 'Enter', metaKey: true });
+
+    expect(sendRequestMock).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('mod+s saves the current request and closes the palette when there is a draft (I12)', async () => {
+    mockCurrentRequest = { ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET), draft: true };
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} />);
+
+    dispatchKeyDown({ key: 's', metaKey: true });
+
+    await waitFor(() => expect(saveRequestMock).toHaveBeenCalled());
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('mod+s does nothing when there is no draft to save (I3/I12)', () => {
+    mockCurrentRequest = { ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET), draft: false };
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} />);
+
+    dispatchKeyDown({ key: 's', metaKey: true });
+
+    expect(saveRequestMock).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('mod+n creates a new request and closes the palette (I12)', () => {
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} />);
+
+    dispatchKeyDown({ key: 'n', metaKey: true });
+
+    expect(addNewRequestMock).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('does not own its hotkeys while closed, so nothing fires (I13)', () => {
+    mockCurrentRequest = { ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET), draft: true };
+    const onClose = vi.fn();
+    render(<CommandPalette open={false} onClose={onClose} />);
+
+    dispatchKeyDown({ key: 'Enter', metaKey: true });
+    dispatchKeyDown({ key: 's', metaKey: true });
+    dispatchKeyDown({ key: 'n', metaKey: true });
+
+    expect(sendRequestMock).not.toHaveBeenCalled();
+    expect(saveRequestMock).not.toHaveBeenCalled();
+    expect(addNewRequestMock).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/components/commandPalette/CommandPalette.test.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { CommandPalette } from './CommandPalette';
@@ -248,5 +248,73 @@ describe('CommandPalette owns Send/Save/New-request hotkeys while open (Task 19,
     expect(saveRequestMock).not.toHaveBeenCalled();
     expect(addNewRequestMock).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe('CommandPalette tab-strip cycling via keyboard (Task 20 migration onto useHotkeys, I4)', () => {
+  // Wrapped in act() (unlike the raw window.dispatchEvent used elsewhere in this file) because
+  // these assertions read the re-rendered DOM (which tab is active), not just whether a mock was
+  // called — a native (non-React-synthetic) event handler's setState needs an explicit act() flush
+  // before the DOM reflects it in a synchronous assertion.
+  const dispatchKeyDown = (init: KeyboardEventInit) =>
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+    });
+
+  const activeTabName = () => screen.getByRole('tab', { selected: true }).textContent ?? '';
+
+  beforeEach(() => {
+    mockCollection = { id: 'col-1', title: 'Test Collection', type: 'collection', children: [] };
+    mockFolders = new Map();
+    mockCurrentRequest = undefined;
+  });
+
+  it('Tab and ArrowRight cycle forward through All -> Requests -> Environments -> Actions and wrap', () => {
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+
+    expect(activeTabName()).toMatch(/all/i);
+
+    dispatchKeyDown({ key: 'Tab' });
+    expect(activeTabName()).toMatch(/requests/i);
+
+    dispatchKeyDown({ key: 'ArrowRight' });
+    expect(activeTabName()).toMatch(/environments/i);
+
+    dispatchKeyDown({ key: 'Tab' });
+    expect(activeTabName()).toMatch(/actions/i);
+
+    dispatchKeyDown({ key: 'ArrowRight' });
+    expect(activeTabName()).toMatch(/all/i); // wraps back to the first tab
+  });
+
+  it('Shift+Tab and ArrowLeft cycle backward and wrap at the start', () => {
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+
+    expect(activeTabName()).toMatch(/all/i);
+
+    dispatchKeyDown({ key: 'Tab', shiftKey: true });
+    expect(activeTabName()).toMatch(/actions/i); // wraps back to the last tab
+
+    dispatchKeyDown({ key: 'ArrowLeft' });
+    expect(activeTabName()).toMatch(/environments/i);
+  });
+
+  it('plain Tab does not also trigger the Shift+Tab handler, and vice versa (I14)', () => {
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+
+    dispatchKeyDown({ key: 'Tab', shiftKey: true });
+    expect(activeTabName()).toMatch(/actions/i); // backward from 'all' wraps to 'actions'
+
+    dispatchKeyDown({ key: 'Tab' });
+    expect(activeTabName()).toMatch(/all/i); // forward from 'actions' wraps to 'all'
+  });
+
+  it('does not cycle tabs while closed', () => {
+    render(<CommandPalette open={false} onClose={vi.fn()} />);
+
+    dispatchKeyDown({ key: 'Tab' });
+    dispatchKeyDown({ key: 'ArrowRight' });
+
+    expect(screen.queryByRole('tab')).toBeNull();
   });
 });

--- a/src/renderer/components/commandPalette/CommandPalette.test.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.test.tsx
@@ -37,11 +37,11 @@ const makeFolder = (id: string, title: string, children: TrufosRequest[]) =>
   }) as unknown as Folder;
 
 // Mutable so each describe block can install its own fixture — CommandPalette now reads both
-// `collection` and `folders` from the store (see Task 13's follow-up fix).
+// `collection` and `folders` from the store.
 let mockCollection: unknown;
 let mockFolders: Map<string, Folder>;
-// Mutable so tests can toggle presence/`draft` state for the I3/I12/I13 hotkey-guard assertions
-// (Task 19) — was a hardcoded `() => undefined` before.
+// Mutable so tests can toggle presence/`draft` state for the hotkey-guard assertions below — was
+// a hardcoded `() => undefined` before.
 let mockCurrentRequest: TrufosRequest | undefined;
 
 vi.mock('@/state/collectionStore', () => ({
@@ -80,7 +80,7 @@ vi.mock('@/hooks/request/useRequestActions', () => ({
   useSaveRequest: () => ({ saveRequest: saveRequestMock, isSaving: false }),
 }));
 
-describe('CommandPalette nested request title collision (Task 13, cmdk value fix)', () => {
+describe('CommandPalette nested request title collision (cmdk value fix)', () => {
   // Two requests in different folders share the title "Get" but have different methods —
   // this is the collision that reproduces the cmdk keyboard-selection mismatch.
   const requestUsersGet = makeRequest('req-users-get', 'folder-users', 'Get', RequestMethod.GET);
@@ -133,7 +133,7 @@ describe('CommandPalette nested request title collision (Task 13, cmdk value fix
   });
 });
 
-describe('CommandPalette nested folder state staleness (Task 13, folders Map fix)', () => {
+describe('CommandPalette nested folder state staleness (folders Map fix)', () => {
   // Simulates the exact post-`updateRequest` divergence confirmed via a real Immer test:
   // `collection.children`'s embedded tree still holds the OLD child (immer never touches
   // `state.collection` when a mutation only goes through `state.folders.get(parentId)`), while
@@ -166,7 +166,7 @@ describe('CommandPalette nested folder state staleness (Task 13, folders Map fix
   });
 });
 
-describe('CommandPalette owns Send/Save/New-request hotkeys while open (Task 19, I12/I13)', () => {
+describe('CommandPalette owns Send/Save/New-request hotkeys while open', () => {
   const dispatchKeyDown = (init: KeyboardEventInit) =>
     window.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
 
@@ -181,7 +181,7 @@ describe('CommandPalette owns Send/Save/New-request hotkeys while open (Task 19,
     mockCurrentRequest = undefined;
   });
 
-  it('mod+enter sends the current request and closes the palette (I12)', async () => {
+  it('mod+enter sends the current request and closes the palette', async () => {
     mockCurrentRequest = makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET);
     const onClose = vi.fn();
     render(<CommandPalette open={true} onClose={onClose} />);
@@ -192,7 +192,7 @@ describe('CommandPalette owns Send/Save/New-request hotkeys while open (Task 19,
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
-  it('mod+enter does nothing when there is no current request (I3/I12)', () => {
+  it('mod+enter does nothing when there is no current request', () => {
     mockCurrentRequest = undefined;
     const onClose = vi.fn();
     render(<CommandPalette open={true} onClose={onClose} />);
@@ -203,7 +203,7 @@ describe('CommandPalette owns Send/Save/New-request hotkeys while open (Task 19,
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it('mod+s saves the current request and closes the palette when there is a draft (I12)', async () => {
+  it('mod+s saves the current request and closes the palette when there is a draft', async () => {
     mockCurrentRequest = { ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET), draft: true };
     const onClose = vi.fn();
     render(<CommandPalette open={true} onClose={onClose} />);
@@ -214,7 +214,7 @@ describe('CommandPalette owns Send/Save/New-request hotkeys while open (Task 19,
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
-  it('mod+s does nothing when there is no draft to save (I3/I12)', () => {
+  it('mod+s does nothing when there is no draft to save', () => {
     mockCurrentRequest = { ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET), draft: false };
     const onClose = vi.fn();
     render(<CommandPalette open={true} onClose={onClose} />);
@@ -225,7 +225,7 @@ describe('CommandPalette owns Send/Save/New-request hotkeys while open (Task 19,
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it('mod+n creates a new request and closes the palette (I12)', () => {
+  it('mod+n creates a new request and closes the palette', () => {
     const onClose = vi.fn();
     render(<CommandPalette open={true} onClose={onClose} />);
 
@@ -235,7 +235,7 @@ describe('CommandPalette owns Send/Save/New-request hotkeys while open (Task 19,
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('does not own its hotkeys while closed, so nothing fires (I13)', () => {
+  it('does not own its hotkeys while closed, so nothing fires', () => {
     mockCurrentRequest = { ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET), draft: true };
     const onClose = vi.fn();
     render(<CommandPalette open={false} onClose={onClose} />);
@@ -251,7 +251,7 @@ describe('CommandPalette owns Send/Save/New-request hotkeys while open (Task 19,
   });
 });
 
-describe('CommandPalette tab-strip cycling via keyboard (Task 20 migration onto useHotkeys, I4)', () => {
+describe('CommandPalette tab-strip cycling via keyboard', () => {
   // Wrapped in act() (unlike the raw window.dispatchEvent used elsewhere in this file) because
   // these assertions read the re-rendered DOM (which tab is active), not just whether a mock was
   // called — a native (non-React-synthetic) event handler's setState needs an explicit act() flush
@@ -299,7 +299,7 @@ describe('CommandPalette tab-strip cycling via keyboard (Task 20 migration onto 
     expect(activeTabName()).toMatch(/environments/i);
   });
 
-  it('plain Tab does not also trigger the Shift+Tab handler, and vice versa (I14)', () => {
+  it('plain Tab does not also trigger the Shift+Tab handler, and vice versa', () => {
     render(<CommandPalette open={true} onClose={vi.fn()} />);
 
     dispatchKeyDown({ key: 'Tab', shiftKey: true });

--- a/src/renderer/components/commandPalette/CommandPalette.test.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.test.tsx
@@ -7,10 +7,10 @@ import { RequestBodyType, TrufosRequest } from 'shim/objects/request';
 import { Folder } from 'shim/objects/folder';
 
 const setSelectedRequestMock = vi.fn();
-const addNewRequestMock = vi.fn();
 const discardChangesMock = vi.fn();
 const sendRequestMock = vi.fn();
 const saveRequestMock = vi.fn();
+const requestCreateItemMock = vi.fn();
 
 const makeRequest = (id: string, parentId: string, title: string, method: RequestMethod) =>
   ({
@@ -49,7 +49,6 @@ vi.mock('@/state/collectionStore', () => ({
     selector({ collection: mockCollection, folders: mockFolders, selectedRequestId: undefined }),
   useCollectionActions: () => ({
     setSelectedRequest: setSelectedRequestMock,
-    addNewRequest: addNewRequestMock,
     updateRequest: vi.fn(),
     discardChanges: discardChangesMock,
     addNewFolder: vi.fn(),
@@ -70,7 +69,11 @@ vi.mock('@/state/responseStore', () => ({
 }));
 
 vi.mock('@/state/viewStore', () => ({
-  useViewActions: () => ({ openCollectionSettings: vi.fn(), openAppSettings: vi.fn() }),
+  useViewActions: () => ({
+    openCollectionSettings: vi.fn(),
+    openAppSettings: vi.fn(),
+    requestCreateItem: requestCreateItemMock,
+  }),
 }));
 
 // Real @/hooks/hotKeys/useHotkey is used (not mocked) so tests exercise the actual window
@@ -168,11 +171,13 @@ describe('CommandPalette nested folder state staleness (folders Map fix)', () =>
 
 describe('CommandPalette owns Send/Save/New-request hotkeys while open', () => {
   const dispatchKeyDown = (init: KeyboardEventInit) =>
-    window.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init })
+    );
 
   beforeEach(() => {
     setSelectedRequestMock.mockClear();
-    addNewRequestMock.mockClear();
+    requestCreateItemMock.mockClear();
     discardChangesMock.mockClear();
     sendRequestMock.mockClear().mockResolvedValue(undefined);
     saveRequestMock.mockClear().mockResolvedValue(undefined);
@@ -204,7 +209,10 @@ describe('CommandPalette owns Send/Save/New-request hotkeys while open', () => {
   });
 
   it('mod+s saves the current request and closes the palette when there is a draft', async () => {
-    mockCurrentRequest = { ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET), draft: true };
+    mockCurrentRequest = {
+      ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET),
+      draft: true,
+    };
     const onClose = vi.fn();
     render(<CommandPalette open={true} onClose={onClose} />);
 
@@ -215,7 +223,10 @@ describe('CommandPalette owns Send/Save/New-request hotkeys while open', () => {
   });
 
   it('mod+s does nothing when there is no draft to save', () => {
-    mockCurrentRequest = { ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET), draft: false };
+    mockCurrentRequest = {
+      ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET),
+      draft: false,
+    };
     const onClose = vi.fn();
     render(<CommandPalette open={true} onClose={onClose} />);
 
@@ -225,18 +236,44 @@ describe('CommandPalette owns Send/Save/New-request hotkeys while open', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it('mod+n creates a new request and closes the palette', () => {
+  it('mod+n requests the sidebar inline-create flow for a request at the collection root and closes the palette', () => {
     const onClose = vi.fn();
     render(<CommandPalette open={true} onClose={onClose} />);
 
     dispatchKeyDown({ key: 'n', metaKey: true });
 
-    expect(addNewRequestMock).toHaveBeenCalled();
+    expect(requestCreateItemMock).toHaveBeenCalledWith({ type: 'request', parentId: 'col-1' });
     expect(onClose).toHaveBeenCalled();
   });
 
+  it('clicking "New request" in the Actions tab requests the sidebar inline-create flow and closes the palette', async () => {
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('tab', { name: /actions/i }));
+    await user.click(screen.getByText('New request'));
+
+    expect(requestCreateItemMock).toHaveBeenCalledWith({ type: 'request', parentId: 'col-1' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('mod+n does nothing when there is no collection loaded', () => {
+    mockCollection = null;
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} />);
+
+    dispatchKeyDown({ key: 'n', metaKey: true });
+
+    expect(requestCreateItemMock).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it('does not own its hotkeys while closed, so nothing fires', () => {
-    mockCurrentRequest = { ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET), draft: true };
+    mockCurrentRequest = {
+      ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET),
+      draft: true,
+    };
     const onClose = vi.fn();
     render(<CommandPalette open={false} onClose={onClose} />);
 
@@ -246,7 +283,7 @@ describe('CommandPalette owns Send/Save/New-request hotkeys while open', () => {
 
     expect(sendRequestMock).not.toHaveBeenCalled();
     expect(saveRequestMock).not.toHaveBeenCalled();
-    expect(addNewRequestMock).not.toHaveBeenCalled();
+    expect(requestCreateItemMock).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
   });
 });
@@ -258,7 +295,9 @@ describe('CommandPalette tab-strip cycling via keyboard', () => {
   // before the DOM reflects it in a synchronous assertion.
   const dispatchKeyDown = (init: KeyboardEventInit) =>
     act(() => {
-      window.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init })
+      );
     });
 
   const activeTabName = () => screen.getByRole('tab', { selected: true }).textContent ?? '';

--- a/src/renderer/components/commandPalette/CommandPalette.test.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.test.tsx
@@ -269,6 +269,47 @@ describe('CommandPalette owns Send/Save/New-request hotkeys while open', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it('closes immediately on mod+enter without waiting for sendRequest to resolve', () => {
+    mockCurrentRequest = makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET);
+    let resolveSend: () => void = () => {};
+    sendRequestMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSend = resolve;
+        })
+    );
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} />);
+
+    dispatchKeyDown({ key: 'Enter', metaKey: true });
+
+    expect(sendRequestMock).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled(); // already closed, the send promise below is still pending
+    resolveSend();
+  });
+
+  it('closes immediately on mod+s without waiting for saveRequest to resolve', () => {
+    mockCurrentRequest = {
+      ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET),
+      draft: true,
+    };
+    let resolveSave: () => void = () => {};
+    saveRequestMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        })
+    );
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} />);
+
+    dispatchKeyDown({ key: 's', metaKey: true });
+
+    expect(saveRequestMock).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled(); // already closed, the save promise below is still pending
+    resolveSave();
+  });
+
   it('does not own its hotkeys while closed, so nothing fires', () => {
     mockCurrentRequest = {
       ...makeRequest('req-1', 'col-1', 'Req', RequestMethod.GET),

--- a/src/renderer/components/commandPalette/CommandPalette.test.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.test.tsx
@@ -70,12 +70,7 @@ describe('CommandPalette nested request title collision (Task 13, cmdk value fix
   // Two requests in different folders share the title "Get" but have different methods —
   // this is the collision that reproduces the cmdk keyboard-selection mismatch.
   const requestUsersGet = makeRequest('req-users-get', 'folder-users', 'Get', RequestMethod.GET);
-  const requestPostsGet = makeRequest(
-    'req-posts-get',
-    'folder-posts',
-    'Get',
-    RequestMethod.DELETE
-  );
+  const requestPostsGet = makeRequest('req-posts-get', 'folder-posts', 'Get', RequestMethod.DELETE);
   const folderUsers = makeFolder('folder-users', 'Users', [requestUsersGet]);
   const folderPosts = makeFolder('folder-posts', 'Posts', [requestPostsGet]);
 

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -91,7 +91,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
 
   const { addResponse } = useResponseActions();
 
-  const { openCollectionSettings } = useViewActions();
+  const { openCollectionSettings, openAppSettings } = useViewActions();
 
   // Reset state when opened
   useEffect(() => {
@@ -285,6 +285,15 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                       >
                         <SettingsIcon className="shrink-0" />
                         <span>Collection settings</span>
+                      </CommandItem>
+                    </CommandGroup>
+
+                    <CommandSeparator />
+
+                    <CommandGroup heading="Trufos">
+                      <CommandItem value="settings" onSelect={() => runAndClose(openAppSettings)}>
+                        <SettingsIcon className="shrink-0" />
+                        <span>Settings</span>
                       </CommandItem>
                     </CommandGroup>
                   </CommandList>

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -1,5 +1,13 @@
 import { Fragment, useCallback, useEffect, useRef, useState, KeyboardEvent } from 'react';
-import { ArrowRight, Plus, Save } from 'lucide-react';
+import {
+  ArrowRight,
+  EraserIcon,
+  FolderPlusIcon,
+  Plus,
+  Save,
+  SettingsIcon,
+  SwitchCameraIcon,
+} from 'lucide-react';
 import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
 import { editor } from 'monaco-editor';
@@ -23,6 +31,7 @@ import {
   useEnvironmentStore,
 } from '@/state/environmentStore';
 import { useResponseActions } from '@/state/responseStore';
+import { useViewActions } from '@/state/viewStore';
 import { HttpService } from '@/services/http/http-service';
 import { RendererEventService } from '@/services/event/renderer-event-service';
 import { saveModelContent } from '@/lib/monaco/models';
@@ -73,13 +82,16 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const collection = useCollectionStore((s) => s.collection);
   const requestGroups = collection ? buildRequestGroups(collection.children) : [];
   const currentRequest = useCollectionStore(selectRequest);
-  const { setSelectedRequest, addNewRequest, updateRequest } = useCollectionActions();
+  const { setSelectedRequest, addNewRequest, updateRequest, discardChanges, addNewFolder } =
+    useCollectionActions();
 
   const environments = useEnvironmentStore(selectEnvironments);
   const selectedEnvironment = useEnvironmentStore(selectSelectedEnvironment);
   const { selectEnvironment } = useEnvironmentActions();
 
   const { addResponse } = useResponseActions();
+
+  const { openCollectionSettings } = useViewActions();
 
   // Reset state when opened
   useEffect(() => {
@@ -239,6 +251,40 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                         <Plus className="shrink-0" />
                         <span>New request</span>
                         <span className="text-muted-foreground ml-auto text-xs">⌘N</span>
+                      </CommandItem>
+                      <CommandItem
+                        value="discard changes"
+                        disabled={!currentRequest?.draft}
+                        onSelect={() => runAndClose(discardChanges)}
+                      >
+                        <EraserIcon className="shrink-0" />
+                        <span>Discard changes</span>
+                      </CommandItem>
+                    </CommandGroup>
+
+                    <CommandSeparator />
+
+                    <CommandGroup heading="Collection">
+                      <CommandItem
+                        value="new folder"
+                        onSelect={() => runAndClose(() => addNewFolder())}
+                      >
+                        <FolderPlusIcon className="shrink-0" />
+                        <span>New folder</span>
+                      </CommandItem>
+                      <CommandItem
+                        value="switch environment"
+                        onSelect={() => setActiveTab('environments')}
+                      >
+                        <SwitchCameraIcon className="shrink-0" />
+                        <span>Switch environment</span>
+                      </CommandItem>
+                      <CommandItem
+                        value="collection settings"
+                        onSelect={() => runAndClose(openCollectionSettings)}
+                      >
+                        <SettingsIcon className="shrink-0" />
+                        <span>Collection settings</span>
                       </CommandItem>
                     </CommandGroup>
                   </CommandList>

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -144,7 +144,9 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                     value={request.title ?? request.url.base}
                     onSelect={() => selectAndClose(request.id)}
                   >
-                    <span className={`shrink-0 text-xs font-normal ${httpMethodColor(request.method)}`}>
+                    <span
+                      className={`shrink-0 text-xs font-normal ${httpMethodColor(request.method)}`}
+                    >
                       {request.method}
                     </span>
                     <span className="truncate">{request.title ?? request.url.base}</span>

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState, KeyboardEvent } from 'react';
-import { ArrowRight, Folder, Globe, Plus, Save, SwitchCamera } from 'lucide-react';
+import { ArrowRight, Folder as FolderIcon, Globe, Plus, Save, SwitchCamera } from 'lucide-react';
+import { Folder } from 'shim/objects/folder';
+import { TrufosRequest } from 'shim/objects/request';
 import { editor } from 'monaco-editor';
 import { Dialog, DialogOverlay, DialogPortal } from '@/components/ui/dialog';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
@@ -30,6 +32,30 @@ import { httpMethodColor } from '@/services/StyleHelper';
 const httpService = HttpService.instance;
 const eventService = RendererEventService.instance;
 
+interface RequestGroup {
+  label: string | null;
+  requests: TrufosRequest[];
+}
+
+/** Walk collection children depth-first, flattening nested folders into a single group per folder. */
+const buildRequestGroups = (
+  children: (Folder | TrufosRequest)[],
+  label: string | null = null
+): RequestGroup[] => {
+  const group: RequestGroup = { label, requests: [] };
+  const subGroups: RequestGroup[] = [];
+
+  for (const child of children) {
+    if (child.type === 'request') {
+      group.requests.push(child);
+    } else {
+      subGroups.push(...buildRequestGroups(child.children, child.title));
+    }
+  }
+
+  return group.requests.length > 0 ? [group, ...subGroups] : subGroups;
+};
+
 const TABS = ['requests', 'collections', 'folders', 'actions'] as const;
 type Tab = (typeof TABS)[number];
 
@@ -43,9 +69,9 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const [search, setSearch] = useState('');
   const tabsRef = useRef<HTMLDivElement>(null);
 
-  const requests = useCollectionStore((s) => s.requests);
   const folders = useCollectionStore((s) => s.folders);
   const collection = useCollectionStore((s) => s.collection);
+  const requestGroups = collection ? buildRequestGroups(collection.children) : [];
   const currentRequest = useCollectionStore(selectRequest);
   const { setSelectedRequest, addNewRequest, updateRequest } = useCollectionActions();
 
@@ -117,126 +143,138 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     },
     [activeTab]
   );
-
+  console.log();
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogPortal>
         <DialogOverlay className="flex items-center justify-center">
           <DialogPrimitive.Content className="bg-background w-full max-w-[600px] overflow-hidden rounded-lg shadow-lg outline-none">
-        <Command shouldFilter={true} onKeyDown={handleKeyDown}>
-          <CommandInput placeholder="Search..." value={search} onValueChange={setSearch} />
-          <Tabs
-            ref={tabsRef}
-            value={activeTab}
-            onValueChange={(v) => setActiveTab(v as Tab)}
-            className="flex flex-col"
-          >
-            <TabsList className="border-b px-2">
-              <TabsTrigger value="requests">Requests</TabsTrigger>
-              <TabsTrigger value="collections">Collections</TabsTrigger>
-              <TabsTrigger value="folders">Folders</TabsTrigger>
-              <TabsTrigger value="actions">Actions</TabsTrigger>
-            </TabsList>
+            <Command shouldFilter={true} onKeyDown={handleKeyDown}>
+              <CommandInput placeholder="Search..." value={search} onValueChange={setSearch} />
+              <Tabs
+                ref={tabsRef}
+                value={activeTab}
+                onValueChange={(v) => setActiveTab(v as Tab)}
+                className="flex flex-col"
+              >
+                <TabsList className="border-b px-2">
+                  <TabsTrigger value="requests">Requests</TabsTrigger>
+                  <TabsTrigger value="collections">Collections</TabsTrigger>
+                  <TabsTrigger value="folders">Folders</TabsTrigger>
+                  <TabsTrigger value="actions">Actions</TabsTrigger>
+                </TabsList>
 
-            <TabsContent value="requests">
-              <CommandList>
-                <CommandEmpty>No requests found.</CommandEmpty>
-                {Array.from(requests.values()).map((request) => (
-                  <CommandItem
-                    key={request.id}
-                    value={request.title ?? request.url.base}
-                    onSelect={() => selectAndClose(request.id)}
-                  >
-                    <span
-                      className={`shrink-0 text-xs font-normal ${httpMethodColor(request.method)}`}
-                    >
-                      {request.method}
-                    </span>
-                    <span className="truncate">{request.title ?? request.url.base}</span>
-                  </CommandItem>
-                ))}
-              </CommandList>
-            </TabsContent>
-
-            <TabsContent value="collections">
-              <CommandList>
-                <CommandEmpty>No collections found.</CommandEmpty>
-                {collection != null && (
-                  <CommandItem key={collection.id} value={collection.title}>
-                    <Globe className="shrink-0" />
-                    <span className="truncate">{collection.title}</span>
-                  </CommandItem>
-                )}
-              </CommandList>
-            </TabsContent>
-
-            <TabsContent value="folders">
-              <CommandList>
-                <CommandEmpty>No folders found.</CommandEmpty>
-                {Array.from(folders.values()).map((folder) => (
-                  <CommandItem key={folder.id} value={folder.title}>
-                    <Folder className="shrink-0" />
-                    <span className="truncate">{folder.title}</span>
-                  </CommandItem>
-                ))}
-              </CommandList>
-            </TabsContent>
-
-            <TabsContent value="actions">
-              <CommandList>
-                <CommandEmpty>No actions available.</CommandEmpty>
-                <CommandGroup heading="Request">
-                  <CommandItem
-                    value="send request"
-                    disabled={currentRequest == null}
-                    onSelect={handleSend}
-                  >
-                    <ArrowRight className="shrink-0" />
-                    <span>Send request</span>
-                    <span className="text-muted-foreground ml-auto text-xs">⌘↵</span>
-                  </CommandItem>
-                  <CommandItem
-                    value="save request"
-                    disabled={currentRequest == null}
-                    onSelect={handleSave}
-                  >
-                    <Save className="shrink-0" />
-                    <span>Save request</span>
-                    <span className="text-muted-foreground ml-auto text-xs">⌘S</span>
-                  </CommandItem>
-                  <CommandItem
-                    value="new request"
-                    onSelect={() => runAndClose(() => addNewRequest())}
-                  >
-                    <Plus className="shrink-0" />
-                    <span>New request</span>
-                    <span className="text-muted-foreground ml-auto text-xs">⌘N</span>
-                  </CommandItem>
-                </CommandGroup>
-                {Object.keys(environments).length > 0 && (
-                  <>
-                    <CommandSeparator />
-                    <CommandGroup heading="Switch environment">
-                      {Object.keys(environments).map((key) => (
-                        <CommandItem
-                          key={key}
-                          value={`switch environment ${key}`}
-                          onSelect={() => runAndClose(() => selectEnvironment(key))}
+                <TabsContent value="requests">
+                  <CommandList>
+                    <CommandEmpty>No requests found.</CommandEmpty>
+                    {requestGroups.map((group, i) => (
+                      <>
+                        {i > 0 && <CommandSeparator key={`sep-${i}`} />}
+                        <CommandGroup
+                          key={group.label ?? '__root__'}
+                          heading={group.label ?? `${collection?.title} root`}
                         >
-                          <SwitchCamera className="shrink-0" />
-                          <span>{key}</span>
-                          {selectedEnvironment === key && (
-                            <span className="text-muted-foreground ml-auto text-xs">active</span>
-                          )}
-                        </CommandItem>
-                      ))}
+                          {group.requests.map((request) => (
+                            <CommandItem
+                              key={request.id}
+                              value={request.title ?? request.url.base}
+                              onSelect={() => selectAndClose(request.id)}
+                            >
+                              <span
+                                className={`shrink-0 text-xs font-normal ${httpMethodColor(request.method)}`}
+                              >
+                                {request.method}
+                              </span>
+                              <span className="truncate">{request.title ?? request.url.base}</span>
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      </>
+                    ))}
+                  </CommandList>
+                </TabsContent>
+
+                <TabsContent value="collections">
+                  <CommandList>
+                    <CommandEmpty>No collections found.</CommandEmpty>
+                    {collection != null && (
+                      <CommandItem key={collection.id} value={collection.title}>
+                        <Globe className="shrink-0" />
+                        <span className="truncate">{collection.title}</span>
+                      </CommandItem>
+                    )}
+                  </CommandList>
+                </TabsContent>
+
+                <TabsContent value="folders">
+                  <CommandList>
+                    <CommandEmpty>No folders found.</CommandEmpty>
+                    {Array.from(folders.values()).map((folder) => (
+                      <CommandItem key={folder.id} value={folder.title}>
+                        <FolderIcon className="shrink-0" />
+                        <span className="truncate">{folder.title}</span>
+                      </CommandItem>
+                    ))}
+                  </CommandList>
+                </TabsContent>
+
+                <TabsContent value="actions">
+                  <CommandList>
+                    <CommandEmpty>No actions available.</CommandEmpty>
+                    <CommandGroup heading="Request">
+                      <CommandItem
+                        value="send request"
+                        disabled={currentRequest == null}
+                        onSelect={handleSend}
+                      >
+                        <ArrowRight className="shrink-0" />
+                        <span>Send request</span>
+                        <span className="text-muted-foreground ml-auto text-xs">⌘↵</span>
+                      </CommandItem>
+                      <CommandItem
+                        value="save request"
+                        disabled={currentRequest == null}
+                        onSelect={handleSave}
+                      >
+                        <Save className="shrink-0" />
+                        <span>Save request</span>
+                        <span className="text-muted-foreground ml-auto text-xs">⌘S</span>
+                      </CommandItem>
+                      <CommandItem
+                        value="new request"
+                        onSelect={() => runAndClose(() => addNewRequest())}
+                      >
+                        <Plus className="shrink-0" />
+                        <span>New request</span>
+                        <span className="text-muted-foreground ml-auto text-xs">⌘N</span>
+                      </CommandItem>
                     </CommandGroup>
-                  </>
-                )}
-              </CommandList>
-            </TabsContent>
-          </Tabs>
-        </Command>
+                    {Object.keys(environments).length > 0 && (
+                      <>
+                        <CommandSeparator />
+                        <CommandGroup heading="Switch environment">
+                          {Object.keys(environments).map((key) => (
+                            <CommandItem
+                              key={key}
+                              value={`switch environment ${key}`}
+                              onSelect={() => runAndClose(() => selectEnvironment(key))}
+                            >
+                              <SwitchCamera className="shrink-0" />
+                              <span>{key}</span>
+                              {selectedEnvironment === key && (
+                                <span className="text-muted-foreground ml-auto text-xs">
+                                  active
+                                </span>
+                              )}
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      </>
+                    )}
+                  </CommandList>
+                </TabsContent>
+              </Tabs>
+            </Command>
           </DialogPrimitive.Content>
         </DialogOverlay>
       </DialogPortal>

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -136,8 +136,6 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const { setSelectedRequest, addNewRequest, updateRequest, discardChanges, addNewFolder } =
     useCollectionActions();
 
-  console.log('allRequests', allRequests);
-  console.log('collection', collection);
   const environments = useEnvironmentStore(selectEnvironments);
   const selectedEnvironment = useEnvironmentStore(selectSelectedEnvironment);
   const { selectEnvironment } = useEnvironmentActions();

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -103,7 +103,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
 
   // Tab/Shift+Tab and Left/Right arrow key cycling
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
       const currentIndex = TABS.indexOf(activeTab);
 
       if (e.key === 'ArrowRight' || (e.key === 'Tab' && !e.shiftKey)) {
@@ -119,7 +119,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="top-[280px] translate-y-0 overflow-hidden p-0 shadow-lg sm:max-w-[600px]">
+      <DialogContent className="top-70 translate-y-0 overflow-hidden p-0 shadow-lg sm:max-w-150">
         <Command shouldFilter={true} onKeyDown={handleKeyDown}>
           <CommandInput placeholder="Search..." value={search} onValueChange={setSearch} />
           <Tabs

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -154,13 +154,13 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const { sendRequest } = useSendRequest();
   const { saveRequest } = useSaveRequest();
 
-  const handleSend = useCallback(async () => {
-    await sendRequest();
+  const handleSend = useCallback(() => {
+    void sendRequest();
     onClose();
   }, [sendRequest, onClose]);
 
-  const handleSave = useCallback(async () => {
-    await saveRequest();
+  const handleSave = useCallback(() => {
+    void saveRequest();
     onClose();
   }, [saveRequest, onClose]);
 

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -149,7 +149,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogPortal>
         <DialogOverlay className="flex items-center justify-center">
-          <DialogPrimitive.Content className="bg-background w-full max-w-150 overflow-hidden rounded-lg p-4 shadow-lg outline-none">
+          <DialogPrimitive.Content className="bg-background w-full max-w-150 overflow-hidden rounded-lg p-2 shadow-lg outline-none">
             <Command shouldFilter={true} onKeyDown={handleKeyDown}>
               <CommandInput placeholder="Search..." value={search} onValueChange={setSearch} />
 
@@ -168,7 +168,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
 
                 <Divider />
 
-                <TabsContent value="requests" className="bg-transparent">
+                <TabsContent value="requests" className="mt-0 rounded-none bg-transparent">
                   <CommandList>
                     <CommandEmpty>No requests found.</CommandEmpty>
                     {requestGroups.map((group, i) => (

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -1,16 +1,33 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Folder, Globe } from 'lucide-react';
+import { ArrowRight, Folder, Globe, Plus, Save, SwitchCamera } from 'lucide-react';
+import { editor } from 'monaco-editor';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import {
   Command,
   CommandEmpty,
+  CommandGroup,
   CommandInput,
   CommandItem,
   CommandList,
+  CommandSeparator,
 } from '@/components/ui/command';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
+import { selectRequest, useCollectionActions, useCollectionStore } from '@/state/collectionStore';
+import {
+  selectEnvironments,
+  selectSelectedEnvironment,
+  useEnvironmentActions,
+  useEnvironmentStore,
+} from '@/state/environmentStore';
+import { useResponseActions } from '@/state/responseStore';
+import { HttpService } from '@/services/http/http-service';
+import { RendererEventService } from '@/services/event/renderer-event-service';
+import { saveModelContent } from '@/lib/monaco/models';
+import { showError } from '@/error/errorHandler';
 import { httpMethodColor } from '@/services/StyleHelper';
+
+const httpService = HttpService.instance;
+const eventService = RendererEventService.instance;
 
 const TABS = ['requests', 'collections', 'folders', 'actions'] as const;
 type Tab = (typeof TABS)[number];
@@ -28,7 +45,14 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const requests = useCollectionStore((s) => s.requests);
   const folders = useCollectionStore((s) => s.folders);
   const collection = useCollectionStore((s) => s.collection);
-  const { setSelectedRequest } = useCollectionActions();
+  const currentRequest = useCollectionStore(selectRequest);
+  const { setSelectedRequest, addNewRequest, updateRequest } = useCollectionActions();
+
+  const environments = useEnvironmentStore(selectEnvironments);
+  const selectedEnvironment = useEnvironmentStore(selectSelectedEnvironment);
+  const { selectEnvironment } = useEnvironmentActions();
+
+  const { addResponse } = useResponseActions();
 
   // Reset state when opened
   useEffect(() => {
@@ -45,6 +69,37 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     },
     [setSelectedRequest, onClose]
   );
+
+  const runAndClose = useCallback(
+    (action: () => void) => {
+      action();
+      onClose();
+    },
+    [onClose]
+  );
+
+  const handleSend = useCallback(async () => {
+    if (currentRequest == null) return;
+    try {
+      await Promise.all(editor.getModels().map(saveModelContent));
+      const response = await httpService.sendRequest(currentRequest);
+      addResponse(currentRequest.id, response);
+    } catch (error) {
+      showError(error);
+    }
+    onClose();
+  }, [currentRequest, addResponse, onClose]);
+
+  const handleSave = useCallback(async () => {
+    if (currentRequest == null) return;
+    try {
+      await Promise.all(editor.getModels().map(saveModelContent));
+      updateRequest(await eventService.saveChanges(currentRequest), true);
+    } catch (error) {
+      showError(error);
+    }
+    onClose();
+  }, [currentRequest, updateRequest, onClose]);
 
   // Tab/Shift+Tab and Left/Right arrow key cycling
   const handleKeyDown = useCallback(
@@ -125,6 +180,54 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
             <TabsContent value="actions">
               <CommandList>
                 <CommandEmpty>No actions available.</CommandEmpty>
+                <CommandGroup heading="Request">
+                  <CommandItem
+                    value="send request"
+                    disabled={currentRequest == null}
+                    onSelect={handleSend}
+                  >
+                    <ArrowRight className="shrink-0" />
+                    <span>Send request</span>
+                    <span className="text-muted-foreground ml-auto text-xs">⌘↵</span>
+                  </CommandItem>
+                  <CommandItem
+                    value="save request"
+                    disabled={currentRequest == null}
+                    onSelect={handleSave}
+                  >
+                    <Save className="shrink-0" />
+                    <span>Save request</span>
+                    <span className="text-muted-foreground ml-auto text-xs">⌘S</span>
+                  </CommandItem>
+                  <CommandItem
+                    value="new request"
+                    onSelect={() => runAndClose(() => addNewRequest())}
+                  >
+                    <Plus className="shrink-0" />
+                    <span>New request</span>
+                    <span className="text-muted-foreground ml-auto text-xs">⌘N</span>
+                  </CommandItem>
+                </CommandGroup>
+                {Object.keys(environments).length > 0 && (
+                  <>
+                    <CommandSeparator />
+                    <CommandGroup heading="Switch environment">
+                      {Object.keys(environments).map((key) => (
+                        <CommandItem
+                          key={key}
+                          value={`switch environment ${key}`}
+                          onSelect={() => runAndClose(() => selectEnvironment(key))}
+                        >
+                          <SwitchCamera className="shrink-0" />
+                          <span>{key}</span>
+                          {selectedEnvironment === key && (
+                            <span className="text-muted-foreground ml-auto text-xs">active</span>
+                          )}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </>
+                )}
               </CommandList>
             </TabsContent>
           </Tabs>

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -363,7 +363,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                   </CommandList>
                 </TabsContent>
 
-                <TabsContent value="environments">
+                <TabsContent value="environments" className="mt-0 rounded-none bg-transparent">
                   <CommandList>
                     <CommandEmpty>No environments found.</CommandEmpty>
                     {Object.keys(environments).map((key) => (
@@ -381,7 +381,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                   </CommandList>
                 </TabsContent>
 
-                <TabsContent value="actions">
+                <TabsContent value="actions" className="mt-0 rounded-none bg-transparent">
                   <CommandList>
                     <CommandEmpty>No actions available.</CommandEmpty>
                     {ACTION_SECTIONS.map((section, i) => (

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, KeyboardEvent } from 'react';
+import { Fragment, useCallback, useEffect, useRef, useState, KeyboardEvent } from 'react';
 import { ArrowRight, Folder as FolderIcon, Globe, Plus, Save, SwitchCamera } from 'lucide-react';
 import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
@@ -144,7 +144,6 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     },
     [activeTab]
   );
-  console.log();
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogPortal>
@@ -172,12 +171,9 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                   <CommandList>
                     <CommandEmpty>No requests found.</CommandEmpty>
                     {requestGroups.map((group, i) => (
-                      <>
+                      <Fragment key={group.label ?? '__root__'}>
                         {i > 0 && <CommandSeparator key={`sep-${i}`} />}
-                        <CommandGroup
-                          key={group.label ?? '__root__'}
-                          heading={group.label ?? `${collection?.title} root`}
-                        >
+                        <CommandGroup heading={group.label ?? `${collection?.title} root`}>
                           {group.requests.map((request) => (
                             <CommandItem
                               key={request.id}
@@ -193,7 +189,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                             </CommandItem>
                           ))}
                         </CommandGroup>
-                      </>
+                      </Fragment>
                     ))}
                   </CommandList>
                 </TabsContent>

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -59,6 +59,7 @@ const httpService = HttpService.instance;
 const eventService = RendererEventService.instance;
 
 interface RequestGroup {
+  id: string | null;
   label: string | null;
   requests: TrufosRequest[];
 }
@@ -77,19 +78,32 @@ interface ActionItem {
   onSelect: () => void;
 }
 
-/** Walk collection children depth-first, flattening nested folders into a single group per folder. */
+/**
+ * Walk collection children depth-first, flattening nested folders into a single group per folder.
+ *
+ * Reads folder children from the `folders` Map (always up-to-date after `updateRequest`/
+ * `moveItem`/etc.), not the folder object's own embedded `children` — immer may not propagate
+ * Map mutations back into the tree references (same defect and same fix as
+ * `treeUtilities.ts`'s `flattenTree`).
+ */
 const buildRequestGroups = (
   children: (Folder | TrufosRequest)[],
-  label: string | null = null
+  folders: Map<Folder['id'], Folder>,
+  folder: Folder | null = null
 ): RequestGroup[] => {
-  const group: RequestGroup = { label, requests: [] };
+  const group: RequestGroup = {
+    id: folder?.id ?? null,
+    label: folder?.title ?? null,
+    requests: [],
+  };
   const subGroups: RequestGroup[] = [];
 
   for (const child of children) {
     if (child.type === 'request') {
       group.requests.push(child);
     } else {
-      subGroups.push(...buildRequestGroups(child.children, child.title));
+      const liveFolder = folders.get(child.id) ?? child;
+      subGroups.push(...buildRequestGroups(liveFolder.children, folders, liveFolder));
     }
   }
 
@@ -116,12 +130,15 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const tabsRef = useRef<HTMLDivElement>(null);
 
   const collection = useCollectionStore((s) => s.collection);
-  const requestGroups = collection ? buildRequestGroups(collection.children) : [];
+  const folders = useCollectionStore((s) => s.folders);
+  const requestGroups = collection ? buildRequestGroups(collection.children, folders) : [];
   const allRequests = requestGroups.flatMap((group) => group.requests);
   const currentRequest = useCollectionStore(selectRequest);
   const { setSelectedRequest, addNewRequest, updateRequest, discardChanges, addNewFolder } =
     useCollectionActions();
 
+  console.log('allRequests', allRequests);
+  console.log('collection', collection);
   const environments = useEnvironmentStore(selectEnvironments);
   const selectedEnvironment = useEnvironmentStore(selectSelectedEnvironment);
   const { selectEnvironment } = useEnvironmentActions();
@@ -197,7 +214,8 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const renderRequestItem = (request: TrufosRequest) => (
     <CommandItem
       key={request.id}
-      value={request.title ?? request.url.base}
+      value={request.id}
+      keywords={[request.title ?? request.url.base]}
       onSelect={() => selectAndClose(request.id)}
       className="data-[selected='true']:bg-divider col-span-full grid grid-cols-subgrid"
     >
@@ -395,7 +413,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                     <CommandEmpty>No requests found.</CommandEmpty>
                     <div className={REQUEST_LIST_GRID}>
                       {requestGroups.map((group, i) => (
-                        <Fragment key={group.label ?? '__root__'}>
+                        <Fragment key={group.id ?? '__root__'}>
                           {i > 0 && <CommandSeparator key={`sep-${i}`} className="col-span-full" />}
                           <CommandGroup
                             heading={group.label ?? `${collection?.title} root`}

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -14,13 +14,15 @@ import {
   Plus,
   Save,
   SettingsIcon,
-  SwitchCameraIcon,
   type LucideIcon,
   GalleryVerticalEnd,
   Globe,
   SquareSlash,
   Server,
   Command as CommandShortcut,
+  Wrench,
+  SquareMousePointer,
+  HardDrive,
 } from 'lucide-react';
 import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
@@ -177,12 +179,27 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     onClose();
   }, [currentRequest, updateRequest, onClose]);
 
+  const renderEnvironmentItem = (key: string) => (
+    <CommandItem
+      key={key}
+      value={key}
+      onSelect={() => runAndClose(() => selectEnvironment(key))}
+      className="hover:bg-divider"
+    >
+      <HardDrive className="shrink-0" />
+      <span className="truncate">{key}</span>
+      {selectedEnvironment === key && (
+        <span className="text-muted-foreground ml-auto text-xs">active</span>
+      )}
+    </CommandItem>
+  );
+
   const renderRequestItem = (request: TrufosRequest) => (
     <CommandItem
       key={request.id}
       value={request.title ?? request.url.base}
       onSelect={() => selectAndClose(request.id)}
-      className="col-span-full grid grid-cols-subgrid"
+      className="hover:bg-divider col-span-full grid grid-cols-subgrid"
     >
       <div
         className="flex items-center justify-center rounded px-2 py-0.5"
@@ -247,14 +264,14 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     {
       value: 'switch environment',
       section: 'Collection',
-      icon: SwitchCameraIcon,
+      icon: SquareMousePointer,
       label: 'Switch environment',
       onSelect: () => setActiveTab('environments'),
     },
     {
       value: 'collection settings',
       section: 'Collection',
-      icon: SettingsIcon,
+      icon: Wrench,
       label: 'Collection settings',
       onSelect: () => runAndClose(openCollectionSettings),
     },
@@ -341,20 +358,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                           </CommandGroup>
                         </div>
                         <CommandGroup heading="Environments">
-                          {Object.keys(environments).map((key) => (
-                            <CommandItem
-                              key={key}
-                              value={key}
-                              onSelect={() => runAndClose(() => selectEnvironment(key))}
-                            >
-                              <span className="truncate">{key}</span>
-                              {selectedEnvironment === key && (
-                                <span className="text-muted-foreground ml-auto text-xs">
-                                  active
-                                </span>
-                              )}
-                            </CommandItem>
-                          ))}
+                          {Object.keys(environments).map(renderEnvironmentItem)}
                         </CommandGroup>
                         <CommandGroup heading="Actions">
                           {actionItems.map((item) => (
@@ -363,6 +367,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                               value={item.value}
                               disabled={item.disabled}
                               onSelect={item.onSelect}
+                              className="hover:bg-divider"
                             >
                               <item.icon className="shrink-0" />
                               <span>{item.label}</span>
@@ -407,18 +412,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                 <TabsContent value="environments" className="mt-0 rounded-none bg-transparent">
                   <CommandList>
                     <CommandEmpty>No environments found.</CommandEmpty>
-                    {Object.keys(environments).map((key) => (
-                      <CommandItem
-                        key={key}
-                        value={key}
-                        onSelect={() => runAndClose(() => selectEnvironment(key))}
-                      >
-                        <span className="truncate">{key}</span>
-                        {selectedEnvironment === key && (
-                          <span className="text-muted-foreground ml-auto text-xs">active</span>
-                        )}
-                      </CommandItem>
-                    ))}
+                    {Object.keys(environments).map(renderEnvironmentItem)}
                   </CommandList>
                 </TabsContent>
 
@@ -437,6 +431,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                                 value={item.value}
                                 disabled={item.disabled}
                                 onSelect={item.onSelect}
+                                className="hover:bg-divider"
                               >
                                 <item.icon className="shrink-0" />
                                 <span>{item.label}</span>

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -54,6 +54,11 @@ import { saveModelContent } from '@/lib/monaco/models';
 import { showError } from '@/error/errorHandler';
 import { httpMethodColor } from '@/services/StyleHelper';
 import { Divider } from '@/components/shared/Divider';
+import {
+  RequestResultsGrid,
+  RequestCommandGroup,
+  RequestCommandItem,
+} from '@/components/commandPalette/RequestResultsGrid';
 
 const httpService = HttpService.instance;
 const eventService = RendererEventService.instance;
@@ -112,12 +117,6 @@ const buildRequestGroups = (
 
 const TABS = ['all', 'requests', 'environments', 'actions'] as const;
 type Tab = (typeof TABS)[number];
-
-/** 2-column grid ancestor: column 1 (method badge) auto-sizes to the widest method text across every subgridded row. */
-const REQUEST_LIST_GRID = 'grid grid-cols-[auto_1fr]';
-/** Passes the 2 grid tracks down through cmdk's fixed group/heading/items DOM so every request row's columns line up. */
-const REQUEST_GROUP_GRID =
-  'col-span-full grid grid-cols-subgrid **:[[cmdk-group-heading]]:col-span-full **:[[cmdk-group-items]]:col-span-full **:[[cmdk-group-items]]:grid **:[[cmdk-group-items]]:grid-cols-subgrid';
 
 interface CommandPaletteProps {
   open: boolean;
@@ -212,12 +211,11 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   );
 
   const renderRequestItem = (request: TrufosRequest) => (
-    <CommandItem
+    <RequestCommandItem
       key={request.id}
       value={request.id}
       keywords={[request.title ?? request.url.base]}
       onSelect={() => selectAndClose(request.id)}
-      className="data-[selected='true']:bg-divider col-span-full grid grid-cols-subgrid"
     >
       <div
         className="flex items-center justify-center rounded px-2 py-0.5"
@@ -231,7 +229,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       </div>
 
       <span className="truncate">{request.title ?? request.url.base}</span>
-    </CommandItem>
+    </RequestCommandItem>
   );
 
   const actionItems: ActionItem[] = [
@@ -360,21 +358,21 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                   <CommandList>
                     <CommandEmpty>No results found.</CommandEmpty>
                     {search.trim() === '' ? (
-                      <div className={REQUEST_LIST_GRID}>
-                        <CommandGroup heading="Recent" className={REQUEST_GROUP_GRID}>
+                      <RequestResultsGrid>
+                        <RequestCommandGroup heading="Recent">
                           {[...allRequests]
                             .sort((a, b) => b.lastModified - a.lastModified)
                             .slice(0, 5)
                             .map(renderRequestItem)}
-                        </CommandGroup>
-                      </div>
+                        </RequestCommandGroup>
+                      </RequestResultsGrid>
                     ) : (
                       <>
-                        <div className={REQUEST_LIST_GRID}>
-                          <CommandGroup heading="Requests" className={REQUEST_GROUP_GRID}>
+                        <RequestResultsGrid>
+                          <RequestCommandGroup heading="Requests">
                             {allRequests.map(renderRequestItem)}
-                          </CommandGroup>
-                        </div>
+                          </RequestCommandGroup>
+                        </RequestResultsGrid>
                         <CommandGroup heading="Environments">
                           {Object.keys(environments).map(renderEnvironmentItem)}
                         </CommandGroup>
@@ -411,19 +409,16 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                 <TabsContent value="requests" className="mt-0 rounded-none bg-transparent">
                   <CommandList>
                     <CommandEmpty>No requests found.</CommandEmpty>
-                    <div className={REQUEST_LIST_GRID}>
+                    <RequestResultsGrid>
                       {requestGroups.map((group, i) => (
                         <Fragment key={group.id ?? '__root__'}>
                           {i > 0 && <CommandSeparator key={`sep-${i}`} className="col-span-full" />}
-                          <CommandGroup
-                            heading={group.label ?? `${collection?.title} root`}
-                            className={REQUEST_GROUP_GRID}
-                          >
+                          <RequestCommandGroup heading={group.label ?? `${collection?.title} root`}>
                             {group.requests.map(renderRequestItem)}
-                          </CommandGroup>
+                          </RequestCommandGroup>
                         </Fragment>
                       ))}
-                    </div>
+                    </RequestResultsGrid>
                   </CommandList>
                 </TabsContent>
 

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -83,6 +83,12 @@ const buildRequestGroups = (
 const TABS = ['all', 'requests', 'environments', 'actions'] as const;
 type Tab = (typeof TABS)[number];
 
+/** 2-column grid ancestor: column 1 (method badge) auto-sizes to the widest method text across every subgridded row. */
+const REQUEST_LIST_GRID = 'grid grid-cols-[auto_1fr]';
+/** Passes the 2 grid tracks down through cmdk's fixed group/heading/items DOM so every request row's columns line up. */
+const REQUEST_GROUP_GRID =
+  'col-span-full grid grid-cols-subgrid **:[[cmdk-group-heading]]:col-span-full **:[[cmdk-group-items]]:col-span-full **:[[cmdk-group-items]]:grid **:[[cmdk-group-items]]:grid-cols-subgrid';
+
 interface CommandPaletteProps {
   open: boolean;
   onClose: () => void;
@@ -160,10 +166,19 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       key={request.id}
       value={request.title ?? request.url.base}
       onSelect={() => selectAndClose(request.id)}
+      className="col-span-full grid grid-cols-subgrid"
     >
-      <span className={`shrink-0 text-xs font-normal ${httpMethodColor(request.method)}`}>
-        {request.method}
-      </span>
+      <div
+        className="flex items-center justify-center rounded px-2 py-0.5"
+        style={{
+          backgroundColor: `color-mix(in srgb, var(--http-${request.method.toLowerCase()}) 20%, transparent)`,
+        }}
+      >
+        <span className={`text-xs font-normal ${httpMethodColor(request.method)}`}>
+          {request.method}
+        </span>
+      </div>
+
       <span className="truncate">{request.title ?? request.url.base}</span>
     </CommandItem>
   );
@@ -275,17 +290,21 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                   <CommandList>
                     <CommandEmpty>No results found.</CommandEmpty>
                     {search.trim() === '' ? (
-                      <CommandGroup heading="Recent">
-                        {[...allRequests]
-                          .sort((a, b) => b.lastModified - a.lastModified)
-                          .slice(0, 5)
-                          .map(renderRequestItem)}
-                      </CommandGroup>
+                      <div className={REQUEST_LIST_GRID}>
+                        <CommandGroup heading="Recent" className={REQUEST_GROUP_GRID}>
+                          {[...allRequests]
+                            .sort((a, b) => b.lastModified - a.lastModified)
+                            .slice(0, 5)
+                            .map(renderRequestItem)}
+                        </CommandGroup>
+                      </div>
                     ) : (
                       <>
-                        <CommandGroup heading="Requests">
-                          {allRequests.map(renderRequestItem)}
-                        </CommandGroup>
+                        <div className={REQUEST_LIST_GRID}>
+                          <CommandGroup heading="Requests" className={REQUEST_GROUP_GRID}>
+                            {allRequests.map(renderRequestItem)}
+                          </CommandGroup>
+                        </div>
                         <CommandGroup heading="Environments">
                           {Object.keys(environments).map((key) => (
                             <CommandItem
@@ -328,14 +347,19 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                 <TabsContent value="requests" className="mt-0 rounded-none bg-transparent">
                   <CommandList>
                     <CommandEmpty>No requests found.</CommandEmpty>
-                    {requestGroups.map((group, i) => (
-                      <Fragment key={group.label ?? '__root__'}>
-                        {i > 0 && <CommandSeparator key={`sep-${i}`} />}
-                        <CommandGroup heading={group.label ?? `${collection?.title} root`}>
-                          {group.requests.map(renderRequestItem)}
-                        </CommandGroup>
-                      </Fragment>
-                    ))}
+                    <div className={REQUEST_LIST_GRID}>
+                      {requestGroups.map((group, i) => (
+                        <Fragment key={group.label ?? '__root__'}>
+                          {i > 0 && <CommandSeparator key={`sep-${i}`} className="col-span-full" />}
+                          <CommandGroup
+                            heading={group.label ?? `${collection?.title} root`}
+                            className={REQUEST_GROUP_GRID}
+                          >
+                            {group.requests.map(renderRequestItem)}
+                          </CommandGroup>
+                        </Fragment>
+                      ))}
+                    </div>
                   </CommandList>
                 </TabsContent>
 

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, KeyboardEvent } from 'react';
 import { ArrowRight, Folder, Globe, Plus, Save, SwitchCamera } from 'lucide-react';
 import { editor } from 'monaco-editor';
-import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Dialog, DialogOverlay, DialogPortal } from '@/components/ui/dialog';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {
   Command,
   CommandEmpty,
@@ -103,7 +104,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
 
   // Tab/Shift+Tab and Left/Right arrow key cycling
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
+    (e: KeyboardEvent<HTMLDivElement>) => {
       const currentIndex = TABS.indexOf(activeTab);
 
       if (e.key === 'ArrowRight' || (e.key === 'Tab' && !e.shiftKey)) {
@@ -119,7 +120,9 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="top-70 translate-y-0 overflow-hidden p-0 shadow-lg sm:max-w-150">
+      <DialogPortal>
+        <DialogOverlay className="flex items-center justify-center">
+          <DialogPrimitive.Content className="bg-background w-full max-w-[600px] overflow-hidden rounded-lg shadow-lg outline-none">
         <Command shouldFilter={true} onKeyDown={handleKeyDown}>
           <CommandInput placeholder="Search..." value={search} onValueChange={setSearch} />
           <Tabs
@@ -234,7 +237,9 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
             </TabsContent>
           </Tabs>
         </Command>
-      </DialogContent>
+          </DialogPrimitive.Content>
+        </DialogOverlay>
+      </DialogPortal>
     </Dialog>
   );
 };

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useRef, useState, KeyboardEvent } from 'react';
-import { ArrowRight, Folder as FolderIcon, Globe, Plus, Save, SwitchCamera } from 'lucide-react';
+import { ArrowRight, Plus, Save, SwitchCamera } from 'lucide-react';
 import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
 import { editor } from 'monaco-editor';
@@ -57,7 +57,7 @@ const buildRequestGroups = (
   return group.requests.length > 0 ? [group, ...subGroups] : subGroups;
 };
 
-const TABS = ['requests', 'collections', 'folders', 'actions'] as const;
+const TABS = ['requests', 'environments', 'actions'] as const;
 type Tab = (typeof TABS)[number];
 
 interface CommandPaletteProps {
@@ -70,7 +70,6 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const [search, setSearch] = useState('');
   const tabsRef = useRef<HTMLDivElement>(null);
 
-  const folders = useCollectionStore((s) => s.folders);
   const collection = useCollectionStore((s) => s.collection);
   const requestGroups = collection ? buildRequestGroups(collection.children) : [];
   const currentRequest = useCollectionStore(selectRequest);
@@ -160,8 +159,6 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
               >
                 <TabsList className="mt-2 px-2">
                   <TabsTrigger value="requests">Requests</TabsTrigger>
-                  <TabsTrigger value="collections">Collections</TabsTrigger>
-                  <TabsTrigger value="folders">Folders</TabsTrigger>
                   <TabsTrigger value="actions">Actions</TabsTrigger>
                 </TabsList>
 
@@ -190,30 +187,6 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                           ))}
                         </CommandGroup>
                       </Fragment>
-                    ))}
-                  </CommandList>
-                </TabsContent>
-
-                <TabsContent value="collections">
-                  <CommandList>
-                    <CommandEmpty>No collections found.</CommandEmpty>
-                    {collection != null && (
-                      <CommandItem key={collection.id} value={collection.title}>
-                        <Globe className="shrink-0" />
-                        <span className="truncate">{collection.title}</span>
-                      </CommandItem>
-                    )}
-                  </CommandList>
-                </TabsContent>
-
-                <TabsContent value="folders">
-                  <CommandList>
-                    <CommandEmpty>No folders found.</CommandEmpty>
-                    {Array.from(folders.values()).map((folder) => (
-                      <CommandItem key={folder.id} value={folder.title}>
-                        <FolderIcon className="shrink-0" />
-                        <span className="truncate">{folder.title}</span>
-                      </CommandItem>
                     ))}
                   </CommandList>
                 </TabsContent>

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -1,4 +1,12 @@
-import { Fragment, useCallback, useEffect, useRef, useState, KeyboardEvent } from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  KeyboardEvent,
+  ReactElement,
+} from 'react';
 import {
   ArrowRight,
   EraserIcon,
@@ -8,6 +16,11 @@ import {
   SettingsIcon,
   SwitchCameraIcon,
   type LucideIcon,
+  GalleryVerticalEnd,
+  Globe,
+  SquareSlash,
+  Server,
+  Command as CommandShortcut,
 } from 'lucide-react';
 import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
@@ -56,7 +69,8 @@ interface ActionItem {
   section: ActionSection;
   icon: LucideIcon;
   label: string;
-  shortcut?: string;
+  shortcutModifier?: ReactElement | string;
+  shortcutKey?: string;
   disabled?: boolean;
   onSelect: () => void;
 }
@@ -113,6 +127,8 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const { addResponse } = useResponseActions();
 
   const { openCollectionSettings, openAppSettings } = useViewActions();
+
+  const isMac = navigator.platform.startsWith('Mac');
 
   // Reset state when opened
   useEffect(() => {
@@ -189,7 +205,8 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       section: 'Request',
       icon: ArrowRight,
       label: 'Send request',
-      shortcut: '⌘↵',
+      shortcutModifier: isMac ? <CommandShortcut size={12} /> : 'Ctrl',
+      shortcutKey: 'Enter',
       disabled: currentRequest == null,
       onSelect: handleSend,
     },
@@ -198,7 +215,8 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       section: 'Request',
       icon: Save,
       label: 'Save request',
-      shortcut: '⌘S',
+      shortcutModifier: isMac ? <CommandShortcut size={12} /> : 'Ctrl',
+      shortcutKey: 'S',
       disabled: currentRequest == null,
       onSelect: handleSave,
     },
@@ -207,7 +225,8 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       section: 'Request',
       icon: Plus,
       label: 'New request',
-      shortcut: '⌘N',
+      shortcutModifier: isMac ? <CommandShortcut size={12} /> : 'Ctrl',
+      shortcutKey: 'N',
       onSelect: () => runAndClose(() => addNewRequest()),
     },
     {
@@ -278,10 +297,26 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                 className="flex flex-col gap-2"
               >
                 <TabsList className="mt-2 px-2">
-                  <TabsTrigger value="all">All</TabsTrigger>
-                  <TabsTrigger value="requests">Requests</TabsTrigger>
-                  <TabsTrigger value="environments">Environments</TabsTrigger>
-                  <TabsTrigger value="actions">Actions</TabsTrigger>
+                  <TabsTrigger className="gap-2 rounded-md px-1.5 py-1" value="all">
+                    <GalleryVerticalEnd size={16} />
+
+                    <span>All</span>
+                  </TabsTrigger>
+                  <TabsTrigger className="gap-2 rounded-md px-1.5 py-1" value="requests">
+                    <Globe size={16} />
+
+                    <span>Requests</span>
+                  </TabsTrigger>
+                  <TabsTrigger className="gap-2 rounded-md px-1.5 py-1" value="environments">
+                    <Server size={16} />
+
+                    <span>Environments</span>
+                  </TabsTrigger>
+                  <TabsTrigger className="gap-2 rounded-md px-1.5 py-1" value="actions">
+                    <SquareSlash size={16} />
+
+                    <span>Actions</span>
+                  </TabsTrigger>
                 </TabsList>
 
                 <Divider />
@@ -331,10 +366,16 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                             >
                               <item.icon className="shrink-0" />
                               <span>{item.label}</span>
-                              {item.shortcut && (
-                                <span className="text-muted-foreground ml-auto text-xs">
-                                  {item.shortcut}
-                                </span>
+                              {item.shortcutModifier && (
+                                <div className="ml-auto flex items-center justify-center gap-1">
+                                  <div className="bg-background-secondary rounded p-1">
+                                    {item.shortcutModifier}
+                                  </div>
+
+                                  <span className="bg-background-secondary rounded p-1">
+                                    {item.shortcutKey}
+                                  </span>
+                                </div>
                               )}
                             </CommandItem>
                           ))}
@@ -399,10 +440,16 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                               >
                                 <item.icon className="shrink-0" />
                                 <span>{item.label}</span>
-                                {item.shortcut && (
-                                  <span className="text-muted-foreground ml-auto text-xs">
-                                    {item.shortcut}
-                                  </span>
+                                {item.shortcutModifier && (
+                                  <div className="ml-auto flex items-center justify-center gap-1">
+                                    <div className="bg-background-secondary rounded p-1">
+                                      {item.shortcutModifier}
+                                    </div>
+
+                                    <span className="bg-background-secondary rounded p-1">
+                                      {item.shortcutKey}
+                                    </span>
+                                  </div>
                                 )}
                               </CommandItem>
                             ))}

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -45,6 +45,7 @@ import {
   RequestCommandItem,
 } from '@/components/commandPalette/RequestResultsGrid';
 import { useSendRequest, useSaveRequest } from '@/hooks/request/useRequestActions';
+import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
 import { HOTKEYS } from '@/hooks/hotKeys/hotkeys';
 import { formatHotkeyForDisplay } from '@/hooks/hotKeys/hotkeyDisplay';
 
@@ -164,6 +165,11 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     onClose();
   }, [saveRequest, onClose]);
 
+  const handleNewRequest = useCallback(
+    () => runAndClose(() => addNewRequest()),
+    [runAndClose, addNewRequest]
+  );
+
   const renderEnvironmentItem = (key: string) => (
     <CommandItem
       key={key}
@@ -201,6 +207,9 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     </RequestCommandItem>
   );
 
+  const canSendRequest = currentRequest != null;
+  const canSaveRequest = !!currentRequest?.draft;
+
   const actionItems: ActionItem[] = [
     {
       value: 'send request',
@@ -208,7 +217,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       icon: ArrowRight,
       label: 'Send request',
       hotkey: HOTKEYS.sendRequest,
-      disabled: currentRequest == null,
+      disabled: !canSendRequest,
       onSelect: handleSend,
     },
     {
@@ -217,7 +226,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       icon: Save,
       label: 'Save request',
       hotkey: HOTKEYS.saveRequest,
-      disabled: currentRequest == null,
+      disabled: !canSaveRequest,
       onSelect: handleSave,
     },
     {
@@ -226,14 +235,14 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       icon: Plus,
       label: 'New request',
       hotkey: HOTKEYS.newRequest,
-      onSelect: () => runAndClose(() => addNewRequest()),
+      onSelect: handleNewRequest,
     },
     {
       value: 'discard changes',
       section: 'Request',
       icon: EraserIcon,
       label: 'Discard changes',
-      disabled: !currentRequest?.draft,
+      disabled: !canSaveRequest,
       onSelect: () => runAndClose(discardChanges),
     },
     {
@@ -265,6 +274,19 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       onSelect: () => runAndClose(openAppSettings),
     },
   ];
+
+  // Owns Send/Save/New-request while the palette is open, so a keypress performs the same action
+  // and closes the palette exactly like clicking the corresponding Actions-tab item does (I2/I12).
+  // `MainTopBar.tsx`/`SidebarHeaderBar.tsx` disable their own global registrations for these same
+  // shortcuts while the palette is open, so the action never fires twice (I13).
+  useHotkeys(
+    [
+      { keys: HOTKEYS.sendRequest, handler: handleSend, enabled: canSendRequest },
+      { keys: HOTKEYS.saveRequest, handler: handleSave, enabled: canSaveRequest },
+      { keys: HOTKEYS.newRequest, handler: handleNewRequest },
+    ],
+    { enabled: open, skipFormElements: false }
+  );
 
   const renderActionItem = (item: ActionItem) => {
     const badge = item.hotkey ? formatHotkeyForDisplay(item.hotkey) : null;

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useRef, useState, KeyboardEvent } from 'react';
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import {
   ArrowRight,
   EraserIcon,
@@ -275,15 +275,30 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     },
   ];
 
-  // Owns Send/Save/New-request while the palette is open, so a keypress performs the same action
-  // and closes the palette exactly like clicking the corresponding Actions-tab item does (I2/I12).
-  // `MainTopBar.tsx`/`SidebarHeaderBar.tsx` disable their own global registrations for these same
-  // shortcuts while the palette is open, so the action never fires twice (I13).
+  const cycleTabForward = useCallback(() => {
+    const currentIndex = TABS.indexOf(activeTab);
+    setActiveTab(TABS[(currentIndex + 1) % TABS.length]);
+  }, [activeTab]);
+
+  const cycleTabBackward = useCallback(() => {
+    const currentIndex = TABS.indexOf(activeTab);
+    setActiveTab(TABS[(currentIndex - 1 + TABS.length) % TABS.length]);
+  }, [activeTab]);
+
+  // Owns every keyboard shortcut scoped to the open palette: Send/Save/New-request (a keypress
+  // performs the same action and closes the palette exactly like clicking the corresponding
+  // Actions-tab item does, I2/I12) and tab-strip cycling via Tab/Shift+Tab/←/→ (I4).
+  // `MainTopBar.tsx`/`SidebarHeaderBar.tsx` disable their own global registrations for the shared
+  // Send/Save/New-request shortcuts while the palette is open, so those never fire twice (I13).
   useHotkeys(
     [
       { keys: HOTKEYS.sendRequest, handler: handleSend, enabled: canSendRequest },
       { keys: HOTKEYS.saveRequest, handler: handleSave, enabled: canSaveRequest },
       { keys: HOTKEYS.newRequest, handler: handleNewRequest },
+      { keys: HOTKEYS.cyclePaletteTabForward, handler: cycleTabForward },
+      { keys: HOTKEYS.cyclePaletteTabForwardTab, handler: cycleTabForward },
+      { keys: HOTKEYS.cyclePaletteTabBackward, handler: cycleTabBackward },
+      { keys: HOTKEYS.cyclePaletteTabBackwardTab, handler: cycleTabBackward },
     ],
     { enabled: open, skipFormElements: false }
   );
@@ -312,27 +327,12 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     );
   };
 
-  // Tab/Shift+Tab and Left/Right arrow key cycling
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLDivElement>) => {
-      const currentIndex = TABS.indexOf(activeTab);
-
-      if (e.key === 'ArrowRight' || (e.key === 'Tab' && !e.shiftKey)) {
-        e.preventDefault();
-        setActiveTab(TABS[(currentIndex + 1) % TABS.length]);
-      } else if (e.key === 'ArrowLeft' || (e.key === 'Tab' && e.shiftKey)) {
-        e.preventDefault();
-        setActiveTab(TABS[(currentIndex - 1 + TABS.length) % TABS.length]);
-      }
-    },
-    [activeTab]
-  );
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogPortal>
         <DialogOverlay className="flex items-center justify-center">
           <DialogPrimitive.Content className="bg-background w-full max-w-150 overflow-hidden rounded-lg p-2 shadow-lg outline-none">
-            <Command shouldFilter={true} onKeyDown={handleKeyDown}>
+            <Command shouldFilter={true}>
               <CommandInput placeholder="Search..." value={search} onValueChange={setSearch} />
 
               <Tabs

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -1,12 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Folder, Globe } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import {
   Command,
   CommandEmpty,
   CommandInput,
+  CommandItem,
   CommandList,
 } from '@/components/ui/command';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
+import { httpMethodColor } from '@/services/StyleHelper';
 
 const TABS = ['requests', 'collections', 'folders', 'actions'] as const;
 type Tab = (typeof TABS)[number];
@@ -21,6 +25,11 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const [search, setSearch] = useState('');
   const tabsRef = useRef<HTMLDivElement>(null);
 
+  const requests = useCollectionStore((s) => s.requests);
+  const folders = useCollectionStore((s) => s.folders);
+  const collection = useCollectionStore((s) => s.collection);
+  const { setSelectedRequest } = useCollectionActions();
+
   // Reset state when opened
   useEffect(() => {
     if (open) {
@@ -28,6 +37,14 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       setSearch('');
     }
   }, [open]);
+
+  const selectAndClose = useCallback(
+    (id: string) => {
+      setSelectedRequest(id);
+      onClose();
+    },
+    [setSelectedRequest, onClose]
+  );
 
   // Tab/Shift+Tab and Left/Right arrow key cycling
   const handleKeyDown = useCallback(
@@ -47,15 +64,9 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent
-        className="top-[280px] translate-y-0 overflow-hidden p-0 shadow-lg sm:max-w-[600px]"
-      >
+      <DialogContent className="top-[280px] translate-y-0 overflow-hidden p-0 shadow-lg sm:max-w-[600px]">
         <Command shouldFilter={true} onKeyDown={handleKeyDown}>
-          <CommandInput
-            placeholder="Search..."
-            value={search}
-            onValueChange={setSearch}
-          />
+          <CommandInput placeholder="Search..." value={search} onValueChange={setSearch} />
           <Tabs
             ref={tabsRef}
             value={activeTab}
@@ -68,21 +79,49 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
               <TabsTrigger value="folders">Folders</TabsTrigger>
               <TabsTrigger value="actions">Actions</TabsTrigger>
             </TabsList>
+
             <TabsContent value="requests">
               <CommandList>
                 <CommandEmpty>No requests found.</CommandEmpty>
+                {Array.from(requests.values()).map((request) => (
+                  <CommandItem
+                    key={request.id}
+                    value={request.title ?? request.url.base}
+                    onSelect={() => selectAndClose(request.id)}
+                  >
+                    <span className={`shrink-0 text-xs font-normal ${httpMethodColor(request.method)}`}>
+                      {request.method}
+                    </span>
+                    <span className="truncate">{request.title ?? request.url.base}</span>
+                  </CommandItem>
+                ))}
               </CommandList>
             </TabsContent>
+
             <TabsContent value="collections">
               <CommandList>
                 <CommandEmpty>No collections found.</CommandEmpty>
+                {collection != null && (
+                  <CommandItem key={collection.id} value={collection.title}>
+                    <Globe className="shrink-0" />
+                    <span className="truncate">{collection.title}</span>
+                  </CommandItem>
+                )}
               </CommandList>
             </TabsContent>
+
             <TabsContent value="folders">
               <CommandList>
                 <CommandEmpty>No folders found.</CommandEmpty>
+                {Array.from(folders.values()).map((folder) => (
+                  <CommandItem key={folder.id} value={folder.title}>
+                    <Folder className="shrink-0" />
+                    <span className="truncate">{folder.title}</span>
+                  </CommandItem>
+                ))}
               </CommandList>
             </TabsContent>
+
             <TabsContent value="actions">
               <CommandList>
                 <CommandEmpty>No actions available.</CommandEmpty>

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -184,7 +184,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       key={key}
       value={key}
       onSelect={() => runAndClose(() => selectEnvironment(key))}
-      className="hover:bg-divider"
+      className="data-[selected='true']:bg-divider"
     >
       <HardDrive className="shrink-0" />
       <span className="truncate">{key}</span>
@@ -199,7 +199,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       key={request.id}
       value={request.title ?? request.url.base}
       onSelect={() => selectAndClose(request.id)}
-      className="hover:bg-divider col-span-full grid grid-cols-subgrid"
+      className="data-[selected='true']:bg-divider col-span-full grid grid-cols-subgrid"
     >
       <div
         className="flex items-center justify-center rounded px-2 py-0.5"
@@ -367,7 +367,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                               value={item.value}
                               disabled={item.disabled}
                               onSelect={item.onSelect}
-                              className="hover:bg-divider"
+                              className="data-[selected='true']:bg-divider"
                             >
                               <item.icon className="shrink-0" />
                               <span>{item.label}</span>
@@ -431,7 +431,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                                 value={item.value}
                                 disabled={item.disabled}
                                 onSelect={item.onSelect}
-                                className="hover:bg-divider"
+                                className="data-[selected='true']:bg-divider"
                               >
                                 <item.icon className="shrink-0" />
                                 <span>{item.label}</span>

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -1,12 +1,4 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  KeyboardEvent,
-  ReactElement,
-} from 'react';
+import { Fragment, useCallback, useEffect, useRef, useState, KeyboardEvent } from 'react';
 import {
   ArrowRight,
   EraserIcon,
@@ -19,7 +11,6 @@ import {
   Globe,
   SquareSlash,
   Server,
-  Command as CommandShortcut,
   Wrench,
   SquareMousePointer,
   HardDrive,
@@ -54,6 +45,8 @@ import {
   RequestCommandItem,
 } from '@/components/commandPalette/RequestResultsGrid';
 import { useSendRequest, useSaveRequest } from '@/hooks/request/useRequestActions';
+import { HOTKEYS } from '@/hooks/hotKeys/hotkeys';
+import { formatHotkeyForDisplay } from '@/hooks/hotKeys/hotkeyDisplay';
 
 interface RequestGroup {
   id: string | null;
@@ -69,8 +62,8 @@ interface ActionItem {
   section: ActionSection;
   icon: LucideIcon;
   label: string;
-  shortcutModifier?: ReactElement | string;
-  shortcutKey?: string;
+  /** A `HOTKEYS.*` value; omit when the action has no real bound hotkey (I9/I11). */
+  hotkey?: string;
   disabled?: boolean;
   onSelect: () => void;
 }
@@ -133,8 +126,6 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const { selectEnvironment } = useEnvironmentActions();
 
   const { openCollectionSettings, openAppSettings } = useViewActions();
-
-  const isMac = navigator.platform.startsWith('Mac');
 
   // Reset state when opened
   useEffect(() => {
@@ -216,8 +207,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       section: 'Request',
       icon: ArrowRight,
       label: 'Send request',
-      shortcutModifier: isMac ? <CommandShortcut size={12} /> : 'Ctrl',
-      shortcutKey: 'Enter',
+      hotkey: HOTKEYS.sendRequest,
       disabled: currentRequest == null,
       onSelect: handleSend,
     },
@@ -226,8 +216,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       section: 'Request',
       icon: Save,
       label: 'Save request',
-      shortcutModifier: isMac ? <CommandShortcut size={12} /> : 'Ctrl',
-      shortcutKey: 'S',
+      hotkey: HOTKEYS.saveRequest,
       disabled: currentRequest == null,
       onSelect: handleSave,
     },
@@ -236,8 +225,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       section: 'Request',
       icon: Plus,
       label: 'New request',
-      shortcutModifier: isMac ? <CommandShortcut size={12} /> : 'Ctrl',
-      shortcutKey: 'N',
+      hotkey: HOTKEYS.newRequest,
       onSelect: () => runAndClose(() => addNewRequest()),
     },
     {
@@ -277,6 +265,30 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       onSelect: () => runAndClose(openAppSettings),
     },
   ];
+
+  const renderActionItem = (item: ActionItem) => {
+    const badge = item.hotkey ? formatHotkeyForDisplay(item.hotkey) : null;
+
+    return (
+      <CommandItem
+        key={item.value}
+        value={item.value}
+        disabled={item.disabled}
+        onSelect={item.onSelect}
+        className="data-[selected='true']:bg-divider"
+      >
+        <item.icon className="shrink-0" />
+        <span>{item.label}</span>
+        {badge && (
+          <div className="ml-auto flex items-center justify-center gap-1">
+            <div className="bg-background-secondary rounded p-1">{badge.modifier}</div>
+
+            <span className="bg-background-secondary rounded p-1">{badge.key}</span>
+          </div>
+        )}
+      </CommandItem>
+    );
+  };
 
   // Tab/Shift+Tab and Left/Right arrow key cycling
   const handleKeyDown = useCallback(
@@ -355,29 +367,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                           {Object.keys(environments).map(renderEnvironmentItem)}
                         </CommandGroup>
                         <CommandGroup heading="Actions">
-                          {actionItems.map((item) => (
-                            <CommandItem
-                              key={item.value}
-                              value={item.value}
-                              disabled={item.disabled}
-                              onSelect={item.onSelect}
-                              className="data-[selected='true']:bg-divider"
-                            >
-                              <item.icon className="shrink-0" />
-                              <span>{item.label}</span>
-                              {item.shortcutModifier && (
-                                <div className="ml-auto flex items-center justify-center gap-1">
-                                  <div className="bg-background-secondary rounded p-1">
-                                    {item.shortcutModifier}
-                                  </div>
-
-                                  <span className="bg-background-secondary rounded p-1">
-                                    {item.shortcutKey}
-                                  </span>
-                                </div>
-                              )}
-                            </CommandItem>
-                          ))}
+                          {actionItems.map(renderActionItem)}
                         </CommandGroup>
                       </>
                     )}
@@ -416,29 +406,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                         <CommandGroup heading={section}>
                           {actionItems
                             .filter((item) => item.section === section)
-                            .map((item) => (
-                              <CommandItem
-                                key={item.value}
-                                value={item.value}
-                                disabled={item.disabled}
-                                onSelect={item.onSelect}
-                                className="data-[selected='true']:bg-divider"
-                              >
-                                <item.icon className="shrink-0" />
-                                <span>{item.label}</span>
-                                {item.shortcutModifier && (
-                                  <div className="ml-auto flex items-center justify-center gap-1">
-                                    <div className="bg-background-secondary rounded p-1">
-                                      {item.shortcutModifier}
-                                    </div>
-
-                                    <span className="bg-background-secondary rounded p-1">
-                                      {item.shortcutKey}
-                                    </span>
-                                  </div>
-                                )}
-                              </CommandItem>
-                            ))}
+                            .map(renderActionItem)}
                         </CommandGroup>
                       </Fragment>
                     ))}

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -46,9 +46,7 @@ import {
   useEnvironmentActions,
   useEnvironmentStore,
 } from '@/state/environmentStore';
-import { useResponseActions } from '@/state/responseStore';
 import { useViewActions } from '@/state/viewStore';
-import { HttpService } from '@/services/http/http-service';
 import { RendererEventService } from '@/services/event/renderer-event-service';
 import { saveModelContent } from '@/lib/monaco/models';
 import { showError } from '@/error/errorHandler';
@@ -59,8 +57,8 @@ import {
   RequestCommandGroup,
   RequestCommandItem,
 } from '@/components/commandPalette/RequestResultsGrid';
+import { useSendRequest } from '@/hooks/request/useRequestActions';
 
-const httpService = HttpService.instance;
 const eventService = RendererEventService.instance;
 
 interface RequestGroup {
@@ -140,8 +138,6 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const selectedEnvironment = useEnvironmentStore(selectSelectedEnvironment);
   const { selectEnvironment } = useEnvironmentActions();
 
-  const { addResponse } = useResponseActions();
-
   const { openCollectionSettings, openAppSettings } = useViewActions();
 
   const isMac = navigator.platform.startsWith('Mac');
@@ -170,17 +166,12 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     [onClose]
   );
 
+  const { sendRequest } = useSendRequest();
+
   const handleSend = useCallback(async () => {
-    if (currentRequest == null) return;
-    try {
-      await Promise.all(editor.getModels().map(saveModelContent));
-      const response = await httpService.sendRequest(currentRequest);
-      addResponse(currentRequest.id, response);
-    } catch (error) {
-      showError(error);
-    }
+    await sendRequest();
     onClose();
-  }, [currentRequest, addResponse, onClose]);
+  }, [sendRequest, onClose]);
 
   const handleSave = useCallback(async () => {
     if (currentRequest == null) return;

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -63,7 +63,7 @@ interface ActionItem {
   section: ActionSection;
   icon: LucideIcon;
   label: string;
-  /** A `HOTKEYS.*` value; omit when the action has no real bound hotkey (I9/I11). */
+  /** A `HOTKEYS.*` value; omit when the action has no real bound hotkey. */
   hotkey?: string;
   disabled?: boolean;
   onSelect: () => void;
@@ -287,9 +287,9 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
 
   // Owns every keyboard shortcut scoped to the open palette: Send/Save/New-request (a keypress
   // performs the same action and closes the palette exactly like clicking the corresponding
-  // Actions-tab item does, I2/I12) and tab-strip cycling via Tab/Shift+Tab/←/→ (I4).
+  // Actions-tab item does) and tab-strip cycling via Tab/Shift+Tab/←/→.
   // `MainTopBar.tsx`/`SidebarHeaderBar.tsx` disable their own global registrations for the shared
-  // Send/Save/New-request shortcuts while the palette is open, so those never fire twice (I13).
+  // Send/Save/New-request shortcuts while the palette is open, so those never fire twice.
   useHotkeys(
     [
       { keys: HOTKEYS.sendRequest, handler: handleSend, enabled: canSendRequest },

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandList,
+} from '@/components/ui/command';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+
+const TABS = ['requests', 'collections', 'folders', 'actions'] as const;
+type Tab = (typeof TABS)[number];
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
+  const [activeTab, setActiveTab] = useState<Tab>('requests');
+  const [search, setSearch] = useState('');
+  const tabsRef = useRef<HTMLDivElement>(null);
+
+  // Reset state when opened
+  useEffect(() => {
+    if (open) {
+      setActiveTab('requests');
+      setSearch('');
+    }
+  }, [open]);
+
+  // Tab/Shift+Tab and Left/Right arrow key cycling
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const currentIndex = TABS.indexOf(activeTab);
+
+      if (e.key === 'ArrowRight' || (e.key === 'Tab' && !e.shiftKey)) {
+        e.preventDefault();
+        setActiveTab(TABS[(currentIndex + 1) % TABS.length]);
+      } else if (e.key === 'ArrowLeft' || (e.key === 'Tab' && e.shiftKey)) {
+        e.preventDefault();
+        setActiveTab(TABS[(currentIndex - 1 + TABS.length) % TABS.length]);
+      }
+    },
+    [activeTab]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent
+        className="top-[280px] translate-y-0 overflow-hidden p-0 shadow-lg sm:max-w-[600px]"
+      >
+        <Command shouldFilter={true} onKeyDown={handleKeyDown}>
+          <CommandInput
+            placeholder="Search..."
+            value={search}
+            onValueChange={setSearch}
+          />
+          <Tabs
+            ref={tabsRef}
+            value={activeTab}
+            onValueChange={(v) => setActiveTab(v as Tab)}
+            className="flex flex-col"
+          >
+            <TabsList className="border-b px-2">
+              <TabsTrigger value="requests">Requests</TabsTrigger>
+              <TabsTrigger value="collections">Collections</TabsTrigger>
+              <TabsTrigger value="folders">Folders</TabsTrigger>
+              <TabsTrigger value="actions">Actions</TabsTrigger>
+            </TabsList>
+            <TabsContent value="requests">
+              <CommandList>
+                <CommandEmpty>No requests found.</CommandEmpty>
+              </CommandList>
+            </TabsContent>
+            <TabsContent value="collections">
+              <CommandList>
+                <CommandEmpty>No collections found.</CommandEmpty>
+              </CommandList>
+            </TabsContent>
+            <TabsContent value="folders">
+              <CommandList>
+                <CommandEmpty>No folders found.</CommandEmpty>
+              </CommandList>
+            </TabsContent>
+            <TabsContent value="actions">
+              <CommandList>
+                <CommandEmpty>No actions available.</CommandEmpty>
+              </CommandList>
+            </TabsContent>
+          </Tabs>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -119,7 +119,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const requestGroups = collection ? buildRequestGroups(collection.children, folders) : [];
   const allRequests = requestGroups.flatMap((group) => group.requests);
   const currentRequest = useCollectionStore(selectRequest);
-  const { setSelectedRequest, discardChanges, addNewFolder } = useCollectionActions();
+  const { setSelectedRequest, discardChanges } = useCollectionActions();
 
   const environments = useEnvironmentStore(selectEnvironments);
   const selectedEnvironment = useEnvironmentStore(selectSelectedEnvironment);
@@ -167,6 +167,11 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const handleNewRequest = useCallback(() => {
     if (collection == null) return;
     runAndClose(() => requestCreateItem({ type: 'request', parentId: collection.id }));
+  }, [collection, runAndClose, requestCreateItem]);
+
+  const handleNewFolder = useCallback(() => {
+    if (collection == null) return;
+    runAndClose(() => requestCreateItem({ type: 'folder', parentId: collection.id }));
   }, [collection, runAndClose, requestCreateItem]);
 
   const renderEnvironmentItem = (key: string) => (
@@ -251,7 +256,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       section: 'Collection',
       icon: FolderPlusIcon,
       label: 'New folder',
-      onSelect: () => runAndClose(() => addNewFolder()),
+      onSelect: handleNewFolder,
     },
     {
       value: 'switch environment',

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -119,14 +119,13 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const requestGroups = collection ? buildRequestGroups(collection.children, folders) : [];
   const allRequests = requestGroups.flatMap((group) => group.requests);
   const currentRequest = useCollectionStore(selectRequest);
-  const { setSelectedRequest, addNewRequest, discardChanges, addNewFolder } =
-    useCollectionActions();
+  const { setSelectedRequest, discardChanges, addNewFolder } = useCollectionActions();
 
   const environments = useEnvironmentStore(selectEnvironments);
   const selectedEnvironment = useEnvironmentStore(selectSelectedEnvironment);
   const { selectEnvironment } = useEnvironmentActions();
 
-  const { openCollectionSettings, openAppSettings } = useViewActions();
+  const { openCollectionSettings, openAppSettings, requestCreateItem } = useViewActions();
 
   // Reset state when opened
   useEffect(() => {
@@ -165,10 +164,10 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     onClose();
   }, [saveRequest, onClose]);
 
-  const handleNewRequest = useCallback(
-    () => runAndClose(() => addNewRequest()),
-    [runAndClose, addNewRequest]
-  );
+  const handleNewRequest = useCallback(() => {
+    if (collection == null) return;
+    runAndClose(() => requestCreateItem({ type: 'request', parentId: collection.id }));
+  }, [collection, runAndClose, requestCreateItem]);
 
   const renderEnvironmentItem = (key: string) => (
     <CommandItem
@@ -209,6 +208,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
 
   const canSendRequest = currentRequest != null;
   const canSaveRequest = !!currentRequest?.draft;
+  const canCreateRequest = collection != null;
 
   const actionItems: ActionItem[] = [
     {
@@ -235,6 +235,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
       icon: Plus,
       label: 'New request',
       hotkey: HOTKEYS.newRequest,
+      disabled: !canCreateRequest,
       onSelect: handleNewRequest,
     },
     {
@@ -294,7 +295,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     [
       { keys: HOTKEYS.sendRequest, handler: handleSend, enabled: canSendRequest },
       { keys: HOTKEYS.saveRequest, handler: handleSave, enabled: canSaveRequest },
-      { keys: HOTKEYS.newRequest, handler: handleNewRequest },
+      { keys: HOTKEYS.newRequest, handler: handleNewRequest, enabled: canCreateRequest },
       { keys: HOTKEYS.cyclePaletteTabForward, handler: cycleTabForward },
       { keys: HOTKEYS.cyclePaletteTabForwardTab, handler: cycleTabForward },
       { keys: HOTKEYS.cyclePaletteTabBackward, handler: cycleTabBackward },
@@ -331,7 +332,15 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogPortal>
         <DialogOverlay className="flex items-center justify-center">
-          <DialogPrimitive.Content className="bg-background w-full max-w-150 overflow-hidden rounded-lg p-2 shadow-lg outline-none">
+          <DialogPrimitive.Content
+            className="bg-background w-full max-w-150 overflow-hidden rounded-lg p-2 shadow-lg outline-none"
+            // Radix's default onCloseAutoFocus returns focus to whatever triggered the dialog once
+            // it finishes closing. This dialog is opened via a global shortcut (mod+k), not a
+            // button with a meaningful "return focus here" target, and without overriding this it
+            // can fight with the inline-rename input the sidebar auto-focuses in the same tick the
+            // palette closes (e.g. after "New request").
+            onCloseAutoFocus={(e) => e.preventDefault()}
+          >
             <Command shouldFilter={true}>
               <CommandInput placeholder="Search..." value={search} onValueChange={setSearch} />
 

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -26,7 +26,6 @@ import {
 } from 'lucide-react';
 import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
-import { editor } from 'monaco-editor';
 import { Dialog, DialogOverlay, DialogPortal } from '@/components/ui/dialog';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {
@@ -47,9 +46,6 @@ import {
   useEnvironmentStore,
 } from '@/state/environmentStore';
 import { useViewActions } from '@/state/viewStore';
-import { RendererEventService } from '@/services/event/renderer-event-service';
-import { saveModelContent } from '@/lib/monaco/models';
-import { showError } from '@/error/errorHandler';
 import { httpMethodColor } from '@/services/StyleHelper';
 import { Divider } from '@/components/shared/Divider';
 import {
@@ -57,9 +53,7 @@ import {
   RequestCommandGroup,
   RequestCommandItem,
 } from '@/components/commandPalette/RequestResultsGrid';
-import { useSendRequest } from '@/hooks/request/useRequestActions';
-
-const eventService = RendererEventService.instance;
+import { useSendRequest, useSaveRequest } from '@/hooks/request/useRequestActions';
 
 interface RequestGroup {
   id: string | null;
@@ -131,7 +125,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   const requestGroups = collection ? buildRequestGroups(collection.children, folders) : [];
   const allRequests = requestGroups.flatMap((group) => group.requests);
   const currentRequest = useCollectionStore(selectRequest);
-  const { setSelectedRequest, addNewRequest, updateRequest, discardChanges, addNewFolder } =
+  const { setSelectedRequest, addNewRequest, discardChanges, addNewFolder } =
     useCollectionActions();
 
   const environments = useEnvironmentStore(selectEnvironments);
@@ -167,6 +161,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   );
 
   const { sendRequest } = useSendRequest();
+  const { saveRequest } = useSaveRequest();
 
   const handleSend = useCallback(async () => {
     await sendRequest();
@@ -174,15 +169,9 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   }, [sendRequest, onClose]);
 
   const handleSave = useCallback(async () => {
-    if (currentRequest == null) return;
-    try {
-      await Promise.all(editor.getModels().map(saveModelContent));
-      updateRequest(await eventService.saveChanges(currentRequest), true);
-    } catch (error) {
-      showError(error);
-    }
+    await saveRequest();
     onClose();
-  }, [currentRequest, updateRequest, onClose]);
+  }, [saveRequest, onClose]);
 
   const renderEnvironmentItem = (key: string) => (
     <CommandItem

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -28,6 +28,7 @@ import { RendererEventService } from '@/services/event/renderer-event-service';
 import { saveModelContent } from '@/lib/monaco/models';
 import { showError } from '@/error/errorHandler';
 import { httpMethodColor } from '@/services/StyleHelper';
+import { Divider } from '@/components/shared/Divider';
 
 const httpService = HttpService.instance;
 const eventService = RendererEventService.instance;
@@ -148,23 +149,26 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogPortal>
         <DialogOverlay className="flex items-center justify-center">
-          <DialogPrimitive.Content className="bg-background w-full max-w-[600px] overflow-hidden rounded-lg shadow-lg outline-none">
+          <DialogPrimitive.Content className="bg-background w-full max-w-150 overflow-hidden rounded-lg p-4 shadow-lg outline-none">
             <Command shouldFilter={true} onKeyDown={handleKeyDown}>
               <CommandInput placeholder="Search..." value={search} onValueChange={setSearch} />
+
               <Tabs
                 ref={tabsRef}
                 value={activeTab}
                 onValueChange={(v) => setActiveTab(v as Tab)}
-                className="flex flex-col"
+                className="flex flex-col gap-2"
               >
-                <TabsList className="border-b px-2">
+                <TabsList className="mt-2 px-2">
                   <TabsTrigger value="requests">Requests</TabsTrigger>
                   <TabsTrigger value="collections">Collections</TabsTrigger>
                   <TabsTrigger value="folders">Folders</TabsTrigger>
                   <TabsTrigger value="actions">Actions</TabsTrigger>
                 </TabsList>
 
-                <TabsContent value="requests">
+                <Divider />
+
+                <TabsContent value="requests" className="bg-transparent">
                   <CommandList>
                     <CommandEmpty>No requests found.</CommandEmpty>
                     {requestGroups.map((group, i) => (

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -7,6 +7,7 @@ import {
   Save,
   SettingsIcon,
   SwitchCameraIcon,
+  type LucideIcon,
 } from 'lucide-react';
 import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
@@ -45,6 +46,19 @@ const eventService = RendererEventService.instance;
 interface RequestGroup {
   label: string | null;
   requests: TrufosRequest[];
+}
+
+type ActionSection = 'Request' | 'Collection' | 'Trufos';
+const ACTION_SECTIONS: ActionSection[] = ['Request', 'Collection', 'Trufos'];
+
+interface ActionItem {
+  value: string;
+  section: ActionSection;
+  icon: LucideIcon;
+  label: string;
+  shortcut?: string;
+  disabled?: boolean;
+  onSelect: () => void;
 }
 
 /** Walk collection children depth-first, flattening nested folders into a single group per folder. */
@@ -140,6 +154,84 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
     onClose();
   }, [currentRequest, updateRequest, onClose]);
 
+  const renderRequestItem = (request: TrufosRequest) => (
+    <CommandItem
+      key={request.id}
+      value={request.title ?? request.url.base}
+      onSelect={() => selectAndClose(request.id)}
+    >
+      <span className={`shrink-0 text-xs font-normal ${httpMethodColor(request.method)}`}>
+        {request.method}
+      </span>
+      <span className="truncate">{request.title ?? request.url.base}</span>
+    </CommandItem>
+  );
+
+  const actionItems: ActionItem[] = [
+    {
+      value: 'send request',
+      section: 'Request',
+      icon: ArrowRight,
+      label: 'Send request',
+      shortcut: '⌘↵',
+      disabled: currentRequest == null,
+      onSelect: handleSend,
+    },
+    {
+      value: 'save request',
+      section: 'Request',
+      icon: Save,
+      label: 'Save request',
+      shortcut: '⌘S',
+      disabled: currentRequest == null,
+      onSelect: handleSave,
+    },
+    {
+      value: 'new request',
+      section: 'Request',
+      icon: Plus,
+      label: 'New request',
+      shortcut: '⌘N',
+      onSelect: () => runAndClose(() => addNewRequest()),
+    },
+    {
+      value: 'discard changes',
+      section: 'Request',
+      icon: EraserIcon,
+      label: 'Discard changes',
+      disabled: !currentRequest?.draft,
+      onSelect: () => runAndClose(discardChanges),
+    },
+    {
+      value: 'new folder',
+      section: 'Collection',
+      icon: FolderPlusIcon,
+      label: 'New folder',
+      onSelect: () => runAndClose(() => addNewFolder()),
+    },
+    {
+      value: 'switch environment',
+      section: 'Collection',
+      icon: SwitchCameraIcon,
+      label: 'Switch environment',
+      onSelect: () => setActiveTab('environments'),
+    },
+    {
+      value: 'collection settings',
+      section: 'Collection',
+      icon: SettingsIcon,
+      label: 'Collection settings',
+      onSelect: () => runAndClose(openCollectionSettings),
+    },
+    {
+      value: 'settings',
+      section: 'Trufos',
+      icon: SettingsIcon,
+      label: 'Settings',
+      onSelect: () => runAndClose(openAppSettings),
+    },
+  ];
+
   // Tab/Shift+Tab and Left/Right arrow key cycling
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
@@ -184,20 +276,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                       <Fragment key={group.label ?? '__root__'}>
                         {i > 0 && <CommandSeparator key={`sep-${i}`} />}
                         <CommandGroup heading={group.label ?? `${collection?.title} root`}>
-                          {group.requests.map((request) => (
-                            <CommandItem
-                              key={request.id}
-                              value={request.title ?? request.url.base}
-                              onSelect={() => selectAndClose(request.id)}
-                            >
-                              <span
-                                className={`shrink-0 text-xs font-normal ${httpMethodColor(request.method)}`}
-                              >
-                                {request.method}
-                              </span>
-                              <span className="truncate">{request.title ?? request.url.base}</span>
-                            </CommandItem>
-                          ))}
+                          {group.requests.map(renderRequestItem)}
                         </CommandGroup>
                       </Fragment>
                     ))}
@@ -225,77 +304,31 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                 <TabsContent value="actions">
                   <CommandList>
                     <CommandEmpty>No actions available.</CommandEmpty>
-                    <CommandGroup heading="Request">
-                      <CommandItem
-                        value="send request"
-                        disabled={currentRequest == null}
-                        onSelect={handleSend}
-                      >
-                        <ArrowRight className="shrink-0" />
-                        <span>Send request</span>
-                        <span className="text-muted-foreground ml-auto text-xs">⌘↵</span>
-                      </CommandItem>
-                      <CommandItem
-                        value="save request"
-                        disabled={currentRequest == null}
-                        onSelect={handleSave}
-                      >
-                        <Save className="shrink-0" />
-                        <span>Save request</span>
-                        <span className="text-muted-foreground ml-auto text-xs">⌘S</span>
-                      </CommandItem>
-                      <CommandItem
-                        value="new request"
-                        onSelect={() => runAndClose(() => addNewRequest())}
-                      >
-                        <Plus className="shrink-0" />
-                        <span>New request</span>
-                        <span className="text-muted-foreground ml-auto text-xs">⌘N</span>
-                      </CommandItem>
-                      <CommandItem
-                        value="discard changes"
-                        disabled={!currentRequest?.draft}
-                        onSelect={() => runAndClose(discardChanges)}
-                      >
-                        <EraserIcon className="shrink-0" />
-                        <span>Discard changes</span>
-                      </CommandItem>
-                    </CommandGroup>
-
-                    <CommandSeparator />
-
-                    <CommandGroup heading="Collection">
-                      <CommandItem
-                        value="new folder"
-                        onSelect={() => runAndClose(() => addNewFolder())}
-                      >
-                        <FolderPlusIcon className="shrink-0" />
-                        <span>New folder</span>
-                      </CommandItem>
-                      <CommandItem
-                        value="switch environment"
-                        onSelect={() => setActiveTab('environments')}
-                      >
-                        <SwitchCameraIcon className="shrink-0" />
-                        <span>Switch environment</span>
-                      </CommandItem>
-                      <CommandItem
-                        value="collection settings"
-                        onSelect={() => runAndClose(openCollectionSettings)}
-                      >
-                        <SettingsIcon className="shrink-0" />
-                        <span>Collection settings</span>
-                      </CommandItem>
-                    </CommandGroup>
-
-                    <CommandSeparator />
-
-                    <CommandGroup heading="Trufos">
-                      <CommandItem value="settings" onSelect={() => runAndClose(openAppSettings)}>
-                        <SettingsIcon className="shrink-0" />
-                        <span>Settings</span>
-                      </CommandItem>
-                    </CommandGroup>
+                    {ACTION_SECTIONS.map((section, i) => (
+                      <Fragment key={section}>
+                        {i > 0 && <CommandSeparator />}
+                        <CommandGroup heading={section}>
+                          {actionItems
+                            .filter((item) => item.section === section)
+                            .map((item) => (
+                              <CommandItem
+                                key={item.value}
+                                value={item.value}
+                                disabled={item.disabled}
+                                onSelect={item.onSelect}
+                              >
+                                <item.icon className="shrink-0" />
+                                <span>{item.label}</span>
+                                {item.shortcut && (
+                                  <span className="text-muted-foreground ml-auto text-xs">
+                                    {item.shortcut}
+                                  </span>
+                                )}
+                              </CommandItem>
+                            ))}
+                        </CommandGroup>
+                      </Fragment>
+                    ))}
                   </CommandList>
                 </TabsContent>
               </Tabs>

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useRef, useState, KeyboardEvent } from 'react';
-import { ArrowRight, Plus, Save, SwitchCamera } from 'lucide-react';
+import { ArrowRight, Plus, Save } from 'lucide-react';
 import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
 import { editor } from 'monaco-editor';
@@ -159,6 +159,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
               >
                 <TabsList className="mt-2 px-2">
                   <TabsTrigger value="requests">Requests</TabsTrigger>
+                  <TabsTrigger value="environments">Environments</TabsTrigger>
                   <TabsTrigger value="actions">Actions</TabsTrigger>
                 </TabsList>
 
@@ -187,6 +188,24 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                           ))}
                         </CommandGroup>
                       </Fragment>
+                    ))}
+                  </CommandList>
+                </TabsContent>
+
+                <TabsContent value="environments">
+                  <CommandList>
+                    <CommandEmpty>No environments found.</CommandEmpty>
+                    {Object.keys(environments).map((key) => (
+                      <CommandItem
+                        key={key}
+                        value={key}
+                        onSelect={() => runAndClose(() => selectEnvironment(key))}
+                      >
+                        <span className="truncate">{key}</span>
+                        {selectedEnvironment === key && (
+                          <span className="text-muted-foreground ml-auto text-xs">active</span>
+                        )}
+                      </CommandItem>
                     ))}
                   </CommandList>
                 </TabsContent>
@@ -222,28 +241,6 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                         <span className="text-muted-foreground ml-auto text-xs">⌘N</span>
                       </CommandItem>
                     </CommandGroup>
-                    {Object.keys(environments).length > 0 && (
-                      <>
-                        <CommandSeparator />
-                        <CommandGroup heading="Switch environment">
-                          {Object.keys(environments).map((key) => (
-                            <CommandItem
-                              key={key}
-                              value={`switch environment ${key}`}
-                              onSelect={() => runAndClose(() => selectEnvironment(key))}
-                            >
-                              <SwitchCamera className="shrink-0" />
-                              <span>{key}</span>
-                              {selectedEnvironment === key && (
-                                <span className="text-muted-foreground ml-auto text-xs">
-                                  active
-                                </span>
-                              )}
-                            </CommandItem>
-                          ))}
-                        </CommandGroup>
-                      </>
-                    )}
                   </CommandList>
                 </TabsContent>
               </Tabs>

--- a/src/renderer/components/commandPalette/CommandPalette.tsx
+++ b/src/renderer/components/commandPalette/CommandPalette.tsx
@@ -80,7 +80,7 @@ const buildRequestGroups = (
   return group.requests.length > 0 ? [group, ...subGroups] : subGroups;
 };
 
-const TABS = ['requests', 'environments', 'actions'] as const;
+const TABS = ['all', 'requests', 'environments', 'actions'] as const;
 type Tab = (typeof TABS)[number];
 
 interface CommandPaletteProps {
@@ -89,12 +89,13 @@ interface CommandPaletteProps {
 }
 
 export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
-  const [activeTab, setActiveTab] = useState<Tab>('requests');
+  const [activeTab, setActiveTab] = useState<Tab>('all');
   const [search, setSearch] = useState('');
   const tabsRef = useRef<HTMLDivElement>(null);
 
   const collection = useCollectionStore((s) => s.collection);
   const requestGroups = collection ? buildRequestGroups(collection.children) : [];
+  const allRequests = requestGroups.flatMap((group) => group.requests);
   const currentRequest = useCollectionStore(selectRequest);
   const { setSelectedRequest, addNewRequest, updateRequest, discardChanges, addNewFolder } =
     useCollectionActions();
@@ -110,7 +111,7 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
   // Reset state when opened
   useEffect(() => {
     if (open) {
-      setActiveTab('requests');
+      setActiveTab('all');
       setSearch('');
     }
   }, [open]);
@@ -262,12 +263,67 @@ export const CommandPalette = ({ open, onClose }: CommandPaletteProps) => {
                 className="flex flex-col gap-2"
               >
                 <TabsList className="mt-2 px-2">
+                  <TabsTrigger value="all">All</TabsTrigger>
                   <TabsTrigger value="requests">Requests</TabsTrigger>
                   <TabsTrigger value="environments">Environments</TabsTrigger>
                   <TabsTrigger value="actions">Actions</TabsTrigger>
                 </TabsList>
 
                 <Divider />
+
+                <TabsContent value="all" className="mt-0 rounded-none bg-transparent">
+                  <CommandList>
+                    <CommandEmpty>No results found.</CommandEmpty>
+                    {search.trim() === '' ? (
+                      <CommandGroup heading="Recent">
+                        {[...allRequests]
+                          .sort((a, b) => b.lastModified - a.lastModified)
+                          .slice(0, 5)
+                          .map(renderRequestItem)}
+                      </CommandGroup>
+                    ) : (
+                      <>
+                        <CommandGroup heading="Requests">
+                          {allRequests.map(renderRequestItem)}
+                        </CommandGroup>
+                        <CommandGroup heading="Environments">
+                          {Object.keys(environments).map((key) => (
+                            <CommandItem
+                              key={key}
+                              value={key}
+                              onSelect={() => runAndClose(() => selectEnvironment(key))}
+                            >
+                              <span className="truncate">{key}</span>
+                              {selectedEnvironment === key && (
+                                <span className="text-muted-foreground ml-auto text-xs">
+                                  active
+                                </span>
+                              )}
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                        <CommandGroup heading="Actions">
+                          {actionItems.map((item) => (
+                            <CommandItem
+                              key={item.value}
+                              value={item.value}
+                              disabled={item.disabled}
+                              onSelect={item.onSelect}
+                            >
+                              <item.icon className="shrink-0" />
+                              <span>{item.label}</span>
+                              {item.shortcut && (
+                                <span className="text-muted-foreground ml-auto text-xs">
+                                  {item.shortcut}
+                                </span>
+                              )}
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      </>
+                    )}
+                  </CommandList>
+                </TabsContent>
 
                 <TabsContent value="requests" className="mt-0 rounded-none bg-transparent">
                   <CommandList>

--- a/src/renderer/components/commandPalette/RequestResultsGrid.tsx
+++ b/src/renderer/components/commandPalette/RequestResultsGrid.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { CommandGroup, CommandItem } from '@/components/ui/command';
+
+/**
+ * 2-column grid ancestor for a block of request rows: column 1 (method badge) auto-sizes to the
+ * widest method text across every subgridded row inside it.
+ */
+export const RequestResultsGrid = ({ children }: { children: React.ReactNode }) => (
+  <div className="grid grid-cols-[auto_1fr]">{children}</div>
+);
+
+interface RequestCommandGroupProps {
+  heading?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+/**
+ * `CommandGroup` wrapper that passes the 2 grid tracks down through cmdk's fixed
+ * group/heading/items DOM so every request row's columns line up. Must be rendered inside a
+ * `RequestResultsGrid`.
+ */
+export const RequestCommandGroup = ({ heading, children }: RequestCommandGroupProps) => (
+  <CommandGroup
+    heading={heading}
+    className="col-span-full grid grid-cols-subgrid **:[[cmdk-group-heading]]:col-span-full **:[[cmdk-group-items]]:col-span-full **:[[cmdk-group-items]]:grid **:[[cmdk-group-items]]:grid-cols-subgrid"
+  >
+    {children}
+  </CommandGroup>
+);
+
+/**
+ * `CommandItem` wrapper for a single request row: joins the row into the ancestor subgrid and
+ * applies the shared hover/keyboard-selection highlight. Must be rendered inside a
+ * `RequestCommandGroup`.
+ */
+export const RequestCommandItem = React.forwardRef<
+  React.ComponentRef<typeof CommandItem>,
+  React.ComponentPropsWithoutRef<typeof CommandItem>
+>(({ className, ...props }, ref) => (
+  <CommandItem
+    ref={ref}
+    className={cn(
+      "data-[selected='true']:bg-divider col-span-full grid grid-cols-subgrid",
+      className
+    )}
+    {...props}
+  />
+));
+RequestCommandItem.displayName = 'RequestCommandItem';

--- a/src/renderer/components/mainWindow/MainTopBar.tsx
+++ b/src/renderer/components/mainWindow/MainTopBar.tsx
@@ -7,6 +7,7 @@ import { ArrowRight, Loader2, SaveIcon, EraserIcon } from 'lucide-react';
 import { TrufosURL } from 'shim/objects/url';
 import { IconButton } from '@/components/ui/icon-button';
 import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
+import { HOTKEYS } from '@/hooks/hotKeys/hotkeys';
 import { useSendRequest, useSaveRequest } from '@/hooks/request/useRequestActions';
 
 export function MainTopBar() {
@@ -21,8 +22,8 @@ export function MainTopBar() {
 
   useHotkeys(
     [
-      { keys: 'mod+s', handler: saveRequest },
-      { keys: 'mod+enter', handler: sendRequest },
+      { keys: HOTKEYS.saveRequest, handler: saveRequest },
+      { keys: HOTKEYS.sendRequest, handler: sendRequest },
     ],
     { skipFormElements: false }
   );

--- a/src/renderer/components/mainWindow/MainTopBar.tsx
+++ b/src/renderer/components/mainWindow/MainTopBar.tsx
@@ -23,7 +23,7 @@ export function MainTopBar() {
   const handleHttpMethodChange = (method: RequestMethod) => updateRequest({ method });
 
   // Disabled while the Command Palette is open — it owns these same shortcuts then, performing
-  // the action and closing itself (I12/I13); see CommandPalette.tsx's own useHotkeys call.
+  // the action and closing itself; see CommandPalette.tsx's own useHotkeys call.
   useHotkeys(
     [
       { keys: HOTKEYS.saveRequest, handler: saveRequest },

--- a/src/renderer/components/mainWindow/MainTopBar.tsx
+++ b/src/renderer/components/mainWindow/MainTopBar.tsx
@@ -9,6 +9,7 @@ import { IconButton } from '@/components/ui/icon-button';
 import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
 import { HOTKEYS } from '@/hooks/hotKeys/hotkeys';
 import { useSendRequest, useSaveRequest } from '@/hooks/request/useRequestActions';
+import { selectIsCommandPaletteOpen, useViewStore } from '@/state/viewStore';
 
 export function MainTopBar() {
   const { updateRequest, discardChanges } = useCollectionActions();
@@ -16,16 +17,19 @@ export function MainTopBar() {
   const { url, method } = request;
   const { sendRequest, isSending } = useSendRequest();
   const { saveRequest } = useSaveRequest();
+  const isCommandPaletteOpen = useViewStore(selectIsCommandPaletteOpen);
 
   const handleUrlChange = (url: TrufosURL) => updateRequest({ url });
   const handleHttpMethodChange = (method: RequestMethod) => updateRequest({ method });
 
+  // Disabled while the Command Palette is open — it owns these same shortcuts then, performing
+  // the action and closing itself (I12/I13); see CommandPalette.tsx's own useHotkeys call.
   useHotkeys(
     [
       { keys: HOTKEYS.saveRequest, handler: saveRequest },
       { keys: HOTKEYS.sendRequest, handler: sendRequest },
     ],
-    { skipFormElements: false }
+    { skipFormElements: false, enabled: !isCommandPaletteOpen }
   );
 
   return (

--- a/src/renderer/components/mainWindow/MainTopBar.tsx
+++ b/src/renderer/components/mainWindow/MainTopBar.tsx
@@ -1,41 +1,23 @@
-import { useCallback } from 'react';
 import { RequestMethod } from 'shim/objects/request-method';
-import { useErrorHandler } from '@/components/ui/use-toast';
 import { HttpMethodSelect } from './mainTopBar/HttpMethodSelect';
 import { UrlInput } from './mainTopBar/UrlInput';
 import { SendButton } from './mainTopBar/SendButton';
-import { RendererEventService } from '@/services/event/renderer-event-service';
 import { selectRequest, useCollectionActions, useCollectionStore } from '@/state/collectionStore';
 import { ArrowRight, Loader2, SaveIcon, EraserIcon } from 'lucide-react';
-import { editor } from 'monaco-editor';
-import { saveModelContent } from '@/lib/monaco/models';
 import { TrufosURL } from 'shim/objects/url';
 import { IconButton } from '@/components/ui/icon-button';
 import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
-import { useSendRequest } from '@/hooks/request/useRequestActions';
-
-const eventService = RendererEventService.instance;
+import { useSendRequest, useSaveRequest } from '@/hooks/request/useRequestActions';
 
 export function MainTopBar() {
   const { updateRequest, discardChanges } = useCollectionActions();
   const request = useCollectionStore(selectRequest)!;
   const { url, method } = request;
   const { sendRequest, isSending } = useSendRequest();
+  const { saveRequest } = useSaveRequest();
 
   const handleUrlChange = (url: TrufosURL) => updateRequest({ url });
   const handleHttpMethodChange = (method: RequestMethod) => updateRequest({ method });
-
-  const saveRequest = useCallback(
-    useErrorHandler(async () => {
-      if (request == null) return;
-
-      console.info('Saving request:', request);
-      await Promise.all(editor.getModels().map(saveModelContent));
-
-      updateRequest(await eventService.saveChanges(request), true);
-    }),
-    [request]
-  );
 
   useHotkeys(
     [

--- a/src/renderer/components/mainWindow/MainTopBar.tsx
+++ b/src/renderer/components/mainWindow/MainTopBar.tsx
@@ -1,51 +1,29 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { RequestMethod } from 'shim/objects/request-method';
 import { useErrorHandler } from '@/components/ui/use-toast';
-import { HttpService } from '@/services/http/http-service';
 import { HttpMethodSelect } from './mainTopBar/HttpMethodSelect';
 import { UrlInput } from './mainTopBar/UrlInput';
 import { SendButton } from './mainTopBar/SendButton';
 import { RendererEventService } from '@/services/event/renderer-event-service';
 import { selectRequest, useCollectionActions, useCollectionStore } from '@/state/collectionStore';
-import { useResponseActions } from '@/state/responseStore';
 import { ArrowRight, Loader2, SaveIcon, EraserIcon } from 'lucide-react';
-import { showError } from '@/error/errorHandler';
 import { editor } from 'monaco-editor';
 import { saveModelContent } from '@/lib/monaco/models';
 import { TrufosURL } from 'shim/objects/url';
 import { IconButton } from '@/components/ui/icon-button';
 import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
+import { useSendRequest } from '@/hooks/request/useRequestActions';
 
-const httpService = HttpService.instance;
 const eventService = RendererEventService.instance;
 
 export function MainTopBar() {
-  const [isLoading, setIsLoading] = useState(false);
-
   const { updateRequest, discardChanges } = useCollectionActions();
-  const { addResponse } = useResponseActions();
   const request = useCollectionStore(selectRequest)!;
   const { url, method } = request;
+  const { sendRequest, isSending } = useSendRequest();
 
   const handleUrlChange = (url: TrufosURL) => updateRequest({ url });
   const handleHttpMethodChange = (method: RequestMethod) => updateRequest({ method });
-
-  const sendRequest = useCallback(
-    useErrorHandler(async () => {
-      try {
-        setIsLoading(true);
-        await Promise.all(editor.getModels().map(saveModelContent));
-
-        const response = await httpService.sendRequest(request);
-        addResponse(request.id, response);
-      } catch (error) {
-        showError(error);
-      } finally {
-        setIsLoading(false);
-      }
-    }),
-    [request, addResponse]
-  );
 
   const saveRequest = useCallback(
     useErrorHandler(async () => {
@@ -82,8 +60,8 @@ export function MainTopBar() {
         <SaveIcon />
       </IconButton>
 
-      <SendButton onClick={sendRequest} disabled={isLoading}>
-        {isLoading ? <Loader2 className="h-5 w-5 animate-spin" /> : <ArrowRight />}
+      <SendButton onClick={sendRequest} disabled={isSending}>
+        {isSending ? <Loader2 className="h-5 w-5 animate-spin" /> : <ArrowRight />}
       </SendButton>
     </div>
   );

--- a/src/renderer/components/mainWindow/bodyTabs/InputTabs/InputTabs.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/InputTabs/InputTabs.tsx
@@ -7,6 +7,7 @@ import { ParamsTab } from '@/components/mainWindow/bodyTabs/InputTabs/tabs/Param
 import { AuthorizationTab } from '@/components/mainWindow/bodyTabs/InputTabs/tabs/AuthorizationTab/AuthorizationTab';
 import { ScriptTab } from '@/components/mainWindow/bodyTabs/InputTabs/tabs/ScriptTab';
 import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
+import { HOTKEYS } from '@/hooks/hotKeys/hotkeys';
 
 interface InputTabsProps {
   className: string;
@@ -34,23 +35,23 @@ export function InputTabs(props: Readonly<InputTabsProps>) {
 
   useHotkeys([
     {
-      keys: 'mod+1',
+      keys: HOTKEYS.selectBodyTab,
       handler: () => setSelectedTab('body'),
     },
     {
-      keys: 'mod+2',
+      keys: HOTKEYS.selectQueryParamsTab,
       handler: () => setSelectedTab('queryParams'),
     },
     {
-      keys: 'mod+3',
+      keys: HOTKEYS.selectHeadersTab,
       handler: () => setSelectedTab('headers'),
     },
     {
-      keys: 'mod+4',
+      keys: HOTKEYS.selectAuthorizationTab,
       handler: () => setSelectedTab('authorization'),
     },
     {
-      keys: 'mod+5',
+      keys: HOTKEYS.selectScriptsTab,
       handler: () => setSelectedTab('scripts'),
     },
   ]);

--- a/src/renderer/components/mainWindow/bodyTabs/OutputTabs.tsx
+++ b/src/renderer/components/mainWindow/bodyTabs/OutputTabs.tsx
@@ -13,6 +13,7 @@ import { selectResponse, useResponseStore } from '@/state/responseStore';
 import { selectRequest, useCollectionStore } from '@/state/collectionStore';
 import { BodyTab } from './OutputTabs/BodyTab';
 import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
+import { HOTKEYS } from '@/hooks/hotKeys/hotkeys';
 
 interface OutputTabsProps {
   className: string;
@@ -28,11 +29,11 @@ export function OutputTabs({ className }: OutputTabsProps) {
 
   useHotkeys([
     {
-      keys: 'mod+6',
+      keys: HOTKEYS.selectResponseBodyTab,
       handler: () => setSelectedTab('body'),
     },
     {
-      keys: 'mod+7',
+      keys: HOTKEYS.selectResponseHeadersTab,
       handler: () => setSelectedTab('header'),
     },
   ]);

--- a/src/renderer/components/shared/settings/AppSettingsModal.tsx
+++ b/src/renderer/components/shared/settings/AppSettingsModal.tsx
@@ -1,11 +1,4 @@
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import { FiSettings } from 'react-icons/fi';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { TrufosTheme, type ThemePreference } from 'shim/app-settings';
 import {
   selectThemePreference,
@@ -20,16 +13,17 @@ const THEME_OPTIONS: { value: ThemePreference; label: string }[] = [
   { value: 'system', label: 'System' },
 ];
 
-export const AppSettingsModal = () => {
+export interface AppSettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const AppSettingsModal = ({ isOpen, onClose }: AppSettingsModalProps) => {
   const theme = useAppSettingsStore(selectThemePreference);
   const { updateSettings } = useAppSettingsActions();
 
   return (
-    <Dialog>
-      <DialogTrigger>
-        <FiSettings className="ml-2 text-xl" />
-      </DialogTrigger>
-
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle className="font-bold">Settings</DialogTitle>

--- a/src/renderer/components/sidebar/FooterBar.tsx
+++ b/src/renderer/components/sidebar/FooterBar.tsx
@@ -2,12 +2,14 @@ import { useEffect, useState } from 'react';
 
 import { RendererEventService } from '@/services/event/renderer-event-service';
 import { GithubIcon } from '@/components/icons';
-import { AppSettingsModal } from '@/components/shared/settings/AppSettingsModal';
 import { Divider } from '@/components/shared/Divider';
 import { SidebarFooter } from '@/components/ui/sidebar';
+import { useViewActions } from '@/state/viewStore';
+import { FiSettings } from 'react-icons/fi';
 
 export function FooterBar() {
   const [appVersion, setAppVersion] = useState<string | undefined>(undefined);
+  const { openAppSettings } = useViewActions();
 
   useEffect(() => {
     RendererEventService.instance.getAppVersion().then(setAppVersion);
@@ -19,7 +21,7 @@ export function FooterBar() {
       <div className="flex items-center justify-between">
         {/* Settings and theme toggle on the left */}
         <div className="flex items-center gap-2">
-          <AppSettingsModal />
+          <FiSettings className="ml-2 cursor-pointer text-xl" onClick={openAppSettings} />
           <span className="shrink-0 text-[12px] leading-[1.2] font-medium tracking-normal whitespace-pre text-(--text-secondary) normal-case no-underline">
             Settings
           </span>

--- a/src/renderer/components/sidebar/SidebarHeaderBar.test.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.test.tsx
@@ -83,7 +83,7 @@ describe('SidebarHeaderBar sort cycle', () => {
   });
 });
 
-describe('SidebarHeaderBar mod+n hotkey ownership while command palette is open (Task 19, I13)', () => {
+describe('SidebarHeaderBar mod+n hotkey ownership while command palette is open', () => {
   // @/state/viewStore is not mocked in this file (real, self-contained store) — same convention
   // used for openCollectionSettings above; toggle it directly for the gating assertions.
   const onCreateItem = vi.fn();

--- a/src/renderer/components/sidebar/SidebarHeaderBar.test.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.test.tsx
@@ -1,9 +1,10 @@
 import { render, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { SidebarHeaderBar } from './SidebarHeaderBar';
 import { SortMode, SORT_CYCLE } from './SidebarRequestList/treeUtilities';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { useViewStore } from '@/state/viewStore';
 
 const renderWithProvider = (ui: React.ReactElement) =>
   render(<TooltipProvider>{ui}</TooltipProvider>);
@@ -79,5 +80,42 @@ describe('SidebarHeaderBar sort cycle', () => {
     await user.hover(sortButton);
 
     expect((await screen.findAllByText('A → Z')).length).toBeGreaterThan(0);
+  });
+});
+
+describe('SidebarHeaderBar mod+n hotkey ownership while command palette is open (Task 19, I13)', () => {
+  // @/state/viewStore is not mocked in this file (real, self-contained store) — same convention
+  // used for openCollectionSettings above; toggle it directly for the gating assertions.
+  const onCreateItem = vi.fn();
+
+  const dispatchModN = () =>
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'n', metaKey: true, bubbles: true, cancelable: true })
+    );
+
+  beforeEach(() => {
+    onCreateItem.mockClear();
+    useViewStore.getState().closeCommandPalette();
+  });
+
+  afterEach(() => {
+    useViewStore.getState().closeCommandPalette();
+  });
+
+  it('does not open the new-request modal via mod+n while the command palette is open', () => {
+    useViewStore.getState().openCommandPalette();
+    renderWithProvider(<SidebarHeaderBar onCreateItem={onCreateItem} />);
+
+    dispatchModN();
+
+    expect(onCreateItem).not.toHaveBeenCalled();
+  });
+
+  it('still opens the new-request modal via mod+n when the command palette is closed', () => {
+    renderWithProvider(<SidebarHeaderBar onCreateItem={onCreateItem} />);
+
+    dispatchModN();
+
+    expect(onCreateItem).toHaveBeenCalledWith({ type: 'request', parentId: 'col-1' });
   });
 });

--- a/src/renderer/components/sidebar/SidebarHeaderBar.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.tsx
@@ -5,7 +5,7 @@ import { AddFolderIcon, CreateRequestIcon, SettingsIcon, SwapIcon } from '@/comp
 import { ArrowUpAZ, ArrowDownAZ, ClockArrowUp, ClockArrowDown } from 'lucide-react';
 
 import { useCollectionActions, useCollectionStore } from '@/state/collectionStore';
-import { useViewActions } from '@/state/viewStore';
+import { selectIsCommandPaletteOpen, useViewActions, useViewStore } from '@/state/viewStore';
 import CollectionDropdown from '@/components/sidebar/CollectionDropdown';
 import { Divider } from '@/components/shared/Divider';
 import { SortMode, SORT_CYCLE } from '@/components/sidebar/SidebarRequestList/treeUtilities';
@@ -47,6 +47,7 @@ export const SidebarHeaderBar = ({ onCreateItem }: SidebarHeaderBarProps) => {
   const sortMode = useCollectionStore((state) => state.sortMode);
   const { setSortMode } = useCollectionActions();
   const { openCollectionSettings } = useViewActions();
+  const isCommandPaletteOpen = useViewStore(selectIsCommandPaletteOpen);
 
   const buttonClassName = cn('flex h-4 w-4 items-center justify-center gap-1');
 
@@ -60,7 +61,12 @@ export const SidebarHeaderBar = ({ onCreateItem }: SidebarHeaderBarProps) => {
     setSortMode(SORT_CYCLE[(currentIndex + 1) % SORT_CYCLE.length]);
   };
 
-  useHotkeys([{ keys: HOTKEYS.newRequest, handler: () => openModal('request') }]);
+  // Disabled while the Command Palette is open — it owns this same shortcut then (I12/I13); see
+  // CommandPalette.tsx's own useHotkeys call.
+  useHotkeys(
+    [{ keys: HOTKEYS.newRequest, handler: () => openModal('request') }],
+    { enabled: !isCommandPaletteOpen }
+  );
 
   return (
     <SidebarHeader className="flex-col gap-6">

--- a/src/renderer/components/sidebar/SidebarHeaderBar.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.tsx
@@ -12,6 +12,7 @@ import { SortMode, SORT_CYCLE } from '@/components/sidebar/SidebarRequestList/tr
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { CreatingItem } from '@/components/sidebar/SidebarRequestList/types';
 import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
+import { HOTKEYS } from '@/hooks/hotKeys/hotkeys';
 
 const SORT_MODE_LABELS: Record<SortMode, string> = {
   [SortMode.DEFAULT]: 'Manual order',
@@ -59,7 +60,7 @@ export const SidebarHeaderBar = ({ onCreateItem }: SidebarHeaderBarProps) => {
     setSortMode(SORT_CYCLE[(currentIndex + 1) % SORT_CYCLE.length]);
   };
 
-  useHotkeys([{ keys: 'mod+n', handler: () => openModal('request') }]);
+  useHotkeys([{ keys: HOTKEYS.newRequest, handler: () => openModal('request') }]);
 
   return (
     <SidebarHeader className="flex-col gap-6">

--- a/src/renderer/components/sidebar/SidebarHeaderBar.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.tsx
@@ -61,7 +61,7 @@ export const SidebarHeaderBar = ({ onCreateItem }: SidebarHeaderBarProps) => {
     setSortMode(SORT_CYCLE[(currentIndex + 1) % SORT_CYCLE.length]);
   };
 
-  // Disabled while the Command Palette is open — it owns this same shortcut then (I12/I13); see
+  // Disabled while the Command Palette is open — it owns this same shortcut then; see
   // CommandPalette.tsx's own useHotkeys call.
   useHotkeys(
     [{ keys: HOTKEYS.newRequest, handler: () => openModal('request') }],

--- a/src/renderer/components/sidebar/SidebarHeaderBar.tsx
+++ b/src/renderer/components/sidebar/SidebarHeaderBar.tsx
@@ -63,10 +63,9 @@ export const SidebarHeaderBar = ({ onCreateItem }: SidebarHeaderBarProps) => {
 
   // Disabled while the Command Palette is open — it owns this same shortcut then; see
   // CommandPalette.tsx's own useHotkeys call.
-  useHotkeys(
-    [{ keys: HOTKEYS.newRequest, handler: () => openModal('request') }],
-    { enabled: !isCommandPaletteOpen }
-  );
+  useHotkeys([{ keys: HOTKEYS.newRequest, handler: () => openModal('request') }], {
+    enabled: !isCommandPaletteOpen,
+  });
 
   return (
     <SidebarHeader className="flex-col gap-6">

--- a/src/renderer/components/sidebar/SidebarRequestList/Nav/NavRequest.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/Nav/NavRequest.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { TrufosRequest } from 'shim/objects/request';
 import { SidebarMenuItem, SidebarMenuSubButton } from '@/components/ui/sidebar';
 import { RequestView } from '@/components/sidebar/SidebarRequestList/Nav/RequestView';
@@ -18,6 +19,20 @@ export const NavRequest = ({ requestId, depth = 0 }: NavRequestProps) => {
     id: requestId,
   });
 
+  // dnd-kit's setNodeRef is a callback ref with no readable `.current`, so a
+  // separate ref is needed to scroll the row into view once it's revealed.
+  const rowRef = useRef<HTMLDivElement>(null);
+  const setRefs = (node: HTMLDivElement | null) => {
+    setNodeRef(node);
+    rowRef.current = node;
+  };
+
+  useEffect(() => {
+    if (isHighlighted) {
+      rowRef.current?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [isHighlighted]);
+
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -26,7 +41,7 @@ export const NavRequest = ({ requestId, depth = 0 }: NavRequestProps) => {
 
   return (
     <div
-      ref={setNodeRef}
+      ref={setRefs}
       style={style}
       {...attributes}
       {...listeners}

--- a/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
+++ b/src/renderer/components/sidebar/SidebarRequestList/SidebarRequestList.tsx
@@ -28,6 +28,7 @@ import { Folder } from 'shim/objects/folder';
 import { TrufosRequest } from 'shim/objects/request';
 import { NavCreateItem } from '@/components/sidebar/SidebarRequestList/Nav/NavCreateItem';
 import { useHotkeys } from '@/hooks/hotKeys/useHotkey';
+import { HOTKEYS } from '@/hooks/hotKeys/hotkeys';
 
 import type { CreatingItem } from '@/components/sidebar/SidebarRequestList/types';
 interface SidebarRequestListProps {
@@ -179,11 +180,11 @@ export const SidebarRequestList = ({ creatingItem, onCreateItem }: SidebarReques
   useHotkeys(
     [
       {
-        keys: 'mod+pageup',
+        keys: HOTKEYS.selectPreviousRequest,
         handler: () => navigateRequest(-1),
       },
       {
-        keys: 'mod+pagedown',
+        keys: HOTKEYS.selectNextRequest,
         handler: () => navigateRequest(1),
       },
     ],

--- a/src/renderer/components/ui/command.tsx
+++ b/src/renderer/components/ui/command.tsx
@@ -13,7 +13,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+      'text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
       className
     )}
     {...props}
@@ -25,7 +25,7 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="**:[[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group]]:px-2 **:[[cmdk-input]]:h-12 **:[[cmdk-item]]:px-2 **:[[cmdk-item]]:py-3">
           {children}
         </Command>
       </DialogContent>
@@ -37,12 +37,12 @@ const CommandInput = React.forwardRef<
   React.ComponentRef<typeof CommandPrimitive.Input>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
-  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+  <div className="flex items-center rounded bg-(--background-secondary) px-3" cmdk-input-wrapper="">
     <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        'placeholder:text-muted-foreground flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+        'placeholder:text-muted-foreground flex h-11 w-full rounded-md py-3 text-sm text-(--text-secondary) outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
         className
       )}
       {...props}
@@ -58,7 +58,7 @@ const CommandList = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.List
     ref={ref}
-    className={cn('max-h-[300px] overflow-x-hidden overflow-y-auto', className)}
+    className={cn('max-h-75 overflow-x-hidden overflow-y-auto', className)}
     {...props}
   />
 ));
@@ -81,7 +81,7 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium',
+      'overflow-hidden p-1 text-(--border) **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium',
       className
     )}
     {...props}
@@ -109,7 +109,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-(--text-secondary) outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className
     )}
     {...props}

--- a/src/renderer/components/ui/command.tsx
+++ b/src/renderer/components/ui/command.tsx
@@ -42,7 +42,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        'placeholder:text-muted-foreground flex h-11 w-full rounded-md py-3 text-sm text-(--text-secondary) outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+        'placeholder:text-muted-foreground flex h-11 w-full rounded-md py-2 text-sm text-(--text-secondary) outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
         className
       )}
       {...props}

--- a/src/renderer/components/ui/tabs.tsx
+++ b/src/renderer/components/ui/tabs.tsx
@@ -21,7 +21,7 @@ const TabsList = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.List
     ref={ref}
-    className={cn('bg-background flex h-10 gap-2 rounded-md rounded-b-none', className)}
+    className={cn('bg-background flex gap-2 rounded-md rounded-b-none', className)}
     {...props}
   />
 ));

--- a/src/renderer/hooks/hotKeys/hotkeyDisplay.tsx
+++ b/src/renderer/hooks/hotKeys/hotkeyDisplay.tsx
@@ -1,0 +1,23 @@
+import type { ReactElement } from 'react';
+import { Command as CommandShortcutIcon } from 'lucide-react';
+
+const isMac = navigator.platform.startsWith('Mac');
+
+/**
+ * Formats a `HOTKEYS.*` string (the same `'+'`-separated format `matchesHotkey` parses, see
+ * `useHotkey.ts`) into a platform-aware display badge: the Mac ⌘ glyph or the literal `'Ctrl'`
+ * for the modifier, and the uppercased trailing key (`'enter'` → `'Enter'`).
+ */
+export function formatHotkeyForDisplay(hotkey: string): {
+  modifier: ReactElement | string;
+  key: string;
+} {
+  const parts = hotkey.toLowerCase().split('+');
+  const rawKey = parts[parts.length - 1];
+  const key = rawKey === 'enter' ? 'Enter' : rawKey.toUpperCase();
+
+  return {
+    modifier: isMac ? <CommandShortcutIcon size={12} /> : 'Ctrl',
+    key,
+  };
+}

--- a/src/renderer/hooks/hotKeys/hotkeys.ts
+++ b/src/renderer/hooks/hotKeys/hotkeys.ts
@@ -9,6 +9,18 @@ export const HOTKEYS = {
   sendRequest: 'mod+enter',
   saveRequest: 'mod+s',
   newRequest: 'mod+n',
+  // Request body tabs (InputTabs.tsx)
+  selectBodyTab: 'mod+1',
+  selectQueryParamsTab: 'mod+2',
+  selectHeadersTab: 'mod+3',
+  selectAuthorizationTab: 'mod+4',
+  selectScriptsTab: 'mod+5',
+  // Response tabs (OutputTabs.tsx)
+  selectResponseBodyTab: 'mod+6',
+  selectResponseHeadersTab: 'mod+7',
+  // Sidebar request navigation (SidebarRequestList.tsx)
+  selectPreviousRequest: 'mod+pageup',
+  selectNextRequest: 'mod+pagedown',
 } as const;
 
 export type HotkeyName = keyof typeof HOTKEYS;

--- a/src/renderer/hooks/hotKeys/hotkeys.ts
+++ b/src/renderer/hooks/hotKeys/hotkeys.ts
@@ -21,6 +21,12 @@ export const HOTKEYS = {
   // Sidebar request navigation (SidebarRequestList.tsx)
   selectPreviousRequest: 'mod+pageup',
   selectNextRequest: 'mod+pagedown',
+  // Command palette tab-strip cycling (CommandPalette.tsx) — the only modifier-free entries, since
+  // this is local widget navigation, not a global app command
+  cyclePaletteTabForward: 'arrowright',
+  cyclePaletteTabForwardTab: 'tab',
+  cyclePaletteTabBackward: 'arrowleft',
+  cyclePaletteTabBackwardTab: 'shift+tab',
 } as const;
 
 export type HotkeyName = keyof typeof HOTKEYS;

--- a/src/renderer/hooks/hotKeys/hotkeys.ts
+++ b/src/renderer/hooks/hotKeys/hotkeys.ts
@@ -1,0 +1,14 @@
+/**
+ * Single source of truth for every global keyboard shortcut string registered via `useHotkeys`
+ * somewhere in the renderer. Both the real `useHotkeys` registration and any UI that displays the
+ * shortcut (e.g. `CommandPalette.tsx`'s action-item badges, via `formatHotkeyForDisplay`) read
+ * from this map — changing a value here changes the real binding and every place it's shown.
+ */
+export const HOTKEYS = {
+  openCommandPalette: 'mod+k',
+  sendRequest: 'mod+enter',
+  saveRequest: 'mod+s',
+  newRequest: 'mod+n',
+} as const;
+
+export type HotkeyName = keyof typeof HOTKEYS;

--- a/src/renderer/hooks/hotKeys/useHotkey.test.ts
+++ b/src/renderer/hooks/hotKeys/useHotkey.test.ts
@@ -84,4 +84,60 @@ describe('useHotkeys', () => {
 
     document.body.removeChild(textarea);
   });
+
+  it('does not match an unrequested modifier: a plain "tab" hotkey does not fire on Shift+Tab', () => {
+    // Arrange
+    const handler = vi.fn();
+    renderHook(() => useHotkeys([{ keys: 'tab', handler }]));
+
+    // Act
+    dispatchKeyDown({ key: 'Tab', shiftKey: true });
+
+    // Assert
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does not match a missing modifier: a "shift+tab" hotkey does not fire on plain Tab', () => {
+    // Arrange
+    const handler = vi.fn();
+    renderHook(() => useHotkeys([{ keys: 'shift+tab', handler }]));
+
+    // Act
+    dispatchKeyDown({ key: 'Tab' });
+
+    // Assert
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('"tab" and "shift+tab" resolve to different handlers regardless of registration order', () => {
+    // Arrange
+    const forward = vi.fn();
+    const backward = vi.fn();
+    renderHook(() =>
+      useHotkeys([
+        { keys: 'tab', handler: forward },
+        { keys: 'shift+tab', handler: backward },
+      ])
+    );
+
+    // Act
+    dispatchKeyDown({ key: 'Tab' });
+    dispatchKeyDown({ key: 'Tab', shiftKey: true });
+
+    // Assert
+    expect(forward).toHaveBeenCalledTimes(1);
+    expect(backward).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not match an unrequested modifier: "mod+s" does not fire on Cmd/Ctrl+Shift+S', () => {
+    // Arrange
+    const handler = vi.fn();
+    renderHook(() => useHotkeys([{ keys: 'mod+s', handler }]));
+
+    // Act
+    dispatchKeyDown({ key: 's', metaKey: true, shiftKey: true });
+
+    // Assert
+    expect(handler).not.toHaveBeenCalled();
+  });
 });

--- a/src/renderer/hooks/hotKeys/useHotkey.ts
+++ b/src/renderer/hooks/hotKeys/useHotkey.ts
@@ -46,6 +46,13 @@ const matchesHotkey = (event: KeyboardEvent, hotkey: string) => {
   if (needsShift && !event.shiftKey) return false;
   if (needsAlt && !event.altKey) return false;
 
+  // Reject unrequested modifiers too — presence is checked above, absence here — so e.g. 'tab'
+  // doesn't also match Shift+Tab, and 'mod+s' doesn't also match Cmd/Ctrl+Shift+S.
+  if (!needsMod && !needsCtrl && event.ctrlKey) return false;
+  if (!needsMod && !needsMeta && event.metaKey) return false;
+  if (!needsShift && event.shiftKey) return false;
+  if (!needsAlt && event.altKey) return false;
+
   return normalizeKey(event.key) === key;
 };
 

--- a/src/renderer/hooks/request/useRequestActions.test.ts
+++ b/src/renderer/hooks/request/useRequestActions.test.ts
@@ -1,0 +1,147 @@
+import { act, renderHook } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useSendRequest, useSaveRequest } from './useRequestActions';
+
+const {
+  mockSendRequest,
+  mockSaveChanges,
+  mockSaveModelContent,
+  mockAddResponse,
+  mockUpdateRequest,
+  mockShowError,
+} = vi.hoisted(() => ({
+  mockSendRequest: vi.fn(),
+  mockSaveChanges: vi.fn(),
+  mockSaveModelContent: vi.fn(),
+  mockAddResponse: vi.fn(),
+  mockUpdateRequest: vi.fn(),
+  mockShowError: vi.fn(),
+}));
+
+let mockCurrentRequest: { id: string; draft?: boolean } | undefined;
+
+vi.mock('monaco-editor', () => ({
+  editor: { getModels: () => [] },
+}));
+
+vi.mock('@/lib/monaco/models', () => ({
+  saveModelContent: mockSaveModelContent,
+}));
+
+vi.mock('@/services/http/http-service', () => ({
+  HttpService: { instance: { sendRequest: mockSendRequest } },
+}));
+
+vi.mock('@/services/event/renderer-event-service', () => ({
+  RendererEventService: { instance: { saveChanges: mockSaveChanges } },
+}));
+
+vi.mock('@/error/errorHandler', () => ({
+  showError: mockShowError,
+}));
+
+vi.mock('@/state/collectionStore', () => ({
+  useCollectionStore: <T>(selector: (state: unknown) => T) => selector({}),
+  useCollectionActions: () => ({ updateRequest: mockUpdateRequest }),
+  selectRequest: () => mockCurrentRequest,
+}));
+
+vi.mock('@/state/responseStore', () => ({
+  useResponseActions: () => ({ addResponse: mockAddResponse }),
+}));
+
+describe('useSendRequest', () => {
+  beforeEach(() => {
+    mockCurrentRequest = { id: 'req-1' };
+    mockSendRequest.mockClear();
+    mockAddResponse.mockClear();
+  });
+
+  it('shares isSending across every hook instance, not just the caller that triggered it', async () => {
+    const a = renderHook(() => useSendRequest());
+    const b = renderHook(() => useSendRequest());
+
+    let resolveSend!: (value: unknown) => void;
+    mockSendRequest.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSend = resolve;
+        })
+    );
+
+    expect(a.result.current.isSending).toBe(false);
+    expect(b.result.current.isSending).toBe(false);
+
+    let sendPromise!: Promise<void>;
+    act(() => {
+      sendPromise = a.result.current.sendRequest();
+    });
+
+    // The send was triggered on `a`'s instance, but `b` — a completely separate hook call —
+    // must observe the same in-flight fact.
+    expect(a.result.current.isSending).toBe(true);
+    expect(b.result.current.isSending).toBe(true);
+
+    // Flush the microtask queue so the hook's internal `await Promise.all([])` (flushing zero
+    // Monaco models) resolves and execution reaches `httpService.sendRequest` — only then is
+    // `resolveSend` actually assigned by the mocked implementation above.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    resolveSend({});
+    await act(async () => {
+      await sendPromise;
+    });
+
+    expect(a.result.current.isSending).toBe(false);
+    expect(b.result.current.isSending).toBe(false);
+  });
+});
+
+describe('useSaveRequest', () => {
+  beforeEach(() => {
+    mockCurrentRequest = { id: 'req-1', draft: true };
+    mockSaveChanges.mockClear();
+    mockUpdateRequest.mockClear();
+  });
+
+  it('shares isSaving across every hook instance, not just the caller that triggered it', async () => {
+    const a = renderHook(() => useSaveRequest());
+    const b = renderHook(() => useSaveRequest());
+
+    let resolveSave!: (value: unknown) => void;
+    mockSaveChanges.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSave = resolve;
+        })
+    );
+
+    expect(a.result.current.isSaving).toBe(false);
+    expect(b.result.current.isSaving).toBe(false);
+
+    let savePromise!: Promise<void>;
+    act(() => {
+      savePromise = a.result.current.saveRequest();
+    });
+
+    expect(a.result.current.isSaving).toBe(true);
+    expect(b.result.current.isSaving).toBe(true);
+
+    // Flush the microtask queue so the hook's internal `await Promise.all([])` (flushing zero
+    // Monaco models) resolves and execution reaches `eventService.saveChanges` — only then is
+    // `resolveSave` actually assigned by the mocked implementation above.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    resolveSave({ id: 'req-1' });
+    await act(async () => {
+      await savePromise;
+    });
+
+    expect(a.result.current.isSaving).toBe(false);
+    expect(b.result.current.isSaving).toBe(false);
+  });
+});

--- a/src/renderer/hooks/request/useRequestActions.ts
+++ b/src/renderer/hooks/request/useRequestActions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import { editor } from 'monaco-editor';
 import { saveModelContent } from '@/lib/monaco/models';
 import { HttpService } from '@/services/http/http-service';
@@ -11,12 +11,42 @@ const httpService = HttpService.instance;
 const eventService = RendererEventService.instance;
 
 /**
+ * A boolean fact shared across every subscriber, independent of React's per-component state.
+ * Used so `isSending`/`isSaving` reflect one real in-flight operation no matter how many
+ * components call `useSendRequest`/`useSaveRequest` — a plain per-hook `useState` would instead
+ * give each caller its own disconnected copy of the same fact.
+ */
+function createBusyFlag() {
+  let value = false;
+  const listeners = new Set<() => void>();
+
+  return {
+    get: () => value,
+    set(next: boolean) {
+      value = next;
+      listeners.forEach((listener) => listener());
+    },
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}
+
+const sendingFlag = createBusyFlag();
+const savingFlag = createBusyFlag();
+
+/**
  * Shared send-request side effect: flushes every open Monaco editor model, sends the currently
  * selected request via the HTTP service, and stores the response. No-ops when there is no
  * selected request. Never throws — errors are caught and shown as a toast.
+ *
+ * `isSending` is a single fact shared across every caller of this hook (not a per-caller local
+ * state), so any UI reading it reflects whether the current request is being sent right now,
+ * regardless of which component triggered the send.
  */
 export function useSendRequest() {
-  const [isSending, setIsSending] = useState(false);
+  const isSending = useSyncExternalStore(sendingFlag.subscribe, sendingFlag.get);
   const request = useCollectionStore(selectRequest);
   const { addResponse } = useResponseActions();
 
@@ -24,7 +54,7 @@ export function useSendRequest() {
     if (request == null) return;
 
     try {
-      setIsSending(true);
+      sendingFlag.set(true);
       await Promise.all(editor.getModels().map(saveModelContent));
 
       const response = await httpService.sendRequest(request);
@@ -32,7 +62,7 @@ export function useSendRequest() {
     } catch (error) {
       showError(error);
     } finally {
-      setIsSending(false);
+      sendingFlag.set(false);
     }
   }, [request, addResponse]);
 
@@ -43,9 +73,13 @@ export function useSendRequest() {
  * Shared save-request side effect: flushes every open Monaco editor model, persists the currently
  * selected request via the event service, and syncs the store with the saved result. No-ops when
  * there is no selected request. Never throws — errors are caught and shown as a toast.
+ *
+ * `isSaving` is a single fact shared across every caller of this hook (not a per-caller local
+ * state), so any UI reading it reflects whether the current request is being saved right now,
+ * regardless of which component triggered the save.
  */
 export function useSaveRequest() {
-  const [isSaving, setIsSaving] = useState(false);
+  const isSaving = useSyncExternalStore(savingFlag.subscribe, savingFlag.get);
   const request = useCollectionStore(selectRequest);
   const { updateRequest } = useCollectionActions();
 
@@ -53,14 +87,14 @@ export function useSaveRequest() {
     if (request == null) return;
 
     try {
-      setIsSaving(true);
+      savingFlag.set(true);
       await Promise.all(editor.getModels().map(saveModelContent));
 
       updateRequest(await eventService.saveChanges(request), true);
     } catch (error) {
       showError(error);
     } finally {
-      setIsSaving(false);
+      savingFlag.set(false);
     }
   }, [request, updateRequest]);
 

--- a/src/renderer/hooks/request/useRequestActions.ts
+++ b/src/renderer/hooks/request/useRequestActions.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from 'react';
+import { editor } from 'monaco-editor';
+import { saveModelContent } from '@/lib/monaco/models';
+import { HttpService } from '@/services/http/http-service';
+import { showError } from '@/error/errorHandler';
+import { selectRequest, useCollectionStore } from '@/state/collectionStore';
+import { useResponseActions } from '@/state/responseStore';
+
+const httpService = HttpService.instance;
+
+/**
+ * Shared send-request side effect: flushes every open Monaco editor model, sends the currently
+ * selected request via the HTTP service, and stores the response. No-ops when there is no
+ * selected request. Never throws — errors are caught and shown as a toast.
+ */
+export function useSendRequest() {
+  const [isSending, setIsSending] = useState(false);
+  const request = useCollectionStore(selectRequest);
+  const { addResponse } = useResponseActions();
+
+  const sendRequest = useCallback(async () => {
+    if (request == null) return;
+
+    try {
+      setIsSending(true);
+      await Promise.all(editor.getModels().map(saveModelContent));
+
+      const response = await httpService.sendRequest(request);
+      addResponse(request.id, response);
+    } catch (error) {
+      showError(error);
+    } finally {
+      setIsSending(false);
+    }
+  }, [request, addResponse]);
+
+  return { sendRequest, isSending };
+}

--- a/src/renderer/hooks/request/useRequestActions.ts
+++ b/src/renderer/hooks/request/useRequestActions.ts
@@ -2,11 +2,13 @@ import { useCallback, useState } from 'react';
 import { editor } from 'monaco-editor';
 import { saveModelContent } from '@/lib/monaco/models';
 import { HttpService } from '@/services/http/http-service';
+import { RendererEventService } from '@/services/event/renderer-event-service';
 import { showError } from '@/error/errorHandler';
-import { selectRequest, useCollectionStore } from '@/state/collectionStore';
+import { selectRequest, useCollectionActions, useCollectionStore } from '@/state/collectionStore';
 import { useResponseActions } from '@/state/responseStore';
 
 const httpService = HttpService.instance;
+const eventService = RendererEventService.instance;
 
 /**
  * Shared send-request side effect: flushes every open Monaco editor model, sends the currently
@@ -35,4 +37,32 @@ export function useSendRequest() {
   }, [request, addResponse]);
 
   return { sendRequest, isSending };
+}
+
+/**
+ * Shared save-request side effect: flushes every open Monaco editor model, persists the currently
+ * selected request via the event service, and syncs the store with the saved result. No-ops when
+ * there is no selected request. Never throws — errors are caught and shown as a toast.
+ */
+export function useSaveRequest() {
+  const [isSaving, setIsSaving] = useState(false);
+  const request = useCollectionStore(selectRequest);
+  const { updateRequest } = useCollectionActions();
+
+  const saveRequest = useCallback(async () => {
+    if (request == null) return;
+
+    try {
+      setIsSaving(true);
+      await Promise.all(editor.getModels().map(saveModelContent));
+
+      updateRequest(await eventService.saveChanges(request), true);
+    } catch (error) {
+      showError(error);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [request, updateRequest]);
+
+  return { saveRequest, isSaving };
 }

--- a/src/renderer/state/collectionStore.ts
+++ b/src/renderer/state/collectionStore.ts
@@ -213,7 +213,18 @@ export const createCollectionStore = (collection: Collection) => {
           createModelsForRequest(id);
         }
 
-        set({ selectedRequestId: id });
+        set((state) => {
+          if (id != null) {
+            let parentId = state.requests.get(id)!.parentId;
+            while (parentId !== state.collection!.id) {
+              state.openFolders.add(parentId);
+              const folder = state.folders.get(parentId);
+              if (folder == null) break;
+              parentId = folder.parentId;
+            }
+          }
+          state.selectedRequestId = id;
+        });
       },
 
       setCurrentScriptType: (type) => {

--- a/src/renderer/state/viewStore.ts
+++ b/src/renderer/state/viewStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { useActions } from '@/state/helper/util';
+import type { CreatingItem } from '@/components/sidebar/SidebarRequestList/types';
 
 interface ViewState {
   /** Whether the collection runner modal is open */
@@ -11,6 +12,12 @@ interface ViewState {
   isCommandPaletteOpen: boolean;
   /** Whether the app settings modal is open */
   isAppSettingsOpen: boolean;
+  /**
+   * One-shot bridge slot: set by a source with no prop path to `Menubar.tsx`'s local
+   * `creatingItem` state (e.g. the Command Palette) to request the sidebar's inline
+   * create-item flow. `Menubar.tsx` consumes it and immediately clears it back to `null`.
+   */
+  pendingCreateItem: CreatingItem;
 }
 
 interface ViewActions {
@@ -22,6 +29,8 @@ interface ViewActions {
   closeCommandPalette(): void;
   openAppSettings(): void;
   closeAppSettings(): void;
+  /** Sets the pending create-item request; pass `null` to clear it. */
+  requestCreateItem(item: CreatingItem): void;
 }
 
 export const useViewStore = create<ViewState & ViewActions>()(
@@ -30,6 +39,7 @@ export const useViewStore = create<ViewState & ViewActions>()(
     isCollectionSettingsOpen: false,
     isCommandPaletteOpen: false,
     isAppSettingsOpen: false,
+    pendingCreateItem: null,
 
     openCollectionRunner() {
       set((state) => {
@@ -78,6 +88,12 @@ export const useViewStore = create<ViewState & ViewActions>()(
         state.isAppSettingsOpen = false;
       });
     },
+
+    requestCreateItem(item) {
+      set((state) => {
+        state.pendingCreateItem = item;
+      });
+    },
   }))
 );
 
@@ -85,4 +101,5 @@ export const selectIsCollectionRunnerOpen = (state: ViewState) => state.isCollec
 export const selectIsCollectionSettingsOpen = (state: ViewState) => state.isCollectionSettingsOpen;
 export const selectIsCommandPaletteOpen = (state: ViewState) => state.isCommandPaletteOpen;
 export const selectIsAppSettingsOpen = (state: ViewState) => state.isAppSettingsOpen;
+export const selectPendingCreateItem = (state: ViewState) => state.pendingCreateItem;
 export const useViewActions = (): ViewActions => useViewStore(useActions());

--- a/src/renderer/state/viewStore.ts
+++ b/src/renderer/state/viewStore.ts
@@ -7,6 +7,8 @@ interface ViewState {
   isCollectionRunnerOpen: boolean;
   /** Whether the collection settings modal is open */
   isCollectionSettingsOpen: boolean;
+  /** Whether the command palette is open */
+  isCommandPaletteOpen: boolean;
 }
 
 interface ViewActions {
@@ -14,12 +16,15 @@ interface ViewActions {
   closeCollectionRunner(): void;
   openCollectionSettings(): void;
   closeCollectionSettings(): void;
+  openCommandPalette(): void;
+  closeCommandPalette(): void;
 }
 
 export const useViewStore = create<ViewState & ViewActions>()(
   immer((set) => ({
     isCollectionRunnerOpen: false,
     isCollectionSettingsOpen: false,
+    isCommandPaletteOpen: false,
 
     openCollectionRunner() {
       set((state) => {
@@ -44,9 +49,22 @@ export const useViewStore = create<ViewState & ViewActions>()(
         state.isCollectionSettingsOpen = false;
       });
     },
+
+    openCommandPalette() {
+      set((state) => {
+        state.isCommandPaletteOpen = true;
+      });
+    },
+
+    closeCommandPalette() {
+      set((state) => {
+        state.isCommandPaletteOpen = false;
+      });
+    },
   }))
 );
 
 export const selectIsCollectionRunnerOpen = (state: ViewState) => state.isCollectionRunnerOpen;
 export const selectIsCollectionSettingsOpen = (state: ViewState) => state.isCollectionSettingsOpen;
+export const selectIsCommandPaletteOpen = (state: ViewState) => state.isCommandPaletteOpen;
 export const useViewActions = (): ViewActions => useViewStore(useActions());

--- a/src/renderer/state/viewStore.ts
+++ b/src/renderer/state/viewStore.ts
@@ -9,6 +9,8 @@ interface ViewState {
   isCollectionSettingsOpen: boolean;
   /** Whether the command palette is open */
   isCommandPaletteOpen: boolean;
+  /** Whether the app settings modal is open */
+  isAppSettingsOpen: boolean;
 }
 
 interface ViewActions {
@@ -18,6 +20,8 @@ interface ViewActions {
   closeCollectionSettings(): void;
   openCommandPalette(): void;
   closeCommandPalette(): void;
+  openAppSettings(): void;
+  closeAppSettings(): void;
 }
 
 export const useViewStore = create<ViewState & ViewActions>()(
@@ -25,6 +29,7 @@ export const useViewStore = create<ViewState & ViewActions>()(
     isCollectionRunnerOpen: false,
     isCollectionSettingsOpen: false,
     isCommandPaletteOpen: false,
+    isAppSettingsOpen: false,
 
     openCollectionRunner() {
       set((state) => {
@@ -61,10 +66,23 @@ export const useViewStore = create<ViewState & ViewActions>()(
         state.isCommandPaletteOpen = false;
       });
     },
+
+    openAppSettings() {
+      set((state) => {
+        state.isAppSettingsOpen = true;
+      });
+    },
+
+    closeAppSettings() {
+      set((state) => {
+        state.isAppSettingsOpen = false;
+      });
+    },
   }))
 );
 
 export const selectIsCollectionRunnerOpen = (state: ViewState) => state.isCollectionRunnerOpen;
 export const selectIsCollectionSettingsOpen = (state: ViewState) => state.isCollectionSettingsOpen;
 export const selectIsCommandPaletteOpen = (state: ViewState) => state.isCommandPaletteOpen;
+export const selectIsAppSettingsOpen = (state: ViewState) => state.isAppSettingsOpen;
 export const useViewActions = (): ViewActions => useViewStore(useActions());

--- a/src/renderer/view/Menubar.test.tsx
+++ b/src/renderer/view/Menubar.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Menubar } from './Menubar';
+import { useViewStore } from '@/state/viewStore';
+import type { CreatingItem } from '@/components/sidebar/SidebarRequestList/types';
+import { SidebarProvider } from '@/components/ui/sidebar';
+
+const renderMenubar = () =>
+  render(
+    <SidebarProvider>
+      <Menubar />
+    </SidebarProvider>
+  );
+
+// SidebarProvider itself renders <Toaster /> (components/ui/sonner.tsx), which needs a
+// ThemeProvider ancestor that in turn needs jsdom's window.matchMedia — unrelated to what this
+// test verifies (the pendingCreateItem bridge), so stub it out rather than wiring up theme context.
+vi.mock('@/components/ui/sonner', () => ({
+  Toaster: () => null,
+}));
+
+// Stub the heavy sidebar subtree — this test only cares whether Menubar folds viewStore's
+// pendingCreateItem into the creatingItem prop it passes down, not the subtree's own rendering.
+vi.mock('@/components/sidebar/SidebarHeaderBar', () => ({
+  SidebarHeaderBar: () => <div>SidebarHeaderBar</div>,
+}));
+
+vi.mock('@/components/sidebar/FooterBar', () => ({
+  FooterBar: () => <div>FooterBar</div>,
+}));
+
+vi.mock('@/components/sidebar/SidebarRequestList/SidebarRequestList', () => ({
+  SidebarRequestList: ({
+    creatingItem,
+    onCreateItem,
+  }: {
+    creatingItem: CreatingItem;
+    onCreateItem: (item: CreatingItem) => void;
+  }) => (
+    <div>
+      <div data-testid="creating-item">{creatingItem ? JSON.stringify(creatingItem) : 'none'}</div>
+      {/* Mirrors NavCreateItem.tsx's onCancel — the real sidebar's own way of clearing creatingItem */}
+      <button onClick={() => onCreateItem(null)}>Cancel create</button>
+    </div>
+  ),
+}));
+
+// @/state/viewStore is not mocked — real, self-contained store; toggled directly, same
+// convention SidebarHeaderBar.test.tsx already uses.
+describe('Menubar pendingCreateItem bridge', () => {
+  beforeEach(() => {
+    act(() => {
+      useViewStore.getState().requestCreateItem(null);
+    });
+  });
+
+  it('renders with no creating item by default', () => {
+    renderMenubar();
+
+    expect(screen.getByTestId('creating-item').textContent).toBe('none');
+  });
+
+  it('folds a pendingCreateItem request into SidebarRequestList and clears it from the store', async () => {
+    renderMenubar();
+
+    act(() => {
+      useViewStore.getState().requestCreateItem({ type: 'request', parentId: 'col-1' });
+    });
+
+    expect(
+      await screen.findByText(JSON.stringify({ type: 'request', parentId: 'col-1' }))
+    ).toBeDefined();
+    expect(useViewStore.getState().pendingCreateItem).toBeNull();
+  });
+
+  it('re-fires for a second identical request rather than silently no-oping', async () => {
+    const item: CreatingItem = { type: 'request', parentId: 'col-1' };
+    const user = userEvent.setup();
+    renderMenubar();
+
+    act(() => {
+      useViewStore.getState().requestCreateItem(item);
+    });
+    expect(await screen.findByText(JSON.stringify(item))).toBeDefined();
+    expect(useViewStore.getState().pendingCreateItem).toBeNull();
+
+    // Simulate the sidebar cancelling the creation (NavCreateItem.tsx's onCancel), clearing
+    // Menubar's local creatingItem back to null.
+    await user.click(screen.getByText('Cancel create'));
+    expect(screen.getByTestId('creating-item').textContent).toBe('none');
+
+    // Requesting the exact same value again must still re-fire the effect — pendingCreateItem
+    // is cleared back to null immediately after being consumed (viewStore.ts's requestCreateItem)
+    // specifically so this transition (null -> item) always looks like a change to Zustand/React,
+    // even when the item's shape is identical to the previous request.
+    act(() => {
+      useViewStore.getState().requestCreateItem(item);
+    });
+
+    expect(await screen.findByText(JSON.stringify(item))).toBeDefined();
+    expect(useViewStore.getState().pendingCreateItem).toBeNull();
+  });
+});

--- a/src/renderer/view/Menubar.tsx
+++ b/src/renderer/view/Menubar.tsx
@@ -1,12 +1,26 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Sidebar } from '@/components/ui/sidebar';
 import { FooterBar } from '@/components/sidebar/FooterBar';
 import { SidebarHeaderBar } from '@/components/sidebar/SidebarHeaderBar';
 import { SidebarRequestList } from '@/components/sidebar/SidebarRequestList/SidebarRequestList';
 import type { CreatingItem } from '@/components/sidebar/SidebarRequestList/types';
+import { selectPendingCreateItem, useViewActions, useViewStore } from '@/state/viewStore';
 
 export const Menubar = () => {
   const [creatingItem, setCreatingItem] = useState<CreatingItem>(null);
+
+  // Bridge: sources with no prop path to this local state (e.g. the Command Palette, a sibling
+  // under App.tsx's SidebarProvider) request an item via viewStore; this consumes the one-shot
+  // request and clears it back to null immediately.
+  const pendingCreateItem = useViewStore(selectPendingCreateItem);
+  const { requestCreateItem } = useViewActions();
+
+  useEffect(() => {
+    if (pendingCreateItem) {
+      setCreatingItem(pendingCreateItem);
+      requestCreateItem(null);
+    }
+  }, [pendingCreateItem, requestCreateItem]);
 
   return (
     <Sidebar className={'flex h-screen flex-col p-6'} collapsible={'none'}>


### PR DESCRIPTION
### **User description**
## Changes
For #867 

- Added Command Palette (mod+k) with All / Requests / Environments / Actions tabs
- Requests tab groups by folder; method badges aligned via CSS subgrid
- All tab: "Recent" (5 most-recent) on empty search, cross-section search otherwise
- Environments tab with active-env indicator
- Actions tab: Send/Save/New/Discard request, New Folder, Switch Environment, Collection Settings, Trufos Settings
- Migrated AppSettingsModal to controlled viewStore state
- Platform-aware shortcut badges (⌘ on Mac, Ctrl elsewhere)
- Selecting a request now expands ancestor folders and scrolls it into view in the sidebar
- Fixed hover/keyboard highlight color regression (divider vs accent)
- Fixed HTTP method badge showing wrong value for nested/duplicate-titled requests (cmdk selection collision + stale Immer state for nested folder items)
- Known follow-up (not in this PR): same stale-state pattern also affects rename/delete/discard/move for nested items in collectionStore.ts — worth its own issue

## Testing

- Manual tests performed. 
- CommandPalette.test.tsx created

## Checklist

- [X] Issue has been linked to this PR
- [X] Code has been reviewed by person creating the PR
- [X] Automated tests have been written, if possible
- [X] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person


___

### **PR Type**
Enhancement


___

### **Description**
- Add Command Palette (Mod+K) with All/Requests/Environments/Actions tabs

- Implement fuzzy search across requests, folders, collections, and actions

- Extract send/save request logic into reusable hooks with shared loading state

- Migrate AppSettingsModal to viewStore-driven open state for palette integration

- Fix hotkey matching to reject unrequested modifiers (e.g., Tab vs Shift+Tab)

- Auto-expand ancestor folders and scroll selected request into view in sidebar


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User presses Mod+K"] --> B["CommandPalette opens"]
  B --> C["All/Requests/Environments/Actions tabs"]
  C --> D["Fuzzy search results"]
  D --> E["Select request or action"]
  E --> F["Execute action or navigate"]
  F --> G["Palette closes"]
  H["useSendRequest/useSaveRequest hooks"] --> I["Shared loading state"]
  I --> J["MainTopBar and CommandPalette use same logic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>19 files</summary><table>
<tr>
  <td><strong>App.tsx</strong><dd><code>Integrate CommandPalette and AppSettingsModal into app root</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-72348b6b222462c023d009b90544f2799da3cf5b1eafc2d280f8a19041271230">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CommandPalette.tsx</strong><dd><code>Implement full command palette with tabs and search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-e722f2b99d46d31fa022681727fcaa973ffde571ef47d3f286ef22cf62ea563b">+458/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RequestResultsGrid.tsx</strong><dd><code>CSS subgrid layout for aligned request method badges</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-4e03ca31f5946beb3e19c8af301bc12dca8608b3f49c13e574c739a3a3745056">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MainTopBar.tsx</strong><dd><code>Refactor to use extracted useSendRequest/useSaveRequest hooks</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-2ffcaea3cb541bf2a319c21f4b364fa5b0d29c36c183908d44c7f05d4053f9f0">+13/-48</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>InputTabs.tsx</strong><dd><code>Use centralized HOTKEYS constants for tab navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>OutputTabs.tsx</strong><dd><code>Use centralized HOTKEYS constants for response tabs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-cdb6c46d76626456f074c8fc26e606d739a237d79847a45ca361bc184a0a7be2">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AppSettingsModal.tsx</strong><dd><code>Convert to controlled component with isOpen and onClose props</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-6675a9e18ade8705e607beb1ef50c70fed4b93d22edbb5a98d7a06a9f2de77e7">+8/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FooterBar.tsx</strong><dd><code>Replace AppSettingsModal with openAppSettings action call</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-25c68cd313881a17ee408b9b91fb0801147c9fddda323b67d8721a6dfa241a3a">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SidebarHeaderBar.tsx</strong><dd><code>Disable mod+n hotkey while command palette is open</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-f309b743e133009344d22d2c557e2a5cfdf6a8c316871c358fb1175dad843a16">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NavRequest.tsx</strong><dd><code>Auto-scroll selected request into view when highlighted</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-082424ffb7aaa08e3cf90536823898e941c782b90b82b0d8a65f1606a5613c42">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SidebarRequestList.tsx</strong><dd><code>Use centralized HOTKEYS constants for request navigation</code>&nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-8a3b19e4fb06d66cbab51b9daa33691eb40ae376d75ccba717327eaea8d28007">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>command.tsx</strong><dd><code>Update styling for command palette integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-a6c50b40e063802c618ab818c48f388b20d0b963f4612b0d1087a7ba07ccae14">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tabs.tsx</strong><dd><code>Remove fixed height from TabsList for flexible layout</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-2078b9c42084fbef8bb7422fff5864f185a4c22ea86b75a3df7b4798d4f61cde">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hotkeys.ts</strong><dd><code>Create single source of truth for all global keyboard shortcuts</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-f5cf4a2640d322b0265ba36c3c24112a027a75628b8533dc7d16dff3c1f5bc25">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hotkeyDisplay.tsx</strong><dd><code>Format hotkeys for platform-aware display with Mac/Ctrl badges</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-ba8dd411b2cfc0024d6339d22db8129dfdd998f945f85cbb8a66bd725335a8d6">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useRequestActions.ts</strong><dd><code>Extract send/save request logic with shared loading state</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-b0ebdd2e5f5087982512814ec9542e70cb96f2a2071d0993c2e2d9a14fa6c81b">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>collectionStore.ts</strong><dd><code>Auto-expand ancestor folders when selecting nested request</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-9bd66bf13fd7c115c613572a46b343298648618f8245cf60b86b6e420d738a32">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>viewStore.ts</strong><dd><code>Add command palette, app settings, and create-item bridge state</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-3f3242036ea07710b3828c5ecae6bcf8ed0bdfa1e31e303b9096f46300677a67">+53/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Menubar.tsx</strong><dd><code>Implement pendingCreateItem bridge from viewStore to sidebar</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-cc250f3311590dfd3658ab42da7506282879ccfe6caa66a353c5f7f8a3081085">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>CommandPalette.test.tsx</strong><dd><code>Comprehensive tests for palette functionality and hotkeys</code></dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-5cafa32b0cc2c46ee3d2560d1caec836a0121ca8928674eae7b8e34dae359909">+400/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SidebarHeaderBar.test.tsx</strong><dd><code>Add tests for hotkey ownership during palette open state</code>&nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-5531a71800f40921903cccc5d42f32426a1b4e4deef2a98141e42b94a47a1b34">+39/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useHotkey.test.ts</strong><dd><code>Add tests for modifier matching edge cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-715cae778dcc7c6ee5b0522e1281a6b7acb643617975b365e0d6f74b868911e4">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useRequestActions.test.ts</strong><dd><code>Test shared loading state across multiple hook instances</code>&nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-90fb6d8a927d3aeadd5fab360bbcf718c90ef327bc10b6a59cf4187d7785692b">+147/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Menubar.test.tsx</strong><dd><code>Test pendingCreateItem bridge and re-fire behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-9ef840e532a16420b317f7d114a4cc23ffd2f56f77ba97a15db35a2f46414776">+104/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug_fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>useHotkey.ts</strong><dd><code>Fix hotkey matching to reject unrequested modifiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-3a6e82627ace060e4872bef9c9cf464ec8dab01675ba1da3541d7e5a69aeb828">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>InputTabs.tsx</strong></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/986/files#diff-34facf6841ac77dbf09ad93791508a9173c180c0700c20440831fc20f6003de3">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

