### PR TITLE
feat(977): Variable Highlighting and Autocomplete in URL Input

### DIFF
--- a/src/main/event/main-event-service.test.ts
+++ b/src/main/event/main-event-service.test.ts
@@ -253,4 +253,32 @@ describe('MainEventService', () => {
       });
     });
   });
+
+  describe('resolveVariablesInString', () => {
+    const mockCollectionVariables = async (variables: Collection['variables']) => {
+      const { EnvironmentService } = await import('../environment/service/environment-service.js');
+      vi.spyOn(EnvironmentService.instance, 'currentCollection', 'get').mockReturnValue({
+        variables,
+        environments: {},
+      } as Collection);
+    };
+
+    it('should return the string with all variables replaced', async () => {
+      await mockCollectionVariables({ baseUrl: { value: 'https://example.com' } });
+      const eventService = new MainEventService();
+
+      await expect(eventService.resolveVariablesInString('{{ baseUrl }}/users')).resolves.toBe(
+        'https://example.com/users'
+      );
+    });
+
+    it('should return null when a variable is not defined', async () => {
+      await mockCollectionVariables({});
+      const eventService = new MainEventService();
+
+      await expect(
+        eventService.resolveVariablesInString('{{ missing }}/users')
+      ).resolves.toBeNull();
+    });
+  });
 });

--- a/src/main/event/main-event-service.ts
+++ b/src/main/event/main-event-service.ts
@@ -181,6 +181,10 @@ export class MainEventService implements IEventService {
     return environmentService.getVariable(key);
   }
 
