### PR TITLE
fix(991): Newline not working in Request Editor

### DIFF
--- a/src/renderer/lib/monaco/SingleLineEditor.test.tsx
+++ b/src/renderer/lib/monaco/SingleLineEditor.test.tsx
@@ -15,6 +15,23 @@ const addAction = vi.fn(() => ({ dispose }));
 let disposeEditor: () => void;
 const onDidDispose = vi.fn((listener: () => void) => (disposeEditor = listener));
 
+/** Notifies the component of a model change the same way monaco does after a paste. */
+let changeModelContent: () => void;
+const onDidChangeModelContent = vi.fn(
+  (listener: () => void) => (changeModelContent = listener)
+) as unknown as editor.IStandaloneCodeEditor['onDidChangeModelContent'];
+
+const applyEdits = vi.fn();
+
+/** The lines of the model, e.g. ['https://example.com', ''] after pasting a URL with a line break. */
+let lines: string[] = [''];
+const getModel = () =>
+  ({
+    getLineCount: () => lines.length,
+    getLineMaxColumn: (lineNumber: number) => lines[lineNumber - 1].length + 1,
+    applyEdits,
+  }) as unknown as editor.ITextModel;
+
 /** The props that {@link SingleLineEditor} passed to the monaco editor on the last render. */
 let editorProps: EditorProps;
 
