### PR TITLE
fix(994): URL input resizing out of window

### DIFF
--- a/src/renderer/lib/monaco/SingleLineEditor.test.tsx
+++ b/src/renderer/lib/monaco/SingleLineEditor.test.tsx
@@ -167,6 +167,15 @@ describe('SingleLineEditor', () => {
     expect(applyEdits).not.toHaveBeenCalled();
   });
 
+  it('should take the editor out of the layout flow so that its parents may shrink', () => {
+    // Arrange
+    render(<SingleLineEditor value="" onChange={vi.fn()} />);
+
+    // Assert: monaco writes an explicit pixel width onto its own DOM. In the layout flow that width
+    // becomes the minimum width of all parents, so they can never shrink again (see #994).
+    expect(editorProps.className).toContain('absolute');
+  });
+
   it('should show the error color when invalid', () => {
     // Arrange
     const { container } = render(<SingleLineEditor value="" invalid onChange={vi.fn()} />);

--- a/src/renderer/lib/monaco/SingleLineEditor.tsx
+++ b/src/renderer/lib/monaco/SingleLineEditor.tsx
@@ -95,6 +95,7 @@ export function SingleLineEditor({
     >
       <MonacoEditor
         height={SINGLE_LINE_EDITOR_HEIGHT}
+        className="absolute h-full"
         language={Language.TEXT}
         value={value}
         options={{ ...SINGLE_LINE_EDITOR_OPTIONS, ariaLabel }}


### PR DESCRIPTION
### **User description**
## Changes

- fix URL input resizing out of window by filling out parent

## Testing

If relevant, mention your manual testing here. If possible, include screenshots.

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes sidebar resize causing request view to move out of window

- Adds `absolute` positioning to MonacoEditor to remove it from layout flow

- Prevents editor's explicit pixel width from constraining parent shrinking

- Adds test verifying editor uses absolute positioning


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MonacoEditor with explicit width"] -->|causes| B["Parent containers cannot shrink"]
  B -->|results in| C["Request view moves out of window"]
  D["Add absolute positioning"] -->|removes from| E["Layout flow"]
  E -->|allows| F["Parents to shrink responsively"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SingleLineEditor.tsx</strong><dd><code>Add absolute positioning to MonacoEditor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/lib/monaco/SingleLineEditor.tsx

<ul><li>Adds <code>className="absolute h-full"</code> prop to <code>MonacoEditor</code> component<br> <li> Positions editor absolutely to prevent its explicit pixel width from <br>constraining parent container shrinking<br> <li> Maintains full height with <code>h-full</code> class</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/998/files#diff-bf4037f567cb150658eddeeeb2d4717138dffbd264074ab03ca31fdf465bfd0b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SingleLineEditor.test.tsx</strong><dd><code>Add test for absolute positioning requirement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/lib/monaco/SingleLineEditor.test.tsx

<ul><li>Adds new test case verifying editor uses absolute positioning<br> <li> Test validates that <code>className</code> contains <code>'absolute'</code> to ensure layout <br>flow removal<br> <li> Includes detailed comment explaining the fix for issue #994</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/998/files#diff-9e48dc51d700539cb22ce703980c8bea4b5eb06d6a900e79c3d491e265fbf393">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