+  async resolveVariablesInString(string: string) {
+    return await environmentService.setVariablesInString(string, true).catch(() => null);
+  }
+
   async setCollectionVariables(variables: VariableMap) {
     environmentService.setCollectionVariables(variables);
     await persistenceService.saveCollection(environmentService.currentCollection);

--- a/src/renderer/components/mainWindow/mainTopBar/UrlInput.test.tsx
+++ b/src/renderer/components/mainWindow/mainTopBar/UrlInput.test.tsx
@@ -1,10 +1,42 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { vi, describe, it, expect } from 'vitest';
-import { UrlInput } from './UrlInput';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { parseUrl } from 'shim/objects/url';
 
+// monaco does not run under jsdom, so the editor is replaced by a plain input here. Its own
+// behavior is covered by SingleLineEditor.test.tsx.
+vi.mock('@/lib/monaco/SingleLineEditor', () => ({
+  SingleLineEditor: ({
+    value,
+    onChange,
+    invalid,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    invalid?: boolean;
+  }) => (
+    <input
+      value={value}
+      data-invalid={invalid}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}));
+
+/** Stands in for the variable resolution of the main process. Defaults to a string without variables. */
+let resolve: (string: string) => string | null | undefined;
+
+vi.mock('@/hooks/useResolvedString', () => ({
+  useResolvedString: (string: string) => resolve(string),
+}));
+
+import { UrlInput } from './UrlInput';
+
 describe('UrlInput', () => {
+  beforeEach(() => {
+    resolve = (string) => string;
+  });
+
   it('should display the initial URL', () => {
     // Arrange
     const url = parseUrl('https://example.com');
@@ -32,12 +64,11 @@ describe('UrlInput', () => {
     expect(onChangeMock).toHaveBeenCalledWith(parseUrl('https://newurl.com'));
   });
 
-  it('should show error style for invalid URL', async () => {
+  it('should mark invalid URLs', async () => {
     // Arrange
     const user = userEvent.setup();
     const url = parseUrl('https://example.com');
-    const onChangeMock = vi.fn();
-    const { getByRole } = render(<UrlInput url={url} onChange={onChangeMock} />);
+    const { getByRole } = render(<UrlInput url={url} onChange={vi.fn()} />);
 
     // Act
     const input = getByRole('textbox') as HTMLInputElement;
@@ -45,7 +76,63 @@ describe('UrlInput', () => {
     await user.type(input, 'not-a-valid-url');
 
     // Assert
-    expect(input.className).toContain('border-(--error)');
+    expect(input.dataset.invalid).toBe('true');
+  });
+
+  it('should accept a URL with variables that resolves to a valid URL', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    resolve = () => 'https://api.example.com/users';
+    const { getByRole } = render(<UrlInput url={parseUrl('')} onChange={vi.fn()} />);
+
+    // Act
+    const input = getByRole('textbox') as HTMLInputElement;
+    await user.type(input, '{{{{ baseUrl }}/users');
+
+    // Assert
+    expect(input.value).toBe('{{ baseUrl }}/users');
+    expect(input.dataset.invalid).toBe('false');
+  });
+
+  it('should reject a URL with variables that resolves to an invalid URL', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    resolve = () => '/users';
+    const { getByRole } = render(<UrlInput url={parseUrl('')} onChange={vi.fn()} />);
+
+    // Act
+    const input = getByRole('textbox') as HTMLInputElement;
+    await user.type(input, '{{{{ basePath }}/users');
+
+    // Assert
+    expect(input.dataset.invalid).toBe('true');
+  });
+
+  it('should reject a URL with an undefined variable', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    resolve = () => null;
+    const { getByRole } = render(<UrlInput url={parseUrl('')} onChange={vi.fn()} />);
+
+    // Act
+    const input = getByRole('textbox') as HTMLInputElement;
+    await user.type(input, '{{{{ missing }}/users');
+
+    // Assert
+    expect(input.dataset.invalid).toBe('true');
+  });
+
+  it('should not mark the URL as invalid while the variables are being resolved', () => {
+    // Arrange
+    resolve = () => undefined;
+
+    // Act
+    const { getByRole } = render(
+      <UrlInput url={parseUrl('{{ baseUrl }}/users')} onChange={vi.fn()} />
+    );
+
+    // Assert
+    expect((getByRole('textbox') as HTMLInputElement).dataset.invalid).toBe('false');
   });
 
   it('should handle URLs with query parameters', async () => {

--- a/src/renderer/components/mainWindow/mainTopBar/UrlInput.tsx
+++ b/src/renderer/components/mainWindow/mainTopBar/UrlInput.tsx
@@ -1,5 +1,5 @@
-import { Input } from '@/components/ui/input';
-import { cn } from '@/lib/utils';
+import { useResolvedString } from '@/hooks/useResolvedString';
+import { SingleLineEditor } from '@/lib/monaco/SingleLineEditor';
 import { useStateDerived } from '@/util/react-util';
 import { FC, useCallback } from 'react';
 import { buildUrl, isUrlValid, parseUrl, TrufosURL, urlsEqual } from 'shim/objects/url';
@@ -11,13 +11,14 @@ interface UrlInputProps {
 
 export const UrlInput: FC<UrlInputProps> = ({ url, onChange }) => {
   const [inputValue, setInputValue] = useStateDerived(url, buildUrl);
-  const [isValid, setIsValid] = useStateDerived(url, isUrlValid);
+  const resolvedUrl = useResolvedString(inputValue);
+
+  // while the variables are being resolved, the URL is assumed to be valid to avoid flickering
+  const isValid = resolvedUrl === undefined || isUrlValid(resolvedUrl);
 
   const handleChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const newValue = event.target.value;
+    (newValue: string) => {
       setInputValue(newValue);
-      setIsValid(URL.canParse(newValue));
       const newUrl = parseUrl(newValue);
       if (!urlsEqual(url, newUrl)) onChange(newUrl);
     },
@@ -25,13 +26,11 @@ export const UrlInput: FC<UrlInputProps> = ({ url, onChange }) => {
   );
 
   return (
-    <Input
+    <SingleLineEditor
       value={inputValue}
-      type="url"
-      inputMode="url"
-      className={cn('bg-background-secondary relative w-full grow rounded-l-none', {
-        'border-(--error)': !isValid,
-      })}
+      invalid={!isValid}
+      ariaLabel="URL"
+      className="bg-background-secondary relative w-full grow rounded-l-none"
       onChange={handleChange}
     />
   );

--- a/src/renderer/components/shared/settings/monaco-settings.ts
+++ b/src/renderer/components/shared/settings/monaco-settings.ts
@@ -29,6 +29,37 @@ export const SCRIPT_EDITOR_OPTIONS: Partial<editor.IStandaloneEditorConstruction
 };
 
 /**
+ * Height of a single line editor in pixels. Must match the line height of
+ * {@link SINGLE_LINE_EDITOR_OPTIONS}.
+ */
+export const SINGLE_LINE_EDITOR_HEIGHT = 20;
+
+/**
+ * Options for editors that hold a single line of text and therefore hide everything that only
+ * makes sense in a multi-line editor.
+ */
+export const SINGLE_LINE_EDITOR_OPTIONS: Partial<editor.IStandaloneEditorConstructionOptions> = {
+  ...DEFAULT_MONACO_OPTIONS,
+  fontSize: 14, // same as the text-sm of a regular input
+  lineHeight: SINGLE_LINE_EDITOR_HEIGHT,
+  lineNumbers: 'off',
+  lineDecorationsWidth: 0,
+  glyphMargin: false,
+  folding: false,
+  overviewRulerLanes: 0,
+  renderLineHighlight: 'none',
+  occurrencesHighlight: 'off',
+  links: false,
+  wordWrap: 'off',
+  scrollBeyondLastLine: false,
+  scrollBeyondLastColumn: 0,
+  scrollbar: { vertical: 'hidden', horizontal: 'hidden', handleMouseWheel: false },
+  padding: { top: 0, bottom: 0 },
+  find: { addExtraSpaceOnTop: false, seedSearchStringFromSelection: 'never' },
+  automaticLayout: true,
+};
+
+/**
  * Maximum length of a template variable string including the brackets and spaces between.
  */
 export const MAX_TEMPLATE_VARIABLE_LENGTH = 100;

--- a/src/renderer/hooks/useResolvedString.test.ts
+++ b/src/renderer/hooks/useResolvedString.test.ts
@@ -1,0 +1,143 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const resolveVariablesInString = vi.fn<(string: string) => Promise<string | null>>();
+
+// the mocks are hoisted, so they must not dereference the variables above before the tests run
+vi.mock('@/services/event/renderer-event-service', () => ({
+  RendererEventService: {
+    instance: { resolveVariablesInString: (string: string) => resolveVariablesInString(string) },
+  },
+}));
+
+const variableState = { variables: {} as Record<string, unknown> };
+vi.mock('@/state/variableStore', () => ({
+  useVariableStore: (selector: (state: typeof variableState) => unknown) => selector(variableState),
+  selectVariables: (state: typeof variableState) => state.variables,
+}));
+
+const environmentState = {
+  environments: {} as Record<string, { variables: Record<string, unknown> }>,
+  selectedEnvironment: undefined as string | undefined,
+};
+vi.mock('@/state/environmentStore', () => ({
+  useEnvironmentStore: (selector: (state: typeof environmentState) => unknown) =>
+    selector(environmentState),
+}));
+
+import { useResolvedString } from './useResolvedString';
+
+describe('useResolvedString', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    variableState.variables = {};
+    environmentState.environments = {};
+    environmentState.selectedEnvironment = undefined;
+  });
+
+  it('should return the resolved string', async () => {
+    // Arrange
+    resolveVariablesInString.mockResolvedValue('https://example.com/users');
+
+    // Act
+    const { result } = renderHook(() => useResolvedString('{{ baseUrl }}/users'));
+
+    // Assert
+    expect(result.current).toBeUndefined(); // still pending
+    await waitFor(() => expect(result.current).toBe('https://example.com/users'));
+    expect(resolveVariablesInString).toHaveBeenCalledWith('{{ baseUrl }}/users');
+  });
+
+  it('should return null when a variable is not defined', async () => {
+    // Arrange
+    resolveVariablesInString.mockResolvedValue(null);
+
+    // Act
+    const { result } = renderHook(() => useResolvedString('{{ missing }}'));
+
+    // Assert
+    await waitFor(() => expect(result.current).toBeNull());
+  });
+
+  it('should stay pending when the resolution fails', async () => {
+    // Arrange
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    resolveVariablesInString.mockRejectedValue(new Error('IPC is broken'));
+
+    // Act
+    const { result } = renderHook(() => useResolvedString('{{ baseUrl }}'));
+
+    // Assert
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should resolve again when the string changes', async () => {
+    // Arrange
+    resolveVariablesInString.mockResolvedValue('first');
+    const { result, rerender } = renderHook(({ string }) => useResolvedString(string), {
+      initialProps: { string: 'a' },
+    });
+    await waitFor(() => expect(result.current).toBe('first'));
+
+    // Act
+    resolveVariablesInString.mockResolvedValue('second');
+    rerender({ string: 'b' });
+
+    // Assert
+    await waitFor(() => expect(result.current).toBe('second'));
+    expect(resolveVariablesInString).toHaveBeenCalledTimes(2);
+  });
+
+  it('should resolve again when the collection variables change', async () => {
+    // Arrange
+    resolveVariablesInString.mockResolvedValue('first');
+    const { result, rerender } = renderHook(() => useResolvedString('{{ baseUrl }}'));
+    await waitFor(() => expect(result.current).toBe('first'));
+
+    // Act
+    variableState.variables = { baseUrl: { value: 'https://example.com' } };
+    resolveVariablesInString.mockResolvedValue('second');
+    rerender();
+
+    // Assert
+    await waitFor(() => expect(result.current).toBe('second'));
+  });
+
+  it('should resolve again when another environment is selected', async () => {
+    // Arrange
+    environmentState.environments = { dev: { variables: {} }, prod: { variables: {} } };
+    environmentState.selectedEnvironment = 'dev';
+    resolveVariablesInString.mockResolvedValue('first');
+    const { result, rerender } = renderHook(() => useResolvedString('{{ baseUrl }}'));
+    await waitFor(() => expect(result.current).toBe('first'));
+
+    // Act
+    environmentState.selectedEnvironment = 'prod';
+    resolveVariablesInString.mockResolvedValue('second');
+    rerender();
+
+    // Assert
+    await waitFor(() => expect(result.current).toBe('second'));
+  });
+
+  it('should ignore the result of an outdated resolution', async () => {
+    // Arrange: the first resolution finishes after the second one
+    let resolveFirst!: (value: string) => void;
+    resolveVariablesInString.mockReturnValueOnce(
+      new Promise((resolve) => (resolveFirst = resolve))
+    );
+    resolveVariablesInString.mockResolvedValueOnce('second');
+    const { result, rerender } = renderHook(({ string }) => useResolvedString(string), {
+      initialProps: { string: 'a' },
+    });
+
+    // Act
+    rerender({ string: 'b' });
+    await waitFor(() => expect(result.current).toBe('second'));
+    resolveFirst('first');
+
+    // Assert
+    await waitFor(() => expect(result.current).toBe('second'));
+  });
+});

--- a/src/renderer/hooks/useResolvedString.ts
+++ b/src/renderer/hooks/useResolvedString.ts
@@ -1,0 +1,38 @@
+import { RendererEventService } from '@/services/event/renderer-event-service';
+import { useEnvironmentStore } from '@/state/environmentStore';
+import { selectVariables, useVariableStore } from '@/state/variableStore';
+import { useEffect, useState } from 'react';
+
+const eventService = RendererEventService.instance;
+
+/**
+ * Resolves the template variables in the given string. The string is resolved again whenever it or
+ * one of the variables it may reference changes.
+ *
+ * @param string The string that may contain `{{ someVariable }}` templates.
+ * @returns The resolved string, null if it references a variable that is not defined, or undefined
+ * while the resolution is still pending.
+ */
+export function useResolvedString(string: string) {
+  const collectionVariables = useVariableStore(selectVariables);
+  const environmentVariables = useEnvironmentStore(
+    (state) => state.environments[state.selectedEnvironment ?? '']?.variables
+  );
+  const [resolvedString, setResolvedString] = useState<string | null>();
+
+  useEffect(() => {
+    let obsolete = false;
+    eventService
+      .resolveVariablesInString(string)
+      .then((resolvedString) => {
+        if (!obsolete) setResolvedString(resolvedString);
+      })
+      .catch(console.error);
+
+    return () => {
+      obsolete = true;
+    };
+  }, [string, collectionVariables, environmentVariables]);
+
+  return resolvedString;
+}

--- a/src/renderer/lib/monaco/SingleLineEditor.test.tsx
+++ b/src/renderer/lib/monaco/SingleLineEditor.test.tsx
@@ -1,0 +1,114 @@
+import { render, cleanup } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { KeyCode, type editor } from 'monaco-editor';
+import { EditorProps, OnMount } from '@monaco-editor/react';
+import { useEffect } from 'react';
+
+// only KeyCode is used at runtime, and monaco itself does not run under jsdom
+vi.mock('monaco-editor', () => ({ KeyCode: { Enter: 3 } }));
+
+const addCommand = vi.fn();
+
+/** The props that {@link SingleLineEditor} passed to the monaco editor on the last render. */
+let editorProps: EditorProps;
+
+// monaco does not run under jsdom, so the editor is replaced by a stub capturing its props
+vi.mock('@/lib/monaco/MonacoEditor', () => ({
+  default: (props: EditorProps) => {
+    editorProps = props;
+    useEffect(() => {
+      (props.onMount as OnMount)?.(
+        { addCommand } as unknown as editor.IStandaloneCodeEditor,
+        {} as Parameters<OnMount>[1] // the component does not use the monaco namespace
+      );
+    }, []);
+    return <div data-testid="monaco-editor" />;
+  },
+}));
+
+vi.mock('@/lib/monaco/language', () => ({ Language: { TEXT: 'plaintext' } }));
+
+vi.mock('@/components/shared/settings/monaco-settings', () => ({
+  SINGLE_LINE_EDITOR_HEIGHT: 20,
+  SINGLE_LINE_EDITOR_OPTIONS: {},
+}));
+
+import { SingleLineEditor } from './SingleLineEditor';
+
+describe('SingleLineEditor', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => cleanup());
+
+  it('should show the value in a plaintext editor to highlight template variables', () => {
+    // Arrange
+    render(<SingleLineEditor value="{{ baseUrl }}/users" onChange={vi.fn()} />);
+
+    // Assert
+    expect(editorProps.value).toBe('{{ baseUrl }}/users');
+    expect(editorProps.language).toBe('plaintext');
+  });
+
+  it('should report changes made by the user', () => {
+    // Arrange
+    const onChange = vi.fn();
+    render(<SingleLineEditor value="https://" onChange={onChange} />);
+
+    // Act
+    editorProps.onChange?.('https://example.com', {} as editor.IModelContentChangedEvent);
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('should strip line breaks from the reported value', () => {
+    // Arrange
+    const onChange = vi.fn();
+    render(<SingleLineEditor value="https://" onChange={onChange} />);
+
+    // Act
+    editorProps.onChange?.('https://example\n.com\r\n', {} as editor.IModelContentChangedEvent);
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('should report an empty value when the editor is cleared', () => {
+    // Arrange
+    const onChange = vi.fn();
+    render(<SingleLineEditor value="https://" onChange={onChange} />);
+
+    // Act
+    editorProps.onChange?.(undefined, {} as editor.IModelContentChangedEvent);
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  it('should swallow enter unless the suggestion widget is open', () => {
+    // Arrange
+    render(<SingleLineEditor value="" onChange={vi.fn()} />);
+
+    // Assert
+    expect(addCommand).toHaveBeenCalledWith(
+      KeyCode.Enter,
+      expect.any(Function),
+      '!suggestWidgetVisible'
+    );
+  });
+
+  it('should show the error color when invalid', () => {
+    // Arrange
+    const { container } = render(<SingleLineEditor value="" invalid onChange={vi.fn()} />);
+
+    // Assert
+    expect(container.firstElementChild?.className).toContain('border-(--error)');
+  });
+
+  it('should not show the error color when valid', () => {
+    // Arrange
+    const { container } = render(<SingleLineEditor value="" onChange={vi.fn()} />);
+
+    // Assert
+    expect(container.firstElementChild?.className).not.toContain('border-(--error)');
+  });
+});

--- a/src/renderer/lib/monaco/SingleLineEditor.tsx
+++ b/src/renderer/lib/monaco/SingleLineEditor.tsx
@@ -1,0 +1,68 @@
+import {
+  SINGLE_LINE_EDITOR_HEIGHT,
+  SINGLE_LINE_EDITOR_OPTIONS,
+} from '@/components/shared/settings/monaco-settings';
+import { Language } from '@/lib/monaco/language';
+import MonacoEditor from '@/lib/monaco/MonacoEditor';
+import { cn } from '@/lib/utils';
+import { OnMount } from '@monaco-editor/react';
+import { KeyCode } from 'monaco-editor';
+
+/** Matches the line breaks that a single line editor must not contain. */
+const LINE_BREAK_REGEX = /[\r\n]+/g;
+
+const handleMount: OnMount = (editor) => {
+  // swallow the line break, but keep enter usable for accepting a variable suggestion
+  editor.addCommand(KeyCode.Enter, () => {}, '!suggestWidgetVisible');
+};
+
+interface SingleLineEditorProps {
+  /** The text to show in the editor. */
+  value: string;
+
+  /** Called with the new text whenever the user changes it. */
+  onChange: (value: string) => void;
+
+  /** Whether to mark the editor with the error color. */
+  invalid?: boolean;
+
+  /** The label announced by screen readers. */
+  ariaLabel?: string;
+
+  className?: string;
+}
+
+/**
+ * A single line text input backed by monaco. In contrast to a plain HTML input, it highlights
+ * template variables and shows their current value on hover, just like the request body editor.
+ *
+ * Line breaks are stripped from the reported value, so the {@link SingleLineEditorProps.value} must
+ * be updated on change to keep pasted text on a single line.
+ */
+export function SingleLineEditor({
+  value,
+  onChange,
+  invalid,
+  ariaLabel,
+  className,
+}: SingleLineEditorProps) {
+  return (
+    <div
+      className={cn(
+        'border-border bg-background focus-within:border-accent-secondary flex h-10 items-center overflow-hidden rounded-full border px-3',
+        { 'border-(--error)': invalid },
+        className
+      )}
+    >
+      <MonacoEditor
+        height={SINGLE_LINE_EDITOR_HEIGHT}
+        language={Language.TEXT}
+        value={value}
+        options={{ ...SINGLE_LINE_EDITOR_OPTIONS, ariaLabel }}
+        loading={null}
+        onMount={handleMount}
+        onChange={(newValue = '') => onChange(newValue.replace(LINE_BREAK_REGEX, ''))}
+      />
+    </div>
+  );
+}

--- a/src/renderer/services/event/renderer-event-service.ts
+++ b/src/renderer/services/event/renderer-event-service.ts
@@ -60,6 +60,7 @@ export class RendererEventService implements IEventService {
   deleteObject = createEventMethod('deleteObject');
   getActiveEnvironmentVariables = createEventMethod('getActiveEnvironmentVariables');
   getVariable = createEventMethod('getVariable');
+  resolveVariablesInString = createEventMethod('resolveVariablesInString');
   setCollectionVariables = createEventMethod('setCollectionVariables');
   setEnvironmentVariables = createEventMethod('setEnvironmentVariables');
   saveFolder = createEventMethod('saveFolder');

--- a/src/shim/event-service.ts
+++ b/src/shim/event-service.ts
@@ -120,6 +120,13 @@ export interface IEventService {
   getVariable(key: string): Promise<VariableObject>;
 
   /**
+   * Replaces all `{{ someVariable }}` templates in the given string with their current values.
+   * @param string The string to resolve the variables in.
+   * @returns The resolved string, or null if it references a variable that is not defined.
+   */
+  resolveVariablesInString(string: string): Promise<string | null>;
+
+  /**
    * Replace all existing collection variables with the given ones.
    * @param variables The variables of the Collection to set.
    */

--- a/src/shim/objects/url.test.ts
+++ b/src/shim/objects/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildUrl, parseUrl, TrufosURL, urlsEqual } from './url';
+import { buildUrl, isUrlValid, parseUrl, TrufosURL, urlsEqual } from './url';
 
 describe('TrufosUrl', () => {
   it.each<[string, TrufosURL]>([
@@ -149,6 +149,21 @@ describe('TrufosUrl', () => {
   ])('buildUrl() should build correct URL string', (url, expected) => {
     // Act
     const result = buildUrl(url);
+
+    // Assert
+    expect(result).toBe(expected);
+  });
+
+  it.each<[string | null, boolean]>([
+    ['https://api.example.com/users?id=123', true],
+    ['not-a-valid-url', false],
+    // a URL containing variables is only valid once they are resolved
+    ['{{ baseUrl }}/users', false],
+    // null means that the URL references a variable that is not defined
+    [null, false],
+  ])('isUrlValid(%s) should return %s', (resolvedUrl, expected) => {
+    // Act
+    const result = isUrlValid(resolvedUrl);
 
     // Assert
     expect(result).toBe(expected);

--- a/src/shim/objects/url.ts
+++ b/src/shim/objects/url.ts
@@ -63,10 +63,13 @@ export function urlsEqual(url1: TrufosURL, url2: TrufosURL) {
 }
 
 /**
- * Check if a URL is valid.
- * @param url The URL to check.
+ * Check if a URL is valid. Template variables must already be resolved, because a URL like
+ * `{{ baseUrl }}/users` is only valid if the variables in it resolve to a valid URL.
+ *
+ * @param resolvedUrl The URL to check, with all template variables resolved. Pass null if the URL
+ * references a variable that is not defined.
  * @returns True if the URL is valid, false otherwise.
  */
-export function isUrlValid(url: TrufosURL) {
-  return URL.canParse(url.base);
+export function isUrlValid(resolvedUrl: string | null) {
+  return resolvedUrl != null && URL.canParse(resolvedUrl);
 }


### PR DESCRIPTION
### **User description**
## Changes

- Add variable autocompletion, highlighting and preview to URL input
- Add URL validation with resolved variables

## Testing

<img width="559" height="226" alt="image" src="https://github.com/user-attachments/assets/3f47d6cd-358f-466b-baa3-02cb6fa6e4f9" />

<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/38c91aaf-690a-4ca5-b4d9-57b818fbdde9" />


## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person


___

### **PR Type**
Enhancement


___

### **Description**
- Add variable highlighting and resolution to URL input field

- Replace plain input with Monaco editor for syntax highlighting

- Validate URLs after resolving template variables

- Support variable autocomplete and preview tooltips in URL


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["URL Input"] -->|"uses"| B["SingleLineEditor"]
  B -->|"highlights"| C["Template Variables"]
  A -->|"resolves via"| D["useResolvedString"]
  D -->|"calls"| E["resolveVariablesInString"]
  E -->|"validates"| F["URL Validity"]
  F -->|"marks invalid"| A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>UrlInput.tsx</strong><dd><code>Replace input with Monaco editor for URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/987/files#diff-4a4fc079fa6150628f0fbb4a392be8c4c316cd1c0a6b4a31b78e919e6b125f01">+11/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SingleLineEditor.tsx</strong><dd><code>Create single-line Monaco editor component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/987/files#diff-bf4037f567cb150658eddeeeb2d4717138dffbd264074ab03ca31fdf465bfd0b">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useResolvedString.ts</strong><dd><code>Hook for resolving template variables asynchronously</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/987/files#diff-c94675e0fb4acba86ea814448910d0e8a121da2af45f0ad04e4f8b8904233e32">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>renderer-event-service.ts</strong><dd><code>Expose resolveVariablesInString event method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/987/files#diff-6446e2be18634b05193826bf484b2b8bc0a1c252f5207f424de9e77b82f4444f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main-event-service.ts</strong><dd><code>Implement variable resolution in main process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/987/files#diff-88f162ee0fb07a5f96655c4e842df6fb5072f17b7c130b8099cfb16c16e65588">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>event-service.ts</strong><dd><code>Add resolveVariablesInString to interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/987/files#diff-9ca4fa37785e3ce6722e2ccb9049e915895c3efc6be7030ad0d8abf3e2933de3">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>url.ts</strong><dd><code>Update isUrlValid to handle resolved URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/987/files#diff-6cb07ad716d616eb154899f384be6e7a80c7225865bd0268211d973fb08ec58e">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>UrlInput.test.tsx</strong><dd><code>Add tests for variable resolution and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/987/files#diff-3cf2b555e67714ca87102afd9d997b34789ca019ea64065859ea90a11d24be4b">+93/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SingleLineEditor.test.tsx</strong><dd><code>Test single-line editor functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/987/files#diff-9e48dc51d700539cb22ce703980c8bea4b5eb06d6a900e79c3d491e265fbf393">+114/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useResolvedString.test.ts</strong><dd><code>Test variable resolution hook behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/987/files#diff-b2ef8851648be5df975d13ee4ecf49325fcc137ee952ecc41fbcdd770e42efea">+143/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main-event-service.test.ts</strong><dd><code>Test variable resolution implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/987/files#diff-bf14319b9cd04db995a57fd7fa8d2c755249179873dd3725b845f875667c0e89">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>url.test.ts</strong><dd><code>Test URL validation with resolved variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/987/files#diff-d61bee7169b5c0854065e933eac9b4161d75bfaaa80be03fa84c489317217fd0">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>monaco-settings.ts</strong><dd><code>Add single-line editor Monaco configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/EXXETA/trufos/pull/987/files#diff-72e5ba3cb67dfa970b8f6cc1b3d9b4a7764aca7c5038c764a4ff473e8230b0a0">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