@@ -24,7 +41,13 @@ vi.mock('@/lib/monaco/MonacoEditor', () => ({
     editorProps = props;
     useEffect(() => {
       (props.onMount as OnMount)?.(
-        { addCommand, addAction, onDidDispose } as unknown as editor.IStandaloneCodeEditor,
+        {
+          addCommand,
+          addAction,
+          onDidDispose,
+          onDidChangeModelContent,
+          getModel,
+        } as unknown as editor.IStandaloneCodeEditor,
         {} as Parameters<OnMount>[1] // the component does not use the monaco namespace
       );
     }, []);
@@ -42,7 +65,10 @@ vi.mock('@/components/shared/settings/monaco-settings', () => ({
 import { SingleLineEditor } from './SingleLineEditor';
 
 describe('SingleLineEditor', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lines = [''];
+  });
   afterEach(() => cleanup());
 
   it('should show the value in a plaintext editor to highlight template variables', () => {
@@ -61,18 +87,6 @@ describe('SingleLineEditor', () => {
 
     // Act
     editorProps.onChange?.('https://example.com', {} as editor.IModelContentChangedEvent);
-
-    // Assert
-    expect(onChange).toHaveBeenCalledWith('https://example.com');
-  });
-
-  it('should strip line breaks from the reported value', () => {
-    // Arrange
-    const onChange = vi.fn();
-    render(<SingleLineEditor value="https://" onChange={onChange} />);
-
-    // Act
-    editorProps.onChange?.('https://example\n.com\r\n', {} as editor.IModelContentChangedEvent);
 
     // Assert
     expect(onChange).toHaveBeenCalledWith('https://example.com');
@@ -122,6 +136,35 @@ describe('SingleLineEditor', () => {
 
     // Assert
     expect(dispose).toHaveBeenCalled();
+  });
+
+  it('should join multi line text in the editor back into a single line', () => {
+    // Arrange
+    render(<SingleLineEditor value="https://example.com" onChange={vi.fn()} />);
+    lines = ['https://example.com', ''];
+
+    // Act: the user pasted a URL that ends with a line break
+    changeModelContent();
+
+    // Assert
+    expect(applyEdits).toHaveBeenCalledWith([
+      {
+        range: { startLineNumber: 1, startColumn: 20, endLineNumber: 2, endColumn: 1 },
+        text: '',
+      },
+    ]);
+  });
+
+  it('should not edit the editor content when it already is a single line', () => {
+    // Arrange
+    render(<SingleLineEditor value="https://example.com" onChange={vi.fn()} />);
+    lines = ['https://example.com'];
+
+    // Act
+    changeModelContent();
+
+    // Assert
+    expect(applyEdits).not.toHaveBeenCalled();
   });
 
   it('should show the error color when invalid', () => {

--- a/src/renderer/lib/monaco/SingleLineEditor.test.tsx
+++ b/src/renderer/lib/monaco/SingleLineEditor.test.tsx
@@ -8,6 +8,12 @@ import { useEffect } from 'react';
 vi.mock('monaco-editor', () => ({ KeyCode: { Enter: 3 } }));
 
 const addCommand = vi.fn();
+const dispose = vi.fn();
+const addAction = vi.fn(() => ({ dispose }));
+
+/** Disposes the editor the same way monaco does when the component unmounts. */
+let disposeEditor: () => void;
+const onDidDispose = vi.fn((listener: () => void) => (disposeEditor = listener));
 
 /** The props that {@link SingleLineEditor} passed to the monaco editor on the last render. */
 let editorProps: EditorProps;
@@ -18,7 +24,7 @@ vi.mock('@/lib/monaco/MonacoEditor', () => ({
     editorProps = props;
     useEffect(() => {
       (props.onMount as OnMount)?.(
-        { addCommand } as unknown as editor.IStandaloneCodeEditor,
+        { addCommand, addAction, onDidDispose } as unknown as editor.IStandaloneCodeEditor,
         {} as Parameters<OnMount>[1] // the component does not use the monaco namespace
       );
     }, []);
@@ -89,11 +95,33 @@ describe('SingleLineEditor', () => {
     render(<SingleLineEditor value="" onChange={vi.fn()} />);
 
     // Assert
-    expect(addCommand).toHaveBeenCalledWith(
-      KeyCode.Enter,
-      expect.any(Function),
-      '!suggestWidgetVisible'
+    expect(addAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keybindings: [KeyCode.Enter],
+        keybindingContext: '!suggestWidgetVisible',
+      })
     );
+  });
+
+  it('should register the enter keybinding as an action so that other editors keep line breaks', () => {
+    // Arrange
+    render(<SingleLineEditor value="" onChange={vi.fn()} />);
+
+    // Assert: addCommand would register the keybinding for all editors, addAction only for this one
+    expect(addCommand).not.toHaveBeenCalled();
+    expect(addAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('should unregister the enter keybinding when the editor is disposed', () => {
+    // Arrange
+    render(<SingleLineEditor value="" onChange={vi.fn()} />);
+    expect(dispose).not.toHaveBeenCalled();
+
+    // Act
+    disposeEditor();
+
+    // Assert
+    expect(dispose).toHaveBeenCalled();
   });
 
   it('should show the error color when invalid', () => {

--- a/src/renderer/lib/monaco/SingleLineEditor.tsx
+++ b/src/renderer/lib/monaco/SingleLineEditor.tsx
@@ -8,9 +8,6 @@ import { cn } from '@/lib/utils';
 import { OnMount } from '@monaco-editor/react';
 import { KeyCode, type editor as monacoEditor } from 'monaco-editor';
 
-/** Matches the line breaks that a single line editor must not contain. */
-const LINE_BREAK_REGEX = /[\r\n]+/g;
-
 /**
  * Swallows the line break, but keeps enter usable for accepting a variable suggestion.
  *
@@ -26,9 +23,37 @@ const IGNORE_LINE_BREAK_ACTION: monacoEditor.IActionDescriptor = {
   run: () => {},
 };
 
+/**
+ * Joins all lines of the editor back into a single one. Enter is swallowed, but line breaks still
+ * enter the model via paste and drag and drop, and stripping them from the reported value alone
+ * does not remove them from the editor.
+ */
+const joinLines = (editor: monacoEditor.ICodeEditor) => {
+  const model = editor.getModel();
+  if (model == null) return;
+  const lineCount = model.getLineCount();
+  if (lineCount === 1) return;
+
+  // deleting the ends of the lines keeps the cursor in place, unlike replacing the whole content
+  const edits: monacoEditor.IIdentifiedSingleEditOperation[] = [];
+  for (let lineNumber = 1; lineNumber < lineCount; lineNumber++) {
+    edits.push({
+      range: {
+        startLineNumber: lineNumber,
+        startColumn: model.getLineMaxColumn(lineNumber),
+        endLineNumber: lineNumber + 1,
+        endColumn: 1,
+      },
+      text: '',
+    });
+  }
+  model.applyEdits(edits);
+};
+
 const handleMount: OnMount = (editor) => {
   const action = editor.addAction(IGNORE_LINE_BREAK_ACTION);
   editor.onDidDispose(() => action.dispose());
+  editor.onDidChangeModelContent(() => joinLines(editor));
 };
 
 interface SingleLineEditorProps {
@@ -51,8 +76,7 @@ interface SingleLineEditorProps {
  * A single line text input backed by monaco. In contrast to a plain HTML input, it highlights
  * template variables and shows their current value on hover, just like the request body editor.
  *
- * Line breaks are stripped from the reported value, so the {@link SingleLineEditorProps.value} must
- * be updated on change to keep pasted text on a single line.
+ * Line breaks are removed from the editor itself, so the reported value never contains any.
  */
 export function SingleLineEditor({
   value,

--- a/src/renderer/lib/monaco/SingleLineEditor.tsx
+++ b/src/renderer/lib/monaco/SingleLineEditor.tsx
@@ -6,14 +6,29 @@ import { Language } from '@/lib/monaco/language';
 import MonacoEditor from '@/lib/monaco/MonacoEditor';
 import { cn } from '@/lib/utils';
 import { OnMount } from '@monaco-editor/react';
-import { KeyCode } from 'monaco-editor';
+import { KeyCode, type editor as monacoEditor } from 'monaco-editor';
 
 /** Matches the line breaks that a single line editor must not contain. */
 const LINE_BREAK_REGEX = /[\r\n]+/g;
 
+/**
+ * Swallows the line break, but keeps enter usable for accepting a variable suggestion.
+ *
+ * This must be registered via `addAction` instead of `addCommand`: monaco holds the keybindings of
+ * all editors in one global service, and only `addAction` scopes them to the editor they are added
+ * to. Otherwise the multi line editors lose their line breaks as well.
+ */
+const IGNORE_LINE_BREAK_ACTION: monacoEditor.IActionDescriptor = {
+  id: 'trufos.ignoreLineBreak',
+  label: 'Ignore Line Break',
+  keybindings: [KeyCode.Enter],
+  keybindingContext: '!suggestWidgetVisible',
+  run: () => {},
+};
+
 const handleMount: OnMount = (editor) => {
-  // swallow the line break, but keep enter usable for accepting a variable suggestion
-  editor.addCommand(KeyCode.Enter, () => {}, '!suggestWidgetVisible');
+  const action = editor.addAction(IGNORE_LINE_BREAK_ACTION);
+  editor.onDidDispose(() => action.dispose());
 };
 
 interface SingleLineEditorProps {
@@ -61,7 +76,7 @@ export function SingleLineEditor({
         options={{ ...SINGLE_LINE_EDITOR_OPTIONS, ariaLabel }}
         loading={null}
         onMount={handleMount}
-        onChange={(newValue = '') => onChange(newValue.replace(LINE_BREAK_REGEX, ''))}
+        onChange={(newValue = '') => onChange(newValue)}
       />
     </div>
   );


### PR DESCRIPTION
### **User description**
## Changes

- Fix `Enter` handling leaking from URL input into request body editor
- Ensure URL input stays single line even when pasting text with newlines

## Testing

- Automated and manual tests (paste something with newlines, create newlines in request body editor)

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Enter key handling to allow newlines in request body editor

- Replace `addCommand` with `addAction` to scope keybinding to single-line editor only

- Implement `joinLines` function to remove multi-line text from pasted content

- Update tests to verify Enter swallowing and multi-line text joining behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User pastes URL<br/>with newlines"] -->|"onDidChangeModelContent"| B["joinLines function"]
  B -->|"applyEdits"| C["Remove line breaks<br/>from editor"]
  D["User presses Enter"] -->|"addAction with<br/>keybindingContext"| E["Swallow Enter<br/>in single-line editor"]
  E -->|"!suggestWidgetVisible"| F["Keep Enter for<br/>suggestions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SingleLineEditor.test.tsx</strong><dd><code>Expand tests for single-line editor behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/lib/monaco/SingleLineEditor.test.tsx

<ul><li>Enhanced mock setup to include <code>addAction</code>, <code>onDidDispose</code>, <br><code>onDidChangeModelContent</code>, and <code>getModel</code> methods<br> <li> Added test helpers to track editor disposal and model content changes<br> <li> Replaced test for stripping line breaks with tests for joining <br>multi-line text via <code>applyEdits</code><br> <li> Added tests to verify <code>addAction</code> is used instead of <code>addCommand</code> and <br>keybinding is properly disposed<br> <li> Added test to verify multi-line text is joined back to single line <br>after paste</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/992/files#diff-9e48dc51d700539cb22ce703980c8bea4b5eb06d6a900e79c3d491e265fbf393">+88/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SingleLineEditor.tsx</strong><dd><code>Fix Enter key and multi-line text handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/lib/monaco/SingleLineEditor.tsx

<ul><li>Replace <code>addCommand</code> with <code>addAction</code> to scope Enter keybinding to this <br>editor only<br> <li> Remove regex-based line break stripping from <code>onChange</code> callback<br> <li> Implement <code>joinLines</code> function to remove multi-line text from editor <br>model via <code>applyEdits</code><br> <li> Register <code>onDidChangeModelContent</code> listener to join lines after paste or <br>drag-and-drop<br> <li> Register <code>onDidDispose</code> listener to clean up action when editor unmounts<br> <li> Update JSDoc to reflect that line breaks are removed from editor, not <br>just reported value</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/992/files#diff-bf4037f567cb150658eddeeeb2d4717138dffbd264074ab03ca31fdf465bfd0b">+47/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

