### PR TITLE
refactor: remove Edit menu and add app Settings navigation

### DIFF
--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -79,33 +79,63 @@ describe('MenuBuilder', () => {
     const template = buildTemplate('darwin');
 
     expect(template[0].label).toBe('Trufos');
-    const appRoles = collectStrings(template[0].submenu as MenuItemConstructorOptions[]);
+    const appItems = template[0].submenu as MenuItemConstructorOptions[];
+    const appRoles = collectStrings(appItems);
     expect(appRoles).toEqual(
       expect.arrayContaining(['about', 'services', 'hide', 'hideOthers', 'unhide', 'quit'])
     );
     expect(template.map((item) => item.label ?? item.role)).toEqual([
       'Trufos',
-      'Edit',
       'Collection',
       'View',
       'Window',
       'help',
     ]);
+
+    // Settings… sits right before Services in the Trufos app-menu tab.
+    const settingsIndex = appItems.findIndex((item) => item.label === 'Settings…');
+    const servicesIndex = appItems.findIndex((item) => item.role === 'services');
+    expect(settingsIndex).toBeGreaterThanOrEqual(0);
+    expect(servicesIndex).toBe(settingsIndex + 2); // separator sits between them
   });
 
-  it('builds the default menu with File, Edit, View and Help', () => {
+  it('builds the default menu with File, View, Collection and Help', () => {
     const template = buildTemplate('win32');
 
     expect(template.map((item) => item.label ?? item.role)).toEqual([
       '&File',
-      '&Edit',
       '&Collection',
       '&View',
       'help',
     ]);
-    const fileRoles = collectStrings(template[0].submenu as MenuItemConstructorOptions[]);
-    expect(fileRoles).toEqual(['close', 'quit']);
+    const fileItems = collectStrings(template[0].submenu as MenuItemConstructorOptions[]);
+    expect(fileItems).toEqual(['close', 'Settings…', 'quit']);
   });
+
+  it('no longer contains an Edit menu on any platform', () => {
+    for (const platform of ['darwin', 'win32', 'linux'] as const) {
+      const strings = collectStrings(buildTemplate(platform));
+      expect(strings).not.toContain('Edit');
+      expect(strings).not.toContain('&Edit');
+      expect(strings).not.toContain('undo');
+      expect(strings).not.toContain('redo');
+      expect(strings).not.toContain('selectAll');
+    }
+  });
+
+  it.each(['darwin', 'win32'] as const)(
+    'opens the app settings modal from the %s menu via CmdOrCtrl+,',
+    (platform) => {
+      const template = buildTemplate(platform);
+      // Settings… lives in the Trufos app-menu tab on macOS, and in &File elsewhere.
+      const items = template[0].submenu as MenuItemConstructorOptions[];
+
+      const settingsItem = items.find((item) => item.label === 'Settings…')!;
+      expect(settingsItem.accelerator).toBe('CmdOrCtrl+,');
+      (settingsItem.click as () => void)();
+      expect(sendMock).toHaveBeenCalledWith('show-app-settings');
+    }
+  );
 
   it.each(['darwin', 'win32'] as const)(
     'includes Reload and DevTools on %s only in development',

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -33,16 +33,12 @@ export class MenuBuilder {
     });
   }
 
-  private buildEditSubmenu(): MenuItemConstructorOptions[] {
-    return [
-      { role: 'undo' },
-      { role: 'redo' },
-      { type: 'separator' },
-      { role: 'cut' },
-      { role: 'copy' },
-      { role: 'paste' },
-      { role: 'selectAll' },
-    ];
+  private buildAppSettingsMenuItem(): MenuItemConstructorOptions {
+    return {
+      label: 'Settings…',
+      accelerator: 'CmdOrCtrl+,',
+      click: () => this.mainWindow.webContents.send('show-app-settings'),
+    };
   }
 
   private buildViewSubmenu(): MenuItemConstructorOptions[] {
@@ -90,6 +86,8 @@ export class MenuBuilder {
         submenu: [
           { role: 'about' },
           { type: 'separator' },
+          this.buildAppSettingsMenuItem(),
+          { type: 'separator' },
           { role: 'services' },
           { type: 'separator' },
           { role: 'hide' },
@@ -99,7 +97,6 @@ export class MenuBuilder {
           { role: 'quit' },
         ],
       },
-      { label: 'Edit', submenu: this.buildEditSubmenu() },
       { label: 'Collection', submenu: this.buildCollectionSubmenu() },
       { label: 'View', submenu: this.buildViewSubmenu() },
       {
@@ -120,9 +117,14 @@ export class MenuBuilder {
     return [
       {
         label: '&File',
-        submenu: [{ role: 'close' }, { role: 'quit' }],
+        submenu: [
+          { role: 'close' },
+          { type: 'separator' },
+          this.buildAppSettingsMenuItem(),
+          { type: 'separator' },
+          { role: 'quit' },
+        ],
       },
-      { label: '&Edit', submenu: this.buildEditSubmenu() },
       { label: '&Collection', submenu: this.buildCollectionSubmenu() },
       { label: '&View', submenu: this.buildViewSubmenu() },
       { role: 'help', submenu: this.buildHelpSubmenu() },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -47,7 +47,8 @@ export const App = () => {
     // Entry points of the native application menu (Collection > ...).
     RendererEventService.instance
       .on('show-collection-runner', () => useViewStore.getState().openCollectionRunner())
-      .on('show-collection-settings', () => useViewStore.getState().openCollectionSettings());
+      .on('show-collection-settings', () => useViewStore.getState().openCollectionSettings())
+      .on('show-app-settings', () => useViewStore.getState().openAppSettings());
 
     RendererEventService.instance
       .getAppSettings()

--- a/src/renderer/services/event/renderer-event-service.ts
+++ b/src/renderer/services/event/renderer-event-service.ts
@@ -32,6 +32,8 @@ export interface RendererEventService {
 
   on(event: 'show-collection-settings', listener: () => void): this;
 
+  on(event: 'show-app-settings', listener: () => void): this;
+
   /**
    * The first argument is the Electron IPC event, which this listener does not need; the payload is
    * the second argument.


### PR DESCRIPTION
### **User description**
## Changes

- Removed the native "Edit" menu (`buildEditSubmenu()`) entirely from both the macOS and
  Windows/Linux application menu templates in `src/main/menu.ts`.
- Added a "Settings…" entry (`Cmd/Ctrl+,`) that sends a `show-app-settings` IPC event to the
  renderer:
  - **macOS:** inside the main `Trufos` app-menu tab, positioned right before `Services`.
  - **Windows/Linux:** inside the `File` menu, positioned above `Quit`.
- Wired the new `show-app-settings` event through to the renderer, following the same
  fire-and-forget IPC pattern already used by `show-collection-runner` /
  `show-collection-settings`:
  - Added a typed `on('show-app-settings', …)` overload to `RendererEventService`.
  - Registered the listener in `App.tsx` to call the existing `openAppSettings()` Zustand
    action.
- Note: `isAppSettingsOpen` state, the controlled `AppSettingsModal` component, its global
  render in `App.tsx`, and the sidebar gear icon in `FooterBar.tsx` were already implemented
  on `main` prior to this PR — this PR only adds the missing menu entry and IPC wiring to
  reach that existing modal.
- Scope is limited to the issue's Acceptance Criteria. The issue's "Further Ideas" section
  (renaming Collection Settings, Zoom menu controls, Help menu additions) is intentionally
  out of scope here.

## Testing

**Automated:**
- Updated `src/main/menu.test.ts`: removed Edit-menu assertions, added coverage that
  `Settings…` is present with the correct accelerator and position on both `darwin` and
  `win32` templates, and that its click handler sends `show-app-settings`.
- Full suite: `yarn test` (541/542 passed, 1 pre-existing skip), `yarn lint` (clean,
  repo-wide), `yarn tsc --noEmit` (clean, repo-wide).
- `prettier --check` verified clean on the 4 files this PR touches (`menu.ts`,
  `menu.test.ts`, `App.tsx`, `renderer-event-service.ts`), checked directly via the
  `prettier` binary rather than the `yarn prettier-check` wrapper — that wrapper script is
  hardcoded to `'**/*.{ts,tsx,mts,mjs,cjs}'` and currently fails tree-wide on this
  repo due to pre-existing `core.autocrlf`/`endOfLine` line-ending drift unrelated to this
  change (281 files, none touched by this PR).

**Manual (Windows):**
- `Ctrl+,` opens the App Settings modal.
- `File > Settings…` menu item opens the App Settings modal.
- The sidebar gear icon (bottom-left) still opens the same modal.
- `Ctrl+Shift+,` still opens Collection Settings, unaffected.
- Confirmed the Edit menu is gone from the menu bar.
- Confirmed `Ctrl+C/V/X/Z/A` still work in text inputs after the Edit menu removal (the
  issue flagged this as a macOS-specific risk worth checking; this covers the Windows path —
  a macOS reviewer should double-check `Cmd+C/V/X/Z/A` there before merge).

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Removed unused "Edit" menu from native application menu

- Added "Settings…" entry with `CmdOrCtrl+,` shortcut to app menu

- Positioned Settings under Trufos menu (macOS) and File menu (Windows/Linux)

- Wired Settings menu item to open AppSettingsModal via IPC event

- Updated menu tests to verify Settings placement and removal of Edit menu


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Native App Menu"] -->|Remove| B["Edit Menu"]
  A -->|Add| C["Settings… Entry"]
  C -->|CmdOrCtrl+,| D["IPC: show-app-settings"]
  D -->|Renderer| E["AppSettingsModal"]
  F["macOS: Trufos Menu"] -->|Settings Position| C
  G["Windows/Linux: File Menu"] -->|Settings Position| C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>menu.ts</strong><dd><code>Replace Edit menu with Settings navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/menu.ts

<ul><li>Replaced <code>buildEditSubmenu()</code> with <code>buildAppSettingsMenuItem()</code> that sends <br>IPC event<br> <li> Added Settings menu item to macOS Trufos app-menu before Services<br> <li> Added Settings menu item to Windows/Linux File menu with separators<br> <li> Removed Edit menu from both <code>buildDarwinTemplate()</code> and <br><code>buildDefaultTemplate()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/1000/files#diff-a8e89ca92b72dea361635d6d87ba1a12933f5e0a701050e3e0a79aab0eea4ce2">+15/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Wire Settings IPC event to Zustand action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/App.tsx

<ul><li>Added listener for <code>show-app-settings</code> IPC event in useEffect hook<br> <li> Calls <code>openAppSettings()</code> Zustand action when Settings menu item clicked<br> <li> Follows existing pattern used by collection runner and settings events</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/1000/files#diff-72348b6b222462c023d009b90544f2799da3cf5b1eafc2d280f8a19041271230">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>renderer-event-service.ts</strong><dd><code>Add show-app-settings IPC event type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/services/event/renderer-event-service.ts

<ul><li>Added typed overload for <code>on('show-app-settings', listener)</code> method<br> <li> Maintains consistency with existing IPC event interface pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/1000/files#diff-6446e2be18634b05193826bf484b2b8bc0a1c252f5207f424de9e77b82f4444f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>menu.test.ts</strong><dd><code>Update menu tests for Settings and Edit removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/menu.test.ts

<ul><li>Removed assertions for Edit menu presence across all platforms<br> <li> Added test verifying Settings… position before Services on macOS<br> <li> Added test confirming Settings… appears in File menu on Windows/Linux<br> <li> Added test validating <code>CmdOrCtrl+,</code> accelerator and IPC event emission<br> <li> Added comprehensive test ensuring Edit menu is completely removed</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/1000/files#diff-8ecc1165efabb70ecb554fc43094ee7dbc2656dc73f9928cfd7931c568e1709f">+36/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

