### PR TITLE
fix(1001): Align footer implementation to penpot design

### DIFF
--- a/src/renderer/components/sidebar/FooterBar.tsx
+++ b/src/renderer/components/sidebar/FooterBar.tsx
@@ -21,6 +21,7 @@ export function FooterBar() {
       <div className="flex items-center justify-between">
         {/* Settings and theme toggle on the left */}
         <button
+          type="button"
           onClick={openAppSettings}
           className="hover:text-foreground flex cursor-pointer items-center gap-2 text-(--text-secondary) transition-colors duration-300"
         >
@@ -37,7 +38,8 @@ export function FooterBar() {
           href="https://github.com/EXXETA/trufos"
           target="_blank"
           rel="noopener noreferrer"
-          className="hover:text-foreground flex cursor-pointer items-center gap-2 text-(--text-secondary) transition-colors duration-300"
+          aria-label="Visit Trufos GitHub repository"
+          className="hover:text-foreground flex items-center gap-2 text-(--text-secondary) transition-colors duration-300"
         >
           <span className="flex h-3.75 w-6.5 shrink-0 items-center self-center text-[12px] leading-[1.2] font-medium whitespace-pre normal-case no-underline">
             {appVersion ?? null}

--- a/src/renderer/components/sidebar/FooterBar.tsx
+++ b/src/renderer/components/sidebar/FooterBar.tsx
@@ -20,23 +20,30 @@ export function FooterBar() {
       <Divider />
       <div className="flex items-center justify-between">
         {/* Settings and theme toggle on the left */}
-        <div className="flex items-center gap-2">
-          <FiSettings className="ml-2 cursor-pointer text-xl" onClick={openAppSettings} />
-          <span className="shrink-0 text-[12px] leading-[1.2] font-medium tracking-normal whitespace-pre text-(--text-secondary) normal-case no-underline">
+        <button
+          onClick={openAppSettings}
+          className="hover:text-foreground flex cursor-pointer items-center gap-2 text-(--text-secondary) transition-colors duration-300"
+        >
+          <div className="flex h-6 w-6 items-center justify-center">
+            <FiSettings className="text-lg" />
+          </div>
+          <span className="shrink-0 text-[12px] leading-[1.2] font-medium tracking-normal whitespace-pre normal-case no-underline">
             Settings
           </span>
-        </div>
+        </button>
 
-        <div className="flex items-center gap-2">
-          {/* Icons and version on the right */}
-          <span className="flex h-3.75 w-6.5 shrink-0 items-center self-center text-[12px] leading-[1.2] font-medium whitespace-pre text-(--text-secondary) normal-case no-underline">
+        {/* Icons and version on the right */}
+        <a
+          href="https://github.com/EXXETA/trufos"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-foreground flex cursor-pointer items-center gap-2 text-(--text-secondary) transition-colors duration-300"
+        >
+          <span className="flex h-3.75 w-6.5 shrink-0 items-center self-center text-[12px] leading-[1.2] font-medium whitespace-pre normal-case no-underline">
             {appVersion ?? null}
           </span>
-          {/* GitHub Icon */}
-          <a href="https://github.com/EXXETA/trufos" target="_blank" rel="noopener noreferrer">
-            <GithubIcon />
-          </a>
-        </div>
+          <GithubIcon />
+        </a>
       </div>
     </SidebarFooter>
   );

--- a/src/renderer/components/ui/sidebar.tsx
+++ b/src/renderer/components/ui/sidebar.tsx
@@ -321,7 +321,7 @@ const SidebarFooter = React.forwardRef<HTMLDivElement, React.ComponentProps<'div
       <div
         ref={ref}
         data-sidebar="footer"
-        className={cn('flex flex-col gap-2', className)}
+        className={cn('flex flex-col gap-6', className)}
         {...props}
       />
     );


### PR DESCRIPTION
### **User description**
## Changes

As described in #1001 there are some differences between the current implementation and the penpot design of the footer. I made the following changes:

- Gap between divider and footer content is now extended from `gap-2` to `gap-6` which is 24px as in our penpot design
- Gap between icons and text was technically correct (8px) but the icons need to be wrapped in a 24x24 div so that the gap is the same as in our penpot design.
- I also made the gear/settings icon a bit smaller (20px -> 18px) because the icon in the penpot design is 17x18px large

The following changes are not from the penpot design but I think could be nice to have:

- I expanded the `onClick` handler from the icons themselves to the icon+text combination. This makes it easier to click on.
- I added a hover effect where the text and icons are brightened when the cursor hovers over either one of them

## To be clarified

Both the font and the icons themselves do not match those from the penpot design. I think some of that was intentional. What was the reason for this change? Should we align that as well?

## Testing

If relevant, mention your manual testing here. If possible, include screenshots.

New look:

<img width="387" height="103" alt="image" src="https://github.com/user-attachments/assets/775afff5-65f6-4835-a1ca-9a7929f812a3" />

and with hover:

<img width="387" height="119" alt="image" src="https://github.com/user-attachments/assets/0600e46e-ca2c-4635-b85a-b35a16195e78" />

Penpot design:

<img width="714" height="180" alt="image" src="https://github.com/user-attachments/assets/af037fa7-0852-464f-9a33-8cb0f59c325a" />

## Checklist

- [x] Issue has been linked to this PR
- [ ] Code has been reviewed by person creating the PR
- [ ] Automated tests have been written, if possible
- [ ] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [x] Changes have been reviewed by second person


___

### **PR Type**
Enhancement


___

### **Description**
- Align footer spacing with penpot design by increasing gap from gap-2 to gap-6

- Wrap settings icon in 24x24px container for proper alignment

- Convert footer elements to semantic button and anchor tags

- Add hover effects with color transition for improved UX

- Include aria-label for GitHub link accessibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Footer Layout"] -->|"Increase gap"| B["gap-2 to gap-6"]
  A -->|"Wrap icons"| C["24x24px containers"]
  A -->|"Semantic HTML"| D["button & anchor tags"]
  A -->|"Interactions"| E["Hover effects & accessibility"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FooterBar.tsx</strong><dd><code>Refactor footer with semantic HTML and hover effects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/components/sidebar/FooterBar.tsx

<ul><li>Converted settings icon wrapper from div to semantic button element<br> <li> Added 24x24px container around FiSettings icon for proper spacing <br>alignment<br> <li> Wrapped GitHub link and version in anchor tag with proper attributes<br> <li> Added hover effects with color transition and cursor pointer styling<br> <li> Included aria-label attribute on GitHub link for accessibility<br> <li> Removed redundant cursor-pointer class from icon element</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/1002/files#diff-25c68cd313881a17ee408b9b91fb0801147c9fddda323b67d8721a6dfa241a3a">+21/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sidebar.tsx</strong><dd><code>Increase footer divider spacing to gap-6</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/renderer/components/ui/sidebar.tsx

<ul><li>Updated SidebarFooter gap from gap-2 to gap-6 to match penpot design <br>spacing</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/1002/files#diff-071335f62d2a5b0c0a1c833032846cf90d69ecd86c386fa293d578da4889609b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

