### PR TITLE
feat(996): parallelize collection loading

### DIFF
--- a/src/main/persistence/service/persistence-service.test.ts
+++ b/src/main/persistence/service/persistence-service.test.ts
@@ -1100,6 +1100,82 @@ describe('PersistenceService', () => {
     expect(loaded.children[0].title).toBe('Folder2');
   });
 
+  it('loadCollection() should keep the directory order when children finish loading out of order', async () => {
+    // Arrange - more children than may be read concurrently, so that reads are queued
+    const childCount = 12;
+    for (let i = 0; i < childCount; i++) {
+      const request = getExampleRequest(collection.id);
+      request.title = `req-${String(i).padStart(2, '0')}`;
+      collection.children.push(request);
+    }
+    await persistenceService.saveCollection(collection, true);
+
+    // let the earlier children finish last, so that collecting them by completion instead of by
+    // position would return them in the wrong order
+    const originalReadFile = fs.readFile.bind(fs);
+    vi.spyOn(fs, 'readFile').mockImplementation(async (...args: Parameters<typeof fs.readFile>) => {
+      const content = await originalReadFile(...args);
+      const index = /req-(\d+)/.exec(String(args[0]))?.[1];
+      if (index != null) {
+        await new Promise((resolve) => setTimeout(resolve, childCount - Number(index)));
+      }
+      return content;
+    });
+
+    // Act
+    const loaded = await persistenceService.loadCollection(collection.dirPath);
+
+    // Assert
+    expect(loaded.children.map((child) => child.title)).toEqual(
+      collection.children.map((child) => child.title)
+    );
+  });
+
+  it('loadCollection() should preserve order.json of nested folders', async () => {
+    // Arrange
+    const folder = getExampleFolder(collection.id);
+    const requests = ['a', 'b', 'c'].map((title) => {
+      const request = getExampleRequest(folder.id);
+      request.title = title;
+      return request;
+    });
+    folder.children.push(...requests);
+    collection.children.push(folder);
+    await persistenceService.saveCollection(collection, true);
+
+    // move the last request to the front
+    await persistenceService.reorderItem(folder, requests[2].id, 0);
+
+    // Act
+    const loaded = await persistenceService.loadCollection(collection.dirPath);
+
+    // Assert
+    const loadedFolder = loaded.children[0];
+    if (loadedFolder.type !== 'folder') throw new Error('expected a folder');
+    expect(loadedFolder.children.map((child) => child.title)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('loadCollection() should fail if the info file of a child is corrupt', async () => {
+    // Arrange
+    const request = getExampleRequest(collection.id);
+    request.title = 'broken';
+    collection.children.push(request);
+    await persistenceService.saveCollection(collection, true);
+    await writeFile(
+      path.join(
+        collection.dirPath,
+        sanitizeTitle(request.title),
+        persistenceService.getInfoFileName(request.type)
+      ),
+      '{ this is not json'
+    );
+
+    // Act & Assert
+    await expect(persistenceService.loadCollection(collection.dirPath)).rejects.toThrow(
+      'Failed to load request info file'
+    );
+  });
+
   it('reorderItem() should reorder items within same parent', async () => {
     // Arrange
     const request1 = getExampleRequest(collection.id);

--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -546,7 +546,7 @@ export class PersistenceService {
     this.idToPathMap.set(info.id, dirPath);
     const children = recursive ? await this.loadChildren(info.id, dirPath) : [];
 
-    const lastModified = await this.getInfoFileModifactionTime(dirPath, type);
+    const lastModified = await this.getInfoFileModificationTime(dirPath, type);
     return fromCollectionInfoFile(info, lastModified, dirPath, children);
   }
 
@@ -570,7 +570,7 @@ export class PersistenceService {
     logger.info('Walking collection at', dirPath);
     const type = 'collection' as const;
     const info = await this.readInfoFile(dirPath, type);
-    const lastModified = await this.getInfoFileModifactionTime(dirPath, type);
+    const lastModified = await this.getInfoFileModificationTime(dirPath, type);
     const children = await this.walkChildren(info.id, dirPath);
 
     const snapshot = fromCollectionInfoFile(
@@ -609,13 +609,13 @@ export class PersistenceService {
   ): Promise<SnapshotChild | undefined> {
     if (await exists(path.join(childDirPath, getInfoFileName('folder')))) {
       const info = await this.readInfoFile(childDirPath, 'folder');
-      const lastModified = await this.getInfoFileModifactionTime(childDirPath, 'folder');
+      const lastModified = await this.getInfoFileModificationTime(childDirPath, 'folder');
       const children = await this.walkChildren(info.id, childDirPath);
       return fromFolderInfoFile(info, lastModified, parentId, children) as FolderSnapshot;
     } else if (await exists(path.join(childDirPath, getInfoFileName('request')))) {
       // NOTE: draft-only (never saved) requests have no main request.json and are skipped here.
       const info = await this.readInfoFile(childDirPath, 'request');
-      const lastModified = await this.getInfoFileModifactionTime(childDirPath, 'request');
+      const lastModified = await this.getInfoFileModificationTime(childDirPath, 'request');
       const request = fromRequestInfoFile(info, lastModified, parentId, false);
       return this.createRequestSnapshot(request, childDirPath);
     }
@@ -654,7 +654,7 @@ export class PersistenceService {
     const info = await this.readInfoFile(draft ? this.getDraftDirPath(dirPath) : dirPath, type);
     this.idToPathMap.set(info.id, dirPath);
 
-    const lastModified = await this.getInfoFileModifactionTime(
+    const lastModified = await this.getInfoFileModificationTime(
       draft ? this.getDraftDirPath(dirPath) : dirPath,
       type
     );
@@ -667,11 +667,11 @@ export class PersistenceService {
     this.idToPathMap.set(info.id, dirPath);
     const children = await this.loadChildren(info.id, dirPath);
 
-    const lastModified = await this.getInfoFileModifactionTime(dirPath, type);
+    const lastModified = await this.getInfoFileModificationTime(dirPath, type);
     return fromFolderInfoFile(info, lastModified, parentId, children);
   }
 
-  private async getInfoFileModifactionTime(
+  private async getInfoFileModificationTime(
     dirPath: string,
     type: TrufosObject['type']
   ): Promise<number> {

--- a/src/main/persistence/service/persistence-service.ts
+++ b/src/main/persistence/service/persistence-service.ts
@@ -1,4 +1,4 @@
-import { exists, isEmpty } from 'main/util/fs-util';
+import { exists, isEmpty, readFileLimited } from 'main/util/fs-util';
 import { assign } from 'main/util/object-util';
 import { randomUUID } from 'node:crypto';
 import { createReadStream } from 'node:fs';
@@ -584,29 +584,42 @@ export class PersistenceService {
   }
 
   private async walkChildren(parentId: string, parentDirPath: string): Promise<SnapshotChild[]> {
-    const children: SnapshotChild[] = [];
+    const nodes = (await fs.readdir(parentDirPath, { withFileTypes: true })).filter(
+      (node) => node.isDirectory() && node.name !== DRAFT_DIR_NAME
+    );
 
-    for (const node of await fs.readdir(parentDirPath, { withFileTypes: true })) {
-      if (!node.isDirectory() || node.name === DRAFT_DIR_NAME) continue;
-      const childDirPath = path.join(parentDirPath, node.name);
+    // Promise.all() resolves by index, so the children keep their directory order regardless of
+    // which of them finishes walking first
+    const [children, order] = await Promise.all([
+      Promise.all(
+        nodes.map((node) => this.walkChild(parentId, path.join(parentDirPath, node.name)))
+      ),
+      this.loadOrderFile(parentDirPath),
+    ]);
 
-      if (await exists(path.join(childDirPath, getInfoFileName('folder')))) {
-        const info = await this.readInfoFile(childDirPath, 'folder');
-        const lastModified = await this.getInfoFileModifactionTime(childDirPath, 'folder');
-        const folderChildren = await this.walkChildren(info.id, childDirPath);
-        children.push(
-          fromFolderInfoFile(info, lastModified, parentId, folderChildren) as FolderSnapshot
-        );
-      } else if (await exists(path.join(childDirPath, getInfoFileName('request')))) {
-        // NOTE: draft-only (never saved) requests have no main request.json and are skipped here.
-        const info = await this.readInfoFile(childDirPath, 'request');
-        const lastModified = await this.getInfoFileModifactionTime(childDirPath, 'request');
-        const request = fromRequestInfoFile(info, lastModified, parentId, false);
-        children.push(this.createRequestSnapshot(request, childDirPath));
-      }
+    return this.sortChildrenArray(
+      children.filter((child) => child != null),
+      order
+    );
+  }
+
+  private async walkChild(
+    parentId: string,
+    childDirPath: string
+  ): Promise<SnapshotChild | undefined> {
+    if (await exists(path.join(childDirPath, getInfoFileName('folder')))) {
+      const info = await this.readInfoFile(childDirPath, 'folder');
+      const lastModified = await this.getInfoFileModifactionTime(childDirPath, 'folder');
+      const children = await this.walkChildren(info.id, childDirPath);
+      return fromFolderInfoFile(info, lastModified, parentId, children) as FolderSnapshot;
+    } else if (await exists(path.join(childDirPath, getInfoFileName('request')))) {
+      // NOTE: draft-only (never saved) requests have no main request.json and are skipped here.
+      const info = await this.readInfoFile(childDirPath, 'request');
+      const lastModified = await this.getInfoFileModifactionTime(childDirPath, 'request');
+      const request = fromRequestInfoFile(info, lastModified, parentId, false);
+      return this.createRequestSnapshot(request, childDirPath);
     }
-
-    return this.sortChildrenArray(children, await this.loadOrderFile(parentDirPath));
+    return undefined;
   }
 
   /**
@@ -671,22 +684,21 @@ export class PersistenceService {
     parentId: string,
     parentDirPath: string
   ): Promise<(Folder | TrufosRequest)[]> {
-    const children: (Folder | TrufosRequest)[] = [];
+    const nodes = (await fs.readdir(parentDirPath, { withFileTypes: true })).filter(
+      (node) => node.isDirectory() && node.name !== DRAFT_DIR_NAME
+    );
 
-    for (const node of await fs.readdir(parentDirPath, {
-      withFileTypes: true,
-    })) {
-      if (!node.isDirectory() || node.name === DRAFT_DIR_NAME) {
-        continue;
-      }
+    // Promise.all() resolves by index, so the children keep their directory order regardless of
+    // which of them finishes loading first
+    const [children, order] = await Promise.all([
+      Promise.all(nodes.map((node) => this.load(parentId, path.join(parentDirPath, node.name)))),
+      this.loadOrderFile(parentDirPath),
+    ]);
 
-      const child = await this.load(parentId, path.join(parentDirPath, node.name));
-      if (child != null) {
-        children.push(child);
-      }
-    }
-
-    return this.sortChildrenArray(children, await this.loadOrderFile(parentDirPath));
+    return this.sortChildrenArray(
+      children.filter((child) => child != null),
+      order
+    );
   }
 
   private sortChildrenArray<T extends { id: string }>(children: T[], order: string[]): T[] {
@@ -704,7 +716,7 @@ export class PersistenceService {
       return [];
     }
 
-    return await OrderFile.parseAsync(JSON.parse(await fs.readFile(filePath, 'utf8')));
+    return await OrderFile.parseAsync(JSON.parse(await readFileLimited(filePath, 'utf8')));
   }
 
   private async saveOrderFile(dirPath: string, children: string[]) {
@@ -737,11 +749,14 @@ export class PersistenceService {
   private readInfoFile(dirPath: string, type: Folder['type']): Promise<FolderInfoFile>;
   private readInfoFile(dirPath: string, type: TrufosRequest['type']): Promise<RequestInfoFile>;
 
-  private async readInfoFile<T extends TrufosObject>(dirPath: string, type: T['type']) {
+  private async readInfoFile<T extends TrufosObject>(
+    dirPath: string,
+    type: T['type']
+  ): Promise<InfoFile> {
     const filePath = path.join(dirPath, this.getInfoFileName(type));
     try {
       const info = assign(
-        JSON.parse(await fs.readFile(filePath, 'utf8')) as InfoFile,
+        JSON.parse(await readFileLimited(filePath, 'utf8')) as InfoFile,
         await this.loadSecrets(dirPath)
       );
       const latest = await migrateInfoFile(info, type, filePath); // (potentially) migrate the info file to the latest version
@@ -756,7 +771,7 @@ export class PersistenceService {
     const filePath = path.join(dirPath, SECRETS_FILE_NAME);
     if (await exists(filePath)) {
       logger.debug('Loading secrets from', filePath);
-      return JSON.parse(secretService.decrypt(await fs.readFile(filePath)));
+      return JSON.parse(secretService.decrypt(await readFileLimited(filePath)));
     } else {
       return {};
     }

--- a/src/main/persistence/service/walk-collection.test.ts
+++ b/src/main/persistence/service/walk-collection.test.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir } from 'node:fs/promises';
+import fs, { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { Readable } from 'node:stream';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { USER_DATA_DIR } from 'main/util/fs-util';
 import { Collection } from 'shim/objects/collection';
 import { Folder } from 'shim/objects/folder';
@@ -66,6 +66,10 @@ async function streamToString(stream?: Readable) {
 describe('PersistenceService.walkCollection()', () => {
   let collection: Collection;
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(async () => {
     collection = getExampleCollection();
     await mkdir(collection.dirPath, { recursive: true });
@@ -109,6 +113,37 @@ describe('PersistenceService.walkCollection()', () => {
 
     const rootSnapshot = snapshot.children[0] as RequestSnapshot;
     expect(await rootSnapshot.getBodyContent()).toBeUndefined();
+  });
+
+  it('keeps the directory order when children finish walking out of order', async () => {
+    // Arrange - more children than may be read concurrently, so that reads are queued
+    const childCount = 12;
+    for (let i = 0; i < childCount; i++) {
+      collection.children.push(
+        getExampleRequest(collection.id, `req-${String(i).padStart(2, '0')}`)
+      );
+    }
+    await persistenceService.saveCollection(collection, true);
+
+    // let the earlier children finish last, so that collecting them by completion instead of by
+    // position would return them in the wrong order
+    const originalReadFile = fs.readFile.bind(fs);
+    vi.spyOn(fs, 'readFile').mockImplementation(async (...args: Parameters<typeof fs.readFile>) => {
+      const content = await originalReadFile(...args);
+      const index = /req-(\d+)/.exec(String(args[0]))?.[1];
+      if (index != null) {
+        await new Promise((resolve) => setTimeout(resolve, childCount - Number(index)));
+      }
+      return content;
+    });
+
+    // Act
+    const snapshot = await persistenceService.walkCollection(collection.dirPath);
+
+    // Assert
+    expect(snapshot.children.map((child) => child.title)).toEqual(
+      collection.children.map((child) => child.title)
+    );
   });
 
   it('uses the saved state of a request, ignoring its draft overlay', async () => {

--- a/src/main/util/fs-util.test.ts
+++ b/src/main/util/fs-util.test.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs/promises';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileLimited } from './fs-util';
+
+/** The concurrent read limit that `readFileLimited()` is expected to enforce. */
+const MAX_CONCURRENT_READS = 10;
+
+/** A promise together with the functions that settle it, so tests control when a read finishes. */
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/**
+ * Replaces `fs.readFile` with a mock that only settles when the test resolves the deferred it
+ * handed out, so that reads can be held in flight for as long as needed.
+ */
+function mockPendingReads() {
+  const deferreds: ReturnType<typeof createDeferred<string>>[] = [];
+  const spy = vi.spyOn(fs, 'readFile').mockImplementation(() => {
+    const deferred = createDeferred<string>();
+    deferreds.push(deferred);
+    return deferred.promise as ReturnType<typeof fs.readFile>;
+  });
+  return { deferreds, spy };
+}
+
+/** Lets all already scheduled microtasks run so that pending reads can start. */
+async function flushMicrotasks() {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('readFileLimited', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('should read no more than the maximum number of files at once', async () => {
+    const { deferreds, spy } = mockPendingReads();
+
+    const reads = Array.from({ length: MAX_CONCURRENT_READS + 5 }, (_, i) =>
+      readFileLimited(`/file-${i}`, 'utf8')
+    );
+    await flushMicrotasks();
+
+    expect(spy).toHaveBeenCalledTimes(MAX_CONCURRENT_READS);
+
+    deferreds.forEach((deferred, i) => deferred.resolve(`content-${i}`));
+    await flushMicrotasks();
+    deferreds.slice(MAX_CONCURRENT_READS).forEach((deferred, i) => deferred.resolve(`late-${i}`));
+
+    await expect(Promise.all(reads)).resolves.toHaveLength(MAX_CONCURRENT_READS + 5);
+    expect(spy).toHaveBeenCalledTimes(MAX_CONCURRENT_READS + 5);
+  });
+
+  it('should start a waiting read as soon as a running read finishes', async () => {
+    const { deferreds, spy } = mockPendingReads();
+
+    const reads = Array.from({ length: MAX_CONCURRENT_READS + 1 }, (_, i) =>
+      readFileLimited(`/file-${i}`, 'utf8')
+    );
+    await flushMicrotasks();
+    expect(spy).toHaveBeenCalledTimes(MAX_CONCURRENT_READS);
+
+    deferreds[0].resolve('first');
+    await flushMicrotasks();
+    expect(spy).toHaveBeenCalledTimes(MAX_CONCURRENT_READS + 1);
+
+    deferreds.slice(1).forEach((deferred, i) => deferred.resolve(`rest-${i}`));
+    await Promise.all(reads);
+  });
+
+  it('should release the slot of a failed read', async () => {
+    const { deferreds, spy } = mockPendingReads();
+
+    const reads = Array.from({ length: MAX_CONCURRENT_READS + 1 }, (_, i) =>
+      readFileLimited(`/file-${i}`, 'utf8')
+    );
+    await flushMicrotasks();
+
+    deferreds[0].reject(new Error('read failed'));
+    await expect(reads[0]).rejects.toThrow('read failed');
+    await flushMicrotasks();
+
+    expect(spy).toHaveBeenCalledTimes(MAX_CONCURRENT_READS + 1);
+    deferreds.slice(1).forEach((deferred, i) => deferred.resolve(`rest-${i}`));
+    await Promise.all(reads.slice(1));
+  });
+
+  it('should start waiting reads in the order they were requested', async () => {
+    const { deferreds, spy } = mockPendingReads();
+
+    const reads = Array.from({ length: MAX_CONCURRENT_READS + 3 }, (_, i) =>
+      readFileLimited(`/file-${i}`, 'utf8')
+    );
+    await flushMicrotasks();
+
+    for (let i = 0; i < 3; i++) {
+      deferreds[i].resolve(`content-${i}`);
+      await flushMicrotasks();
+      expect(spy).toHaveBeenLastCalledWith(`/file-${MAX_CONCURRENT_READS + i}`, 'utf8');
+    }
+
+    deferreds.slice(3).forEach((deferred, i) => deferred.resolve(`rest-${i}`));
+    await Promise.all(reads);
+  });
+
+  it('should return the file content decoded or as raw bytes', async () => {
+    await fs.writeFile('/content.txt', 'file content', 'utf8');
+
+    await expect(readFileLimited('/content.txt', 'utf8')).resolves.toBe('file content');
+    await expect(readFileLimited('/content.txt')).resolves.toEqual(Buffer.from('file content'));
+  });
+});

--- a/src/main/util/fs-util.ts
+++ b/src/main/util/fs-util.ts
@@ -4,6 +4,51 @@ import { app } from 'electron';
 export const USER_DATA_DIR = app.getPath('userData');
 
 /**
+ * The number of files that may still be read concurrently by {@link readFileLimited}. Counts down
+ * as reads take a slot and back up as they return it.
+ */
+let availableFileReads = 10;
+
+/** The reads waiting for a slot, in the order they asked for one. */
+const waitingReads: (() => void)[] = [];
+
+/**
+ * Reads a file, but waits for a free slot while {@link availableFileReads} is exhausted.
+ *
+ * `fs.readFile()` opens, reads and closes the file in three separate steps and keeps the file
+ * descriptor open in between. Reading a whole collection at once would therefore pile up one
+ * descriptor per pending read and exhaust the process limit (EMFILE) on large collections. This
+ * does not make reading slower: libuv already executes file system work on a small thread pool,
+ * so the limit only caps the descriptors held in the meantime.
+ *
+ * @param filePath the path to the file to read
+ * @param encoding OPTIONAL: the encoding to decode the file with. If omitted, the raw bytes are
+ *   returned.
+ */
+export function readFileLimited(filePath: string, encoding: BufferEncoding): Promise<string>;
+export function readFileLimited(filePath: string): Promise<NonSharedBuffer>;
+export async function readFileLimited(filePath: string, encoding?: BufferEncoding) {
+  if (availableFileReads > 0) {
+    availableFileReads--;
+  } else {
+    await new Promise<void>((resolve) => waitingReads.push(resolve));
+  }
+
+  try {
+    return await fs.readFile(filePath, encoding);
+  } finally {
+    // hand the slot over to the next waiting read instead of returning and re-taking it, so that
+    // a read started in the meantime cannot slip past the limit
+    const next = waitingReads.shift();
+    if (next != null) {
+      next();
+    } else {
+      availableFileReads++;
+    }
+  }
+}
+
+/**
  * Check if a file or directory exists
  * @param filePath the path to the file or directory
  */


### PR DESCRIPTION
### **User description**
## Changes

- Parallelize request/folder loading of a collection

## Testing

- I loaded a huge collection. It's roughly twice as fast

## Checklist

- [x] Issue has been linked to this PR
- [x] Code has been reviewed by person creating the PR
- [x] Automated tests have been written, if possible
- [x] Manual testing has been performed
- [ ] Documentation has been updated, if necessary
- [ ] Changes have been reviewed by second person


___

### **PR Type**
Enhancement


___

### **Description**
- Parallelize collection and folder loading with concurrent file reads

- Implement read limiting to prevent file descriptor exhaustion

- Maintain deterministic ordering of collection items during parallel loads

- Fix typo in method name `getInfoFileModifactionTime` to `getInfoFileModificationTime`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Collection Loading"] --> B["Parallel Child Loading"]
  B --> C["readFileLimited with Queue"]
  C --> D["Max 10 Concurrent Reads"]
  D --> E["Deterministic Order via Promise.all"]
  E --> F["Loaded Collection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fs-util.ts</strong><dd><code>Add concurrent file read limiting utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/util/fs-util.ts

<ul><li>Introduced <code>readFileLimited()</code> function that enforces max 10 concurrent <br>file reads<br> <li> Implements a queue-based system to manage file descriptor slots<br> <li> Prevents EMFILE errors on large collections by limiting concurrent <br><code>fs.readFile()</code> calls<br> <li> Supports both encoded string and raw buffer returns</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/1010/files#diff-da2ee41d8f59036e88a7321dc8373de87a5c34c752ef1fd14e68bcdf0f3c99e6">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>persistence-service.ts</strong><dd><code>Parallelize collection loading with read limiting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/persistence/service/persistence-service.ts

<ul><li>Refactored <code>loadChildren()</code> to use <code>Promise.all()</code> for parallel loading<br> <li> Refactored <code>walkChildren()</code> to use <code>Promise.all()</code> for parallel walking<br> <li> Extracted <code>walkChild()</code> helper method for individual child processing<br> <li> Replaced all <code>fs.readFile()</code> calls with <code>readFileLimited()</code> to enforce <br>concurrency limits<br> <li> Fixed typo: <code>getInfoFileModifactionTime</code> → <code>getInfoFileModificationTime</code></ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/1010/files#diff-a155f0cb611cc8da68af673aff42a673b39cb2c527ace1600936f469cdaeb09a">+61/-46</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fs-util.test.ts</strong><dd><code>Add tests for read limiting functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/util/fs-util.test.ts

<ul><li>Added comprehensive test suite for <code>readFileLimited()</code> function<br> <li> Tests verify max concurrent reads limit enforcement<br> <li> Tests confirm waiting reads start in order when slots free up<br> <li> Tests validate error handling and slot release on failures</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/1010/files#diff-87d39320a8bc35cbf94ff9299e7c70c4bf2748f295d50c75d450e31ad93f5f56">+117/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>persistence-service.test.ts</strong><dd><code>Add tests for parallel loading order preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/persistence/service/persistence-service.test.ts

<ul><li>Added test for maintaining directory order when children load out of <br>order<br> <li> Added test for preserving nested folder order from order.json<br> <li> Added test for error handling when child info file is corrupt<br> <li> Tests use mocked delays to simulate concurrent completion scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/1010/files#diff-94b3a259a8deab7f7aead7a07142f3c524fac977d47a4be62f1a7b1089ca77c2">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>walk-collection.test.ts</strong><dd><code>Add test for walk collection ordering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/persistence/service/walk-collection.test.ts

<ul><li>Added <code>afterEach</code> hook to restore mocked functions<br> <li> Added test for maintaining directory order during parallel walking<br> <li> Test simulates concurrent completion with variable delays<br> <li> Verifies snapshot children maintain original directory order</ul>


</details>


  </td>
  <td><a href="https://github.com/EXXETA/trufos/pull/1010/files#diff-e62931571e2b2b95b357bf5662c6948ce04cd0734c9239c49eca4e4dad5dc28c">+37/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

